### PR TITLE
feat(a2a): A2A Rooms P4 — cross-node rooms (join/approve/roster/talk)

### DIFF
--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -841,6 +841,16 @@ class HandoffHandler(BaseHTTPRequestHandler):
         if self.path == room_join_path:
             self._handle_room_join_request(cfg)
             return
+        # A2A Rooms P4.2 (design §6 / §14 R2): the leader-signed roster broadcast
+        # is ALSO routed to a SEPARATE handler with the SAME fail-closed auth
+        # preamble (remote_addr -> HMAC -> skew -> dedupe). Its terminal action
+        # is a member-local room_roster_cache write — it NEVER reaches the
+        # enqueue/allowlist/queue boundary, creates no task, and admits nothing.
+        room_roster_path = cfg.get("listen", {}).get(
+            "room_roster_path", a2a.ROOM_ROSTER_PATH)
+        if self.path == room_roster_path:
+            self._handle_room_roster_broadcast(cfg)
+            return
         if self.path != enqueue_path:
             self._reply(404, {"ok": False, "error": "not found"})
             return
@@ -1843,6 +1853,314 @@ class HandoffHandler(BaseHTTPRequestHandler):
         self._reply(200, {"ok": True, "status": rooms.JOIN_PENDING,
                           "room_id": room_id,
                           "joiner": f"{joiner_agent}@{joiner_node}"})
+
+    def _handle_room_roster_broadcast(self, cfg: dict[str, Any]) -> None:
+        """Receiver branch for the leader-signed cross-node roster broadcast
+        (A2A Rooms P4.2, design §6 / §14 R2).
+
+        HIGH-RISK: a NEW remote-traffic surface. It runs the SAME fail-closed
+        auth preamble as do_POST / _handle_room_join_request (NO step weakened),
+        then applies the member-side roster-acceptance contracts and writes the
+        member-local room_roster_cache. Validation ORDER (security=True audit on
+        every reject; NO persistence until ALL pass):
+          a. tailnet-only bind — guaranteed at startup (resolve_bind).
+          b. protocol tag == ROOM_ROSTER_PROTOCOL_VERSION.
+          c. message_id REQUIRED (anchors dedupe).
+          d. peer ALREADY PAIRED (find_peer; unknown -> 403). NOT discovery.
+          e. remote_addr == the peer's CURRENT resolved Tailscale IP (before
+             the body is read off the socket).
+          f. HMAC: secret present, body hash, signature (constant-time). The
+             X-AGB-Signature IS the leader-node↔member-node PAIRWISE signature
+             (§14 R2) — a member that lacks the leader↔Z secret cannot forge a
+             roster node Z would accept. The PATH is in the canonical string, so
+             an enqueue/join/identity signature cannot be replayed here.
+          g. clock-skew window — transient drift 503, far-stale 401.
+          h. durable dedupe (replay-safe) on (peer, message_id). A byte-identical
+             re-broadcast is an idempotent 200; an id-reuse-with-different-body is
+             a 409. The dedupe ledger lives in rooms.db (the member's own db).
+          i. parse the control body (shape only).
+          j. ACCEPT per the member-side contracts (anti-rogue-leader binding +
+             monotonic epoch + atomic cache write) — see
+             rooms.accept_roster_broadcast. The authenticated `peer_id` is the
+             ONLY trusted leader identity (it MUST equal the body's leader_node);
+             a roster from a non-leader peer persists NOTHING.
+        """
+        client_ip = self._client_ip()
+        peer_id = self.headers.get("X-AGB-Peer", "")
+        message_id = self.headers.get("X-AGB-Message-Id", "")
+        timestamp = self.headers.get("X-AGB-Timestamp", "")
+        body_hash_hdr = self.headers.get("X-AGB-Body-SHA256", "")
+        signature = self.headers.get("X-AGB-Signature", "")
+        protocol = self.headers.get("X-AGB-Protocol", "")
+
+        # --- b. protocol tag ---
+        if protocol != a2a.ROOM_ROSTER_PROTOCOL_VERSION:
+            audit("room_roster_reject", reason="bad_protocol",
+                  peer=peer_id, client=client_ip, got=protocol)
+            self._reply(400, {"ok": False, "error": "unsupported protocol"})
+            return
+
+        # --- c. message_id REQUIRED (non-empty) ---
+        if not message_id:
+            audit("room_roster_reject", reason="missing_message_id",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(400, {"ok": False, "error": "message id required"})
+            return
+
+        # --- d. peer must be ALREADY PAIRED (not a discovery channel) ---
+        try:
+            peer = a2a.find_peer(cfg, peer_id)
+        except a2a.A2AError:
+            audit("room_roster_reject", reason="unknown_peer",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(403, {"ok": False, "error": "unknown peer"})
+            return
+
+        # --- e. remote_addr == authenticated peer's CURRENT address (before body) ---
+        try:
+            peer_addr = a2a.resolve_peer_address(peer)
+        except a2a.A2AError as exc:
+            audit("room_roster_reject", reason=getattr(exc, "code",
+                  "resolve_error"), peer=peer_id, client=client_ip,
+                  security=True)
+            self._reply(403, {"ok": False, "error": "source address mismatch"})
+            return
+        if not peer_addr or client_ip != peer_addr:
+            audit("room_roster_reject", reason="addr_mismatch",
+                  peer=peer_id, client=client_ip, expected=peer_addr,
+                  security=True)
+            self._reply(403, {"ok": False, "error": "source address mismatch"})
+            return
+
+        # --- size guard before reading the body (roster bodies are small) ---
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            content_length = -1
+        if content_length < 0:
+            self._reply(411, {"ok": False, "error": "length required"})
+            return
+        max_body = 256 * 1024  # a roster of many members, still bounded
+        if content_length > max_body:
+            audit("room_roster_reject", reason="oversize",
+                  peer=peer_id, client=client_ip, declared=content_length)
+            self._reply(413, {"ok": False, "error": "body too large"})
+            return
+        raw = self.rfile.read(content_length) if content_length else b""
+
+        # --- f. HMAC: secret present, body hash, signature (auth boundary) ---
+        secrets = a2a.peer_secrets(peer)
+        if not secrets:
+            audit("room_roster_reject", reason="no_secret",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(403, {"ok": False, "error": "peer not provisioned"})
+            return
+        computed_hash = a2a.body_sha256(raw)
+        if body_hash_hdr != computed_hash:
+            audit("room_roster_reject", reason="body_hash",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(401, {"ok": False, "error": "body hash mismatch"})
+            return
+        # HMAC FIRST (before timestamp-band classification) so an
+        # unauthenticated request never receives a transient/permanent split
+        # that leaks signature validity (same ordering as do_POST, #1346). The
+        # path is part of the canonical string, so a signature minted for the
+        # enqueue/join/identity endpoint cannot be replayed against this one.
+        canonical = a2a.canonical_string(
+            "POST", self.path, peer_id, message_id, timestamp, computed_hash)
+        if not a2a.verify_signature(secrets, canonical, signature):
+            audit("room_roster_reject", reason="bad_signature",
+                  peer=peer_id, client=client_ip, message_id=message_id,
+                  security=True)
+            self._reply(401, {"ok": False, "error": "signature verification failed"})
+            return
+
+        # --- g. clock-skew window (authenticated past this point) ---
+        skew = int(cfg.get("timestamp_skew_seconds",
+                           a2a.DEFAULT_TIMESTAMP_SKEW_SECONDS))
+        grace_skew = int(cfg.get("timestamp_skew_grace_seconds",
+                                 a2a.DEFAULT_TIMESTAMP_SKEW_GRACE_SECONDS))
+        if grace_skew < skew:
+            grace_skew = skew
+        receiver_now = a2a.now_ts()
+        try:
+            req_ts = int(timestamp)
+        except (TypeError, ValueError):
+            audit("room_roster_reject", reason="bad_timestamp",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(401, {"ok": False, "error": "bad timestamp"})
+            return
+        ts_delta = abs(receiver_now - req_ts)
+        if ts_delta > grace_skew:
+            audit("room_roster_reject", reason="clock_skew_permanent",
+                  peer=peer_id, client=client_ip, delta_seconds=ts_delta,
+                  security=True)
+            self._reply(401, {"ok": False,
+                              "error": "timestamp far outside skew window",
+                              "receiver_ts": receiver_now})
+            return
+        if ts_delta > skew:
+            audit("room_roster_reject", reason="clock_skew_transient",
+                  peer=peer_id, client=client_ip, delta_seconds=ts_delta)
+            self._reply(503, {"ok": False,
+                              "error": "timestamp outside skew window — retry",
+                              "receiver_ts": receiver_now},
+                        extra_headers={"Retry-After": str(max(1, skew))})
+            return
+
+        # --- h. durable dedupe — READ-ONLY replay check (peer-scoped) ---
+        # A byte-identical re-broadcast (same peer+id+body) is an idempotent 200;
+        # an id-reuse with a DIFFERENT body is a 409. The dedupe ledger reuses
+        # the room_join_dedupe table in the MEMBER's rooms.db (the member's own
+        # db). A rejected/no-op acceptance leaves NO dedupe row, so a replay
+        # re-runs acceptance (the stale-epoch / not-leader teeth hold on replay).
+        if rooms is None:
+            audit("room_roster_error", reason="rooms_module_unavailable",
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(500, {"ok": False, "error": "rooms unavailable"})
+            return
+        try:
+            ro = rooms.open_rooms_readonly()
+            if ro is not None:
+                try:
+                    dup = rooms.room_join_dedupe_lookup(
+                        ro, peer_id, message_id, computed_hash)
+                finally:
+                    ro.close()
+            else:
+                dup = "new"
+        except Exception as exc:  # noqa: BLE001 - last-resort guard
+            audit("room_roster_error", reason="dedupe_error",
+                  peer=peer_id, client=client_ip, detail=str(exc)[:200])
+            self._reply(500, {"ok": False, "error": "internal error"})
+            return
+        if dup == rooms.JOIN_DEDUPE_DUPLICATE:
+            audit("room_roster_accept", reason="duplicate",
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(200, {"ok": True, "duplicate": True})
+            return
+        if dup == rooms.JOIN_DEDUPE_CONFLICT:
+            audit("room_roster_reject", reason="hash_conflict",
+                  peer=peer_id, client=client_ip, message_id=message_id,
+                  security=True)
+            self._reply(409, {"ok": False,
+                              "error": "message id reused with different body"})
+            return
+
+        # --- i. parse the control body (shape only) ---
+        try:
+            roster = a2a.parse_room_roster_broadcast(raw)
+        except a2a.A2AError as exc:
+            audit("room_roster_reject", reason=getattr(exc, "code",
+                  "bad_room_roster"), peer=peer_id, client=client_ip,
+                  message_id=message_id)
+            self._reply(422, {"ok": False, "error": str(exc)})
+            return
+
+        room_id = str(roster["room_id"])
+        leader_node = str(roster["leader_node"])
+        room_epoch = int(roster["room_epoch"])
+        members = list(roster["members"])
+
+        # --- j. ACCEPT per the member-side contracts WITH atomic dedupe (codex
+        # P4.2 r3 BLOCKING — close the TOCTOU race). accept_roster_broadcast
+        # enforces leader-authority (peer==leader_node), the leader pin, the
+        # first-roster binding, the monotonic epoch, AND folds the peer-scoped
+        # dedupe RESERVATION into the SAME transaction as the cache write. So a
+        # same-(peer,message_id)/DIFFERENT-body roster is caught as a CONFLICT
+        # BEFORE any cache mutation (409, nothing written), and a contract REJECT
+        # (not_leader / leader_mismatch / no_binding / stale) reserves NO dedupe
+        # row so a replay re-evaluates. The earlier read-only dedupe pre-check
+        # (step h) is a fast-path early answer for an ALREADY-RESERVED id; the
+        # authoritative serialization is here.
+        try:
+            conn = rooms.open_rooms()
+        except rooms.RoomsError as exc:
+            audit("room_roster_error", reason=getattr(exc, "code", "rooms_db"),
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(500, {"ok": False, "error": "rooms db error"})
+            return
+        try:
+            try:
+                outcome = rooms.accept_roster_broadcast(
+                    conn, room_id=room_id, room_epoch=room_epoch,
+                    members=members, leader_node=leader_node, peer_id=peer_id,
+                    message_id=message_id, body_sha256=computed_hash,
+                    mac=signature,
+                )
+            except rooms.RoomsError as exc:
+                audit("room_roster_error", reason=getattr(exc, "code",
+                      "accept_error"), peer=peer_id, client=client_ip,
+                      message_id=message_id, room_id=room_id)
+                self._reply(500, {"ok": False, "error": "internal error"})
+                return
+        finally:
+            conn.close()
+
+        if outcome == rooms.ROSTER_NOT_LEADER:
+            audit("room_roster_reject", reason="not_leader",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  leader_node=leader_node, message_id=message_id,
+                  security=True)
+            self._reply(403, {"ok": False,
+                              "error": "roster sender is not the room leader"})
+            return
+        if outcome == rooms.ROSTER_LEADER_MISMATCH:
+            # A configured peer self-claiming leadership of a room already led by
+            # a DIFFERENT node — a takeover attempt. Reject, persist nothing
+            # (codex P4.2 r1 BLOCKING).
+            audit("room_roster_reject", reason="leader_mismatch",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  leader_node=leader_node, message_id=message_id,
+                  security=True)
+            self._reply(403, {"ok": False,
+                              "error": "roster sender is not the established "
+                              "room leader (takeover refused)"})
+            return
+        if outcome == rooms.ROSTER_NO_LOCAL_BINDING:
+            audit("room_roster_reject", reason="no_local_binding",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  message_id=message_id, security=True)
+            self._reply(403, {"ok": False,
+                              "error": "no local join state for this room — "
+                              "refusing to mint a roster cache from an "
+                              "inbound broadcast"})
+            return
+        if outcome == rooms.ROSTER_DEDUPE_CONFLICT:
+            # Same (peer, message_id) reused with a DIFFERENT body — caught at the
+            # atomic dedupe reservation BEFORE any cache write (codex P4.2 r3).
+            audit("room_roster_reject", reason="hash_conflict",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  message_id=message_id, security=True)
+            self._reply(409, {"ok": False,
+                              "error": "message id reused with different body"})
+            return
+        if outcome == rooms.ROSTER_STALE_EPOCH:
+            # Not an error (a legitimate lower/same-epoch non-duplicate is simply
+            # ignored), but we still return 200 with applied=False so the leader
+            # does not retry forever. No dedupe row reserved.
+            audit("room_roster_ignore", reason="stale_epoch",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  epoch=room_epoch, message_id=message_id)
+            self._reply(200, {"ok": True, "applied": False,
+                              "reason": "stale_epoch"})
+            return
+
+        if outcome == rooms.ROSTER_DUPLICATE:
+            audit("room_roster_accept", reason="duplicate",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  message_id=message_id)
+            self._reply(200, {"ok": True, "duplicate": True,
+                              "room_id": room_id, "epoch": room_epoch})
+            return
+
+        # ACCEPTED — the member-local roster cache now reflects this epoch.
+        audit("room_roster_accept", reason="applied",
+              peer=peer_id, client=client_ip, room_id=room_id,
+              epoch=room_epoch, members=len(members), message_id=message_id)
+        self._reply(200, {"ok": True, "applied": True,
+                          "room_id": room_id, "epoch": room_epoch,
+                          "members": len(members)})
 
 
 # --------------------------------------------------------------------------

--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -690,6 +690,32 @@ def room_scoped_check(env: dict[str, Any],
 # Enqueue boundary — call the EXISTING bridge-task.sh create
 # --------------------------------------------------------------------------
 
+def _peer_safe_enqueue_detail(target: str, raw_detail: str) -> str:
+    """A TERSE, peer-facing reason for an enqueue rejection (P4.5 info-hygiene).
+
+    The raw `bridge-task.sh create` stdout/stderr is for the LOCAL audit only —
+    on an unknown target it carries the full `agb list` roster dump (every
+    agent's engine/session/workdir/source), which must NEVER be echoed back to a
+    remote authenticated peer. This collapses any rejection to a short reason
+    that names ONLY the target the peer already chose:
+
+      - unknown/unregistered target  -> "unknown target '<agent>'"
+      - anything else                -> "enqueue rejected"
+
+    The unknown-target case is recognized by the roster-dump fingerprint the
+    `bridge_require_agent` failure prints (the `engine=`/`workdir=`/`source=`
+    columns of `bridge_list_agents`) — a structural marker, not a translatable
+    sentence, so it survives wording/locale changes. We never reflect any
+    substring of `raw_detail` into the returned string.
+    """
+    lowered = (raw_detail or "").lower()
+    roster_dump = ("engine=" in lowered and "workdir=" in lowered
+                   and "source=" in lowered)
+    if roster_dump:
+        return f"unknown target '{target}'"
+    return "enqueue rejected"
+
+
 def enqueue_via_bridge_task(
     *,
     target: str,
@@ -698,11 +724,13 @@ def enqueue_via_bridge_task(
     priority: str,
     title: str,
     body_file: Path,
-) -> tuple[bool, str, str]:
+) -> tuple[bool, str, str, str]:
     """Invoke `bridge-task.sh create` as an argv array (never a shell string).
 
-    Returns (ok, task_id, detail). On failure `detail` carries the stderr
-    tail and `task_id` is empty.
+    Returns (ok, task_id, audit_detail, peer_detail). On failure `audit_detail`
+    carries the full stderr/stdout tail (LOCAL audit/log only) and `peer_detail`
+    is a TERSE, roster-leak-free reason safe to return to the remote peer (P4.5).
+    On success `task_id` is the created id and the detail fields carry stdout.
     """
     script = Path(__file__).resolve().parent / "bridge-task.sh"
     bash = os.environ.get("BRIDGE_BASH_BIN", "bash")
@@ -731,11 +759,14 @@ def enqueue_via_bridge_task(
             argv, capture_output=True, text=True, timeout=120,
         )
     except (subprocess.SubprocessError, OSError) as exc:
-        return False, "", f"bridge-task.sh invocation failed: {exc}"
+        invoke_detail = f"bridge-task.sh invocation failed: {exc}"
+        return False, "", invoke_detail, "enqueue rejected"
 
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout or "").strip()[-400:]
-        return False, "", detail or f"bridge-task.sh exited {proc.returncode}"
+        audit_detail = detail or f"bridge-task.sh exited {proc.returncode}"
+        peer_detail = _peer_safe_enqueue_detail(target, audit_detail)
+        return False, "", audit_detail, peer_detail
 
     # Parse `created task #<id> for <agent> ...`.
     task_id = ""
@@ -743,7 +774,8 @@ def enqueue_via_bridge_task(
         if token.startswith("#") and token[1:].isdigit():
             task_id = token[1:]
             break
-    return True, task_id, (proc.stdout or "").strip()
+    stdout_detail = (proc.stdout or "").strip()
+    return True, task_id, stdout_detail, stdout_detail
 
 
 def staged_body_text(env: dict[str, Any]) -> str:
@@ -1268,7 +1300,7 @@ class HandoffHandler(BaseHTTPRequestHandler):
                 peer_id, message_id, staged_body_text(env))
 
             sender = env.get("sender", {})
-            ok, task_id, detail = enqueue_via_bridge_task(
+            ok, task_id, audit_detail, peer_detail = enqueue_via_bridge_task(
                 target=env["target_agent"],
                 sender_bridge=sender.get("bridge", "unknown"),
                 sender_agent=sender.get("agent", "unknown"),
@@ -1278,21 +1310,24 @@ class HandoffHandler(BaseHTTPRequestHandler):
             )
             if not ok:
                 # Distinguish a transient lock failure (retryable 503) from
-                # a permanent validation/guard/allowlist rejection (422).
-                lowered = detail.lower()
+                # a permanent validation/guard/allowlist rejection (422). The
+                # rejection status + the LOCAL audit detail are unchanged; only
+                # the PEER-FACING `error` is terse — `audit_detail` (which on an
+                # unknown target carries the full `agb list` roster dump) goes to
+                # the local audit/log ONLY, never back to the remote peer (P4.5).
+                lowered = audit_detail.lower()
                 transient = any(s in lowered for s in
                                 ("locked", "database is locked", "timeout",
                                  "temporarily"))
                 if transient:
                     audit("enqueue_transient_fail", peer=peer_id,
-                          message_id=message_id, detail=detail[:200])
+                          message_id=message_id, detail=audit_detail[:200])
                     self._reply(503, {"ok": False, "error": "queue busy, retry"},
                                 extra_headers={"Retry-After": "30"})
                 else:
                     audit("enqueue_permanent_fail", peer=peer_id,
-                          message_id=message_id, detail=detail[:200])
-                    self._reply(422, {"ok": False,
-                                      "error": f"enqueue rejected: {detail[:200]}"})
+                          message_id=message_id, detail=audit_detail[:200])
+                    self._reply(422, {"ok": False, "error": peer_detail})
                 return
 
             now = a2a.now_ts()

--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -830,6 +830,17 @@ class HandoffHandler(BaseHTTPRequestHandler):
         if self.path == identity_update_path:
             self._handle_identity_update(cfg)
             return
+        # A2A Rooms P4.1 (design §11 / §14 R3): the signed cross-node
+        # room-join-request is ALSO routed to a SEPARATE handler with the same
+        # fail-closed auth preamble (remote_addr -> HMAC -> skew -> dedupe). Its
+        # terminal action is a token-verified PENDING join row — it NEVER reaches
+        # the enqueue/allowlist/queue boundary, creates no leader task, and
+        # admits nothing (approve is P4.2).
+        room_join_path = cfg.get("listen", {}).get(
+            "room_join_path", a2a.ROOM_JOIN_PATH)
+        if self.path == room_join_path:
+            self._handle_room_join_request(cfg)
+            return
         if self.path != enqueue_path:
             self._reply(404, {"ok": False, "error": "not found"})
             return
@@ -1494,6 +1505,423 @@ class HandoffHandler(BaseHTTPRequestHandler):
             return "new"
         finally:
             conn.close()
+
+    def _handle_room_join_request(self, cfg: dict[str, Any]) -> None:
+        """Receiver branch for the signed cross-node room-join-request
+        (A2A Rooms P4.1, design §11 / §14 R3).
+
+        HIGH-RISK: this is the only NEW remote-traffic surface in P4.1. It runs
+        the SAME fail-closed auth preamble as do_POST / _handle_identity_update
+        (NO step weakened), then performs the room-specific verification and
+        persists a PENDING join row. Validation ORDER (security=True audit on
+        every reject; NO persistence until ALL pass):
+          a. tailnet-only bind — guaranteed at startup (resolve_bind).
+          b. protocol tag == ROOM_JOIN_PROTOCOL_VERSION.
+          c. message_id REQUIRED (anchors dedupe + is in the signed canonical).
+          d. peer ALREADY PAIRED (find_peer; unknown -> 403). NOT discovery.
+          e. remote_addr == the peer's CURRENT resolved Tailscale IP (before
+             the body is read off the socket).
+          f. HMAC: secret present, body hash, signature (constant-time). The
+             request PATH is in the canonical string, so an enqueue/identity
+             signature cannot be replayed against this endpoint.
+          g. clock-skew window — transient drift 503, far-stale 401.
+          h. durable dedupe (replay-safe) on message_id.
+          i. parse the control body (shape only — never trusts the joiner id
+             beyond the node-link auth already enforced).
+          j. room is on THIS node (leader_node == this node) — else 404; a node
+             that does not lead the room has no authority to admit/queue it.
+          k. token verify: hash compare + TTL + revocation (verify_invite_token_
+             outcome). expired/revoked/mismatch -> 403, NO pending row.
+          l. rate-limit per (token-hash, SOURCE NODE) — a leaked reusable token
+             cannot mint unbounded pending rows from one node.
+          m. persist a VERIFIED pending row anchored to `joiner_agent` (the
+             OS-actor attestation made by node B) @ the HMAC-AUTHENTICATED
+             sender bridge as the node (NEVER a wire-asserted node). NO
+             membership add, NO leader task, NO token/hash in the row/audit.
+        """
+        client_ip = self._client_ip()
+        peer_id = self.headers.get("X-AGB-Peer", "")
+        message_id = self.headers.get("X-AGB-Message-Id", "")
+        timestamp = self.headers.get("X-AGB-Timestamp", "")
+        body_hash_hdr = self.headers.get("X-AGB-Body-SHA256", "")
+        signature = self.headers.get("X-AGB-Signature", "")
+        protocol = self.headers.get("X-AGB-Protocol", "")
+
+        # --- b. protocol tag ---
+        if protocol != a2a.ROOM_JOIN_PROTOCOL_VERSION:
+            audit("room_join_reject", reason="bad_protocol",
+                  peer=peer_id, client=client_ip, got=protocol)
+            self._reply(400, {"ok": False, "error": "unsupported protocol"})
+            return
+
+        # --- c. message_id REQUIRED (non-empty) ---
+        if not message_id:
+            audit("room_join_reject", reason="missing_message_id",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(400, {"ok": False, "error": "message id required"})
+            return
+
+        # --- d. peer must be ALREADY PAIRED (not a discovery channel) ---
+        try:
+            peer = a2a.find_peer(cfg, peer_id)
+        except a2a.A2AError:
+            audit("room_join_reject", reason="unknown_peer",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(403, {"ok": False, "error": "unknown peer"})
+            return
+
+        # --- e. remote_addr == authenticated peer's CURRENT address (before body) ---
+        try:
+            peer_addr = a2a.resolve_peer_address(peer)
+        except a2a.A2AError as exc:
+            audit("room_join_reject", reason=getattr(exc, "code",
+                  "resolve_error"), peer=peer_id, client=client_ip,
+                  security=True)
+            self._reply(403, {"ok": False, "error": "source address mismatch"})
+            return
+        if not peer_addr or client_ip != peer_addr:
+            audit("room_join_reject", reason="addr_mismatch",
+                  peer=peer_id, client=client_ip, expected=peer_addr,
+                  security=True)
+            self._reply(403, {"ok": False, "error": "source address mismatch"})
+            return
+
+        # --- size guard before reading the body (tiny control body) ---
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            content_length = -1
+        if content_length < 0:
+            self._reply(411, {"ok": False, "error": "length required"})
+            return
+        max_body = 8 * 1024
+        if content_length > max_body:
+            audit("room_join_reject", reason="oversize",
+                  peer=peer_id, client=client_ip, declared=content_length)
+            self._reply(413, {"ok": False, "error": "body too large"})
+            return
+        raw = self.rfile.read(content_length) if content_length else b""
+
+        # --- f. HMAC: secret present, body hash, signature (auth boundary) ---
+        secrets = a2a.peer_secrets(peer)
+        if not secrets:
+            audit("room_join_reject", reason="no_secret",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(403, {"ok": False, "error": "peer not provisioned"})
+            return
+        computed_hash = a2a.body_sha256(raw)
+        if body_hash_hdr != computed_hash:
+            audit("room_join_reject", reason="body_hash",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(401, {"ok": False, "error": "body hash mismatch"})
+            return
+        # HMAC FIRST (before timestamp-band classification) so an
+        # unauthenticated request never receives a transient/permanent split
+        # that leaks signature validity (same ordering as do_POST, #1346). The
+        # path is part of the canonical string, so an enqueue signature cannot
+        # be replayed against this control endpoint.
+        canonical = a2a.canonical_string(
+            "POST", self.path, peer_id, message_id, timestamp, computed_hash)
+        if not a2a.verify_signature(secrets, canonical, signature):
+            audit("room_join_reject", reason="bad_signature",
+                  peer=peer_id, client=client_ip, message_id=message_id,
+                  security=True)
+            self._reply(401, {"ok": False, "error": "signature verification failed"})
+            return
+
+        # --- g. clock-skew window (authenticated past this point) ---
+        skew = int(cfg.get("timestamp_skew_seconds",
+                           a2a.DEFAULT_TIMESTAMP_SKEW_SECONDS))
+        grace_skew = int(cfg.get("timestamp_skew_grace_seconds",
+                                 a2a.DEFAULT_TIMESTAMP_SKEW_GRACE_SECONDS))
+        if grace_skew < skew:
+            grace_skew = skew
+        receiver_now = a2a.now_ts()
+        try:
+            req_ts = int(timestamp)
+        except (TypeError, ValueError):
+            audit("room_join_reject", reason="bad_timestamp",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(401, {"ok": False, "error": "bad timestamp"})
+            return
+        ts_delta = abs(receiver_now - req_ts)
+        if ts_delta > grace_skew:
+            audit("room_join_reject", reason="clock_skew_permanent",
+                  peer=peer_id, client=client_ip, delta_seconds=ts_delta,
+                  security=True)
+            self._reply(401, {"ok": False,
+                              "error": "timestamp far outside skew window",
+                              "receiver_ts": receiver_now})
+            return
+        if ts_delta > skew:
+            audit("room_join_reject", reason="clock_skew_transient",
+                  peer=peer_id, client=client_ip, delta_seconds=ts_delta)
+            self._reply(503, {"ok": False,
+                              "error": "timestamp outside skew window — retry",
+                              "receiver_ts": receiver_now},
+                        extra_headers={"Retry-After": str(max(1, skew))})
+            return
+
+        # --- h. durable dedupe — READ-ONLY replay check (codex P4.1 r1/r2) ---
+        # CRITICAL: only a PREVIOUSLY-ACCEPTED request may replay as an
+        # idempotent 200. The dedupe ledger lives in rooms.db (NOT inbox.db) so
+        # the reservation commits ATOMICALLY with the pending row on the accept
+        # path (step m); a dedupe row therefore exists IFF a pending row exists.
+        # This read-only lookup gives the fast idempotent/conflict answer for an
+        # ALREADY-ACCEPTED id; a rejected request leaves NO dedupe row, so a
+        # replay re-runs verification and re-rejects (T3/T5 hold on replay). If
+        # rooms.db is absent (this is not the leader node), the lookup is "new"
+        # and the leader-node check (step j) will 404 anyway.
+        if rooms is None:
+            audit("room_join_error", reason="rooms_module_unavailable",
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(500, {"ok": False, "error": "rooms unavailable"})
+            return
+        try:
+            ro = rooms.open_rooms_readonly()
+            if ro is not None:
+                try:
+                    dup = rooms.room_join_dedupe_lookup(
+                        ro, peer_id, message_id, computed_hash)
+                finally:
+                    ro.close()
+            else:
+                dup = "new"
+        except Exception as exc:  # noqa: BLE001 - last-resort guard
+            audit("room_join_error", reason="dedupe_error",
+                  peer=peer_id, client=client_ip, detail=str(exc)[:200])
+            self._reply(500, {"ok": False, "error": "internal error"})
+            return
+        if dup == rooms.JOIN_DEDUPE_DUPLICATE:
+            audit("room_join_accept", reason="duplicate",
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(200, {"ok": True, "duplicate": True})
+            return
+        if dup == rooms.JOIN_DEDUPE_CONFLICT:
+            audit("room_join_reject", reason="hash_conflict",
+                  peer=peer_id, client=client_ip, message_id=message_id,
+                  security=True)
+            self._reply(409, {"ok": False,
+                              "error": "message id reused with different body"})
+            return
+
+        # --- i. parse the control body (shape only) ---
+        try:
+            claim = a2a.parse_room_join_request(raw)
+        except a2a.A2AError as exc:
+            audit("room_join_reject", reason=getattr(exc, "code",
+                  "bad_room_join"), peer=peer_id, client=client_ip,
+                  message_id=message_id)
+            self._reply(422, {"ok": False, "error": str(exc)})
+            return
+
+        # (rooms-module availability was already asserted at step h.)
+        room_id = str(claim["room_id"])
+        token_hash = str(claim["join_token_sha256"])
+        joiner_agent = str(claim["joiner_agent"])
+        # The joiner's NODE is the HMAC-authenticated sender bridge — NEVER a
+        # wire-asserted field (contract 2). `peer_id` is the signed X-AGB-Peer
+        # the auth preamble already bound to this connection.
+        joiner_node = peer_id
+        this_node = str(cfg.get("bridge_id") or "")
+
+        # Open the rooms db to verify + persist. A leader-node receiver MUST have
+        # the controller-owned rooms.db; we open it read-write (the verified
+        # pending-row write needs it). open_rooms() creates it if absent, but a
+        # genuine leader node always has it — and a non-leader node fails the
+        # leader-node check below anyway, persisting nothing.
+        try:
+            conn = rooms.open_rooms()
+        except rooms.RoomsError as exc:
+            audit("room_join_error", reason=getattr(exc, "code", "rooms_db"),
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(500, {"ok": False, "error": "rooms db error"})
+            return
+        try:
+            room = rooms.get_room(conn, room_id)
+            if room is None:
+                audit("room_join_reject", reason="room_unknown",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      message_id=message_id, security=True)
+                self._reply(404, {"ok": False, "error": "room not found"})
+                return
+
+            # --- j. room must be LED BY this node (else we have no authority) ---
+            leader_node = str(room["leader_node"] or "")
+            if leader_node != this_node:
+                audit("room_join_reject", reason="not_leader_node",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      message_id=message_id, security=True)
+                self._reply(404, {"ok": False,
+                                  "error": "room not led by this node"})
+                return
+
+            # --- k. token verify: hash + TTL + revocation (NEVER log the hash) ---
+            # The wire carried sha256(token); compare it to the stored hash with
+            # the SAME TTL/revocation semantics verify_invite_token_outcome
+            # applies to a raw token, by hashing through a thin shim. We do NOT
+            # reconstruct the raw token (we never have it) — instead we compare
+            # the presented hash to the stored hash directly with TTL on top.
+            outcome = _room_join_verify_hash(room, token_hash)
+            if outcome != rooms.TOKEN_OK:
+                # outcome is one of mismatch/revoked/expired — a stable,
+                # token-free code, safe to audit.
+                audit("room_join_reject", reason=f"token_{outcome}",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      message_id=message_id, security=True)
+                self._reply(403, {"ok": False,
+                                  "error": f"invite token {outcome}"})
+                return
+
+            # --- l. rate-limit per (token-hash, SOURCE NODE) ---
+            # Keyed on the source NODE (the authenticated peer), so a leaked
+            # reusable token cannot mint unbounded pending rows from one node.
+            # record_join_attempt keys its counter on the token HASH internally;
+            # we pass the already-hashed token via the hash-preserving shim so
+            # the raw token is never needed.
+            try:
+                _room_join_rate_check(conn, token_hash, source=joiner_node)
+            except rooms.RoomsError as exc:
+                audit("room_join_reject", reason="rate_limited",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      message_id=message_id, security=True)
+                self._reply(429, {"ok": False, "error": str(exc)},
+                            extra_headers={"Retry-After": "120"})
+                return
+
+            # --- m. ACCEPT: reserve the dedupe row + persist the pending row
+            # ATOMICALLY in ONE rooms.db transaction (codex P4.1 r2). Because
+            # both writes commit together (or roll back together), "a dedupe row
+            # exists" is equivalent to "a pending row exists" — there is no window
+            # where a surviving reservation could let a replay return a bogus
+            # idempotent 200 with no pending row. The re-check inside the call
+            # closes the concurrent-replay-reserved-first race, resolving it to
+            # the same idempotent/conflict outcome the read-only lookup would have.
+            ttl_expiry = 0
+            try:
+                ttl = int(room["invite_token_ttl"])
+                if ttl > 0:
+                    ttl_expiry = int(room["invite_token_ts"]) + ttl
+            except (KeyError, IndexError, TypeError, ValueError):
+                ttl_expiry = 0
+            try:
+                outcome = rooms.record_verified_cross_node_join_request_atomic(
+                    conn, message_id=message_id, body_sha256=computed_hash,
+                    peer=peer_id, room_id=room_id, agent=joiner_agent,
+                    node=joiner_node, via_node=joiner_node,
+                    ttl_expiry=ttl_expiry,
+                )
+            except Exception as exc:  # noqa: BLE001 - last-resort guard
+                # The atomic helper rolled BOTH writes back on failure, so no
+                # orphan dedupe row survives → a replay re-runs verification.
+                audit("room_join_error", reason="persist_error",
+                      peer=peer_id, client=client_ip, message_id=message_id,
+                      detail=str(exc)[:200])
+                self._reply(500, {"ok": False, "error": "internal error"})
+                return
+        finally:
+            conn.close()
+
+        if outcome == rooms.JOIN_DEDUPE_DUPLICATE:
+            audit("room_join_accept", reason="duplicate",
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(200, {"ok": True, "duplicate": True})
+            return
+        if outcome == rooms.JOIN_DEDUPE_CONFLICT:
+            audit("room_join_reject", reason="hash_conflict",
+                  peer=peer_id, client=client_ip, message_id=message_id,
+                  security=True)
+            self._reply(409, {"ok": False,
+                              "error": "message id reused with different body"})
+            return
+
+        # Audit carries ONLY verified metadata — room id, joiner agent@node,
+        # message id — NEVER the token or its hash (contract 5).
+        audit("room_join_accept", reason="pending",
+              peer=peer_id, client=client_ip, room_id=room_id,
+              joiner=f"{joiner_agent}@{joiner_node}", message_id=message_id)
+        self._reply(200, {"ok": True, "status": rooms.JOIN_PENDING,
+                          "room_id": room_id,
+                          "joiner": f"{joiner_agent}@{joiner_node}"})
+
+
+# --------------------------------------------------------------------------
+# Room-join hash-only verification + rate-limit shims (P4.1)
+# --------------------------------------------------------------------------
+#
+# The wire carries sha256(token), NOT the raw token, so the leader-node receiver
+# never possesses the raw token. The rooms_common verify/rate helpers were
+# written for the single-node path that DOES hold the raw token (it hashes
+# internally). These shims let the receiver apply the SAME TTL/revocation +
+# rate-limit semantics to an already-hashed token without reconstructing the
+# raw value (which is impossible) and without duplicating the rooms_common
+# logic. They live here (the receiver), not in rooms_common, because they are a
+# cross-node-receiver-specific adaptation of the existing primitives.
+
+
+def _room_join_verify_hash(room: Any, token_hash: str) -> str:
+    """Verify a presented token HASH against the room (hash + TTL + revocation).
+
+    Mirrors rooms.verify_invite_token_outcome but takes the hash directly (the
+    receiver never has the raw token). Returns a rooms.TOKEN_* code. The order
+    matches the raw-token path: revocation -> constant-time hash compare ->
+    TTL — so the receiver path can never be MORE permissive than the local path.
+    """
+    import hmac as _hmac
+
+    stored = room["invite_token_sha256"]
+    if not stored:
+        return rooms.TOKEN_REVOKED
+    if not _hmac.compare_digest(str(stored), token_hash):
+        return rooms.TOKEN_MISMATCH
+    try:
+        ttl = int(room["invite_token_ttl"])
+    except (KeyError, IndexError, TypeError, ValueError):
+        ttl = 0
+    if ttl > 0:
+        try:
+            issued = int(room["invite_token_ts"])
+        except (KeyError, IndexError, TypeError, ValueError):
+            issued = 0
+        if issued + ttl < a2a.now_ts():
+            return rooms.TOKEN_EXPIRED
+    return rooms.TOKEN_OK
+
+
+def _room_join_rate_check(conn: Any, token_hash: str, *, source: str) -> None:
+    """Per-(token-hash, source-node) rate limit using the room_join_rate table.
+
+    Mirrors rooms.record_join_attempt's counter logic but keys directly on the
+    already-known token HASH (the receiver does not have the raw token to hash).
+    Raises rooms.RoomsError(code='rate_limited') past the ceiling. Kept in lock-
+    step with rooms.record_join_attempt's DEFAULT ceiling + schema.
+    """
+    limit = rooms.DEFAULT_JOIN_RATE_LIMIT_PER_TOKEN
+    ts = rooms.now_ts()
+    row = conn.execute(
+        "SELECT attempts FROM room_join_rate WHERE token_sha256=? AND source=?",
+        (token_hash, source),
+    ).fetchone()
+    attempts = (int(row["attempts"]) if row else 0) + 1
+    if row:
+        conn.execute(
+            "UPDATE room_join_rate SET attempts=?, last_ts=? "
+            "WHERE token_sha256=? AND source=?",
+            (attempts, ts, token_hash, source),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO room_join_rate (token_sha256, source, attempts, "
+            "first_ts, last_ts) VALUES (?, ?, ?, ?, ?)",
+            (token_hash, source, attempts, ts, ts),
+        )
+    conn.commit()
+    if attempts > limit:
+        raise rooms.RoomsError(
+            "join rate limit exceeded for this invite token "
+            f"(source node, {attempts} attempts > {limit})",
+            code="rate_limited",
+        )
 
 
 # --------------------------------------------------------------------------

--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -23,6 +23,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import ipaddress
 import json
 import os
@@ -610,16 +611,20 @@ def _identity_update_apply(
 #     HMAC / source-addr / allowlist / dedupe auth — it runs AFTER them and
 #     can only ADD a deny for a room-scoped message.
 #   - ROOM-scoped message -> the fail-closed membership decision against the
-#     local rooms.db: the enqueue is allowed ONLY if BOTH the sender
-#     (sender_agent@sender_node) AND the target (target_agent@<this_node>)
-#     are current members of the room. Any of {rooms module unavailable,
-#     rooms.db absent/unreadable, room unknown, either party not a member}
-#     -> FAIL CLOSED (deny). Because P1a is single-node and the receiver only
-#     ever handles cross-node traffic, no production message is room-scoped
-#     yet — so this branch is wired + unit-tested but off the hot path. P4
-#     replaces the raw membership read with a leader-MAC'd roster verify +
-#     freshness (roster_max_age / epoch refresh) WITHOUT touching this
-#     signature or the fail-closed default.
+#     member-local leader-MAC'd ROSTER CACHE (NOT a live rooms.db membership
+#     read, and NOT a live leader call): the enqueue is allowed ONLY if the
+#     local `room_roster_cache` for `room_id` exists, its cached epoch EQUALS
+#     the envelope's `room_epoch`, AND BOTH the sender (sender_agent@<the
+#     node-link-authenticated peer>) AND the target (target_agent@<this_node>)
+#     appear in that cached roster. Any of {rooms module unavailable,
+#     rooms.db absent/unreadable, no cache for the room, epoch mismatch, either
+#     party not a cached member} -> FAIL CLOSED (deny). This is the P4.3
+#     activation the P1a seam was frozen for: P4.3 replaces the raw `is_member`
+#     read with the leader-MAC'd roster-cache verify + epoch freshness WITHOUT
+#     touching this `(env, cfg) -> (ok, reason)` signature or the fail-closed
+#     default. The roster cache is written ONLY by P4.2's
+#     `accept_roster_broadcast` after a pairwise-HMAC verify FROM the leader, so
+#     the receiver never trusts a membership claim inside the inbound message.
 
 def room_scoped_check(env: dict[str, Any],
                       cfg: dict[str, Any]) -> tuple[bool, str]:
@@ -629,13 +634,31 @@ def room_scoped_check(env: dict[str, Any],
     config (carries this node's `bridge_id`); it is the authenticated peer
     config the caller already validated — the seam does NOT re-derive trust
     from it, it only reads the local node id.
+
+    A2A Rooms P4.3 (design §11): for a room-scoped envelope the decision is the
+    member-local leader-MAC'd ROSTER-CACHE membership gate
+    (`rooms.roster_cache_membership_check`), with `room_epoch` from the wire and
+    the un-spoofable authenticated peer as the sender node. A NON-room message
+    (no `room_id`) returns the unconditional `not_room_scoped` pass — the two
+    paths are fully separate: a plain send is NEVER gated by room membership and
+    NEVER grants/implies it (brief contract 5).
     """
     if not a2a.envelope_is_room_scoped(env):
         return True, "not_room_scoped"
 
     room_id = str(env.get("room_id") or "")
+    # `room_epoch` is validated as a non-negative int by parse_envelope before
+    # this seam runs; 0 is a legitimate epoch, so we read the actual value and
+    # let the gate's EXACT-match enforce freshness (contract 3, fail-closed both
+    # ways — a stale OR ahead epoch is rejected, never delivered).
+    room_epoch = int(env.get("room_epoch") or 0)
     sender = env.get("sender", {})
     sender_agent = str(sender.get("agent") or "") if isinstance(sender, dict) else ""
+    # The SENDER NODE is the node-link-AUTHENTICATED peer (the signed X-AGB-Peer
+    # the caller already verified), surfaced as `sender.bridge` in the envelope
+    # and pinned to == peer_id by the do_POST `reject_sender_mismatch` check that
+    # runs BEFORE this seam. We read it from the envelope (already proven to
+    # equal the authenticated peer) so the seam stays a pure (env, cfg) function.
     sender_node = str(sender.get("bridge") or "") if isinstance(sender, dict) else ""
     target_agent = str(env.get("target_agent") or "")
     this_node = str(cfg.get("bridge_id") or "")
@@ -653,16 +676,14 @@ def room_scoped_check(env: dict[str, Any],
         return False, "no_rooms_db"
 
     try:
-        room = rooms.get_room(conn, room_id)
-        if room is None:
-            return False, "room_unknown"
-        if not rooms.is_member(conn, room_id, sender_agent, sender_node):
-            return False, "sender_not_member"
-        if not rooms.is_member(conn, room_id, target_agent, this_node):
-            return False, "target_not_member"
+        reason = rooms.roster_cache_membership_check(
+            conn, room_id=room_id, room_epoch=room_epoch,
+            sender_agent=sender_agent, sender_node=sender_node,
+            target_agent=target_agent, target_node=this_node,
+        )
     finally:
         conn.close()
-    return True, "members_ok"
+    return (reason == rooms.ROOM_TALK_OK), reason
 
 
 # --------------------------------------------------------------------------
@@ -743,6 +764,73 @@ def staged_body_text(env: dict[str, Any]) -> str:
         "",
     ]
     return "\n".join(header) + env.get("body", "")
+
+
+def stage_inbound_body(peer_id: str, message_id: str, text: str) -> Path:
+    """Stage an inbound enqueue body to a PEER-SCOPED, COLLISION-PROOF file.
+
+    A2A Rooms P4.3 (codex r2 review BLOCKING): the staged artifact MUST NOT be
+    keyed on `message_id` alone. With the composite `(peer, message_id)` dedupe
+    ledger, the SAME sender-chosen `message_id` is legal for DIFFERENT
+    authenticated peers — and the receiver is threaded (one do_POST per request),
+    while `bridge-task.sh create --body-file <path>` reads the staged file LATER
+    (in a subprocess). A message_id-only path (`incoming/<id>.md`) let two
+    concurrent same-id peers race on ONE shared file: peer B could overwrite it
+    AFTER peer A verified its body hash but BEFORE peer A's bridge-task subprocess
+    read `--body-file`, so peer A's task would be created with peer B's body /
+    provenance while peer A's dedupe row recorded peer A's hash. That is a
+    cross-peer side effect outside the peer-scoped dedupe contract.
+
+    The defense: the filename is derived from sha256(peer_id || "\\0" ||
+    message_id) (so two peers reusing one id get DISTINCT base names — the NUL
+    separator makes the pair-encoding unambiguous), and the file is created with
+    O_EXCL (exclusive create) plus a per-attempt random suffix, so NO two
+    concurrent stages — even the SAME (peer, message_id) re-delivered twice —
+    can ever point at or overwrite the same path. The UNIQUE created path is
+    returned and is exactly what flows to `--body-file` (no re-derivation back to
+    a message_id-only path). Mode 0600; the later bridge-task subprocess (same
+    uid) reads it fine.
+    """
+    incoming = a2a.incoming_dir()
+    # Controller-side staging dir under the receiver's OWN handoff state — never
+    # an isolated-agent path (the receiver daemon owns it). Same controller-only
+    # context as the pre-existing log_dir / pid_path mkdirs in this file.
+    incoming.mkdir(parents=True, exist_ok=True)  # noqa: raw-pathlib-controller-only
+    digest = hashlib.sha256(
+        peer_id.encode("utf-8") + b"\x00" + message_id.encode("utf-8")
+    ).hexdigest()
+    data = text.encode("utf-8")
+    # O_EXCL exclusive create with a random suffix: the digest scopes the name to
+    # the (peer, message_id) pair; the random suffix + O_EXCL guarantees a fresh,
+    # never-shared inode even under concurrent same-pair re-delivery. Retry on the
+    # astronomically-unlikely suffix collision (O_EXCL raises FileExistsError).
+    for _ in range(8):
+        suffix = os.urandom(8).hex()
+        staged = incoming / f"{digest}-{suffix}.md"
+        try:
+            fd = os.open(
+                str(staged),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+        except FileExistsError:
+            continue
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(data)
+        except OSError:
+            # Best-effort cleanup of a half-written exclusive file, then re-raise
+            # so the caller surfaces a 5xx rather than enqueuing a partial body.
+            # Controller-side staging path (receiver-owned), never an iso path.
+            try:
+                os.unlink(str(staged))  # noqa: raw-pathlib-controller-only
+            except OSError:
+                pass
+            raise
+        return staged
+    raise OSError(
+        "could not create a unique staged-body file after repeated O_EXCL "
+        "collisions")
 
 
 # --------------------------------------------------------------------------
@@ -1099,17 +1187,21 @@ class HandoffHandler(BaseHTTPRequestHandler):
         a2a.ensure_handoff_dirs()
         conn = a2a.open_inbox()
         try:
+            # Dedupe is scoped to the AUTHENTICATED peer (composite PK) so one
+            # peer cannot pre-seed/block another peer's sender-chosen message_id
+            # (A2A Rooms P4.3 codex review — same fix class as room_join_dedupe).
             existing = conn.execute(
                 "SELECT body_sha256, created_task_id FROM inbox_dedupe "
-                "WHERE message_id=?", (message_id,)
+                "WHERE peer=? AND message_id=?", (peer_id, message_id)
             ).fetchone()
             if existing is not None:
                 if existing["body_sha256"] == body_hash:
                     # Same id + same body → idempotent success.
                     conn.execute(
                         "UPDATE inbox_dedupe SET last_seen_ts=?, "
-                        "delivery_count=delivery_count+1 WHERE message_id=?",
-                        (a2a.now_ts(), message_id),
+                        "delivery_count=delivery_count+1 "
+                        "WHERE peer=? AND message_id=?",
+                        (a2a.now_ts(), peer_id, message_id),
                     )
                     conn.commit()
                     audit("accept_duplicate", peer=peer_id, client=client_ip,
@@ -1121,8 +1213,9 @@ class HandoffHandler(BaseHTTPRequestHandler):
                 # Same id + different body → security event, conflict.
                 conn.execute(
                     "UPDATE inbox_dedupe SET last_seen_ts=?, "
-                    "delivery_count=delivery_count+1 WHERE message_id=?",
-                    (a2a.now_ts(), message_id),
+                    "delivery_count=delivery_count+1 "
+                    "WHERE peer=? AND message_id=?",
+                    (a2a.now_ts(), peer_id, message_id),
                 )
                 conn.commit()
                 audit("reject_hash_conflict", peer=peer_id, client=client_ip,
@@ -1164,12 +1257,15 @@ class HandoffHandler(BaseHTTPRequestHandler):
                     return
 
             # --- stage body + enqueue via bridge-task.sh ---
-            staged = a2a.incoming_dir() / f"{message_id.replace(':', '_').replace('/', '_')}.md"
-            staged.write_text(staged_body_text(env), encoding="utf-8")
-            try:
-                os.chmod(staged, 0o600)
-            except OSError:
-                pass
+            # PEER-SCOPED + O_EXCL collision-proof staging (codex P4.3 r2): the
+            # composite-PK ledger legalizes the same message_id across peers, so
+            # the staged file MUST NOT be message_id-keyed (else two concurrent
+            # same-id peers race on one shared file between stage and the later
+            # bridge-task --body-file read). stage_inbound_body returns a UNIQUE
+            # path scoped to (peer_id, message_id) that flows straight to
+            # --body-file. peer_id is the authenticated X-AGB-Peer.
+            staged = stage_inbound_body(
+                peer_id, message_id, staged_body_text(env))
 
             sender = env.get("sender", {})
             ok, task_id, detail = enqueue_via_bridge_task(
@@ -1484,23 +1580,29 @@ class HandoffHandler(BaseHTTPRequestHandler):
         a2a.ensure_handoff_dirs()
         conn = a2a.open_inbox()
         try:
+            # Peer-scoped dedupe (composite PK) — same isolation as the enqueue
+            # path (A2A Rooms P4.3 codex review): one peer cannot pre-seed/block
+            # another peer's message_id in the shared inbox_dedupe ledger.
             existing = conn.execute(
-                "SELECT body_sha256 FROM inbox_dedupe WHERE message_id=?",
-                (message_id,),
+                "SELECT body_sha256 FROM inbox_dedupe "
+                "WHERE peer=? AND message_id=?",
+                (peer_id, message_id),
             ).fetchone()
             if existing is not None:
                 if existing["body_sha256"] == body_hash:
                     conn.execute(
                         "UPDATE inbox_dedupe SET last_seen_ts=?, "
-                        "delivery_count=delivery_count+1 WHERE message_id=?",
-                        (a2a.now_ts(), message_id),
+                        "delivery_count=delivery_count+1 "
+                        "WHERE peer=? AND message_id=?",
+                        (a2a.now_ts(), peer_id, message_id),
                     )
                     conn.commit()
                     return "duplicate"
                 conn.execute(
                     "UPDATE inbox_dedupe SET last_seen_ts=?, "
-                    "delivery_count=delivery_count+1 WHERE message_id=?",
-                    (a2a.now_ts(), message_id),
+                    "delivery_count=delivery_count+1 "
+                    "WHERE peer=? AND message_id=?",
+                    (a2a.now_ts(), peer_id, message_id),
                 )
                 conn.commit()
                 return "conflict"

--- a/bridge-rooms.py
+++ b/bridge-rooms.py
@@ -303,14 +303,31 @@ def cmd_list(args: argparse.Namespace) -> int:
     try:
         owned = local_node() if args.owned else None
         rows = rooms.list_rooms(conn, owned_node=owned)
+        led_ids = {r["room_id"] for r in rows}
         items = [
             {
                 "room_id": r["room_id"], "name": r["name"],
                 "leader": f"{r['leader_agent']}@{r['leader_node']}",
                 "epoch": int(r["epoch"]), "status": r["status"],
+                "role": "leader", "source": "rooms",
             }
             for r in rows
         ]
+        # Member-side fallback (P4.5): include rooms this node JOINED but does
+        # not LEAD. They have a `room_roster_cache` row (the applied leader-MAC
+        # roster) but no `rooms` row, so `list_rooms` misses them. `--owned`
+        # asks specifically for led rooms, so the cache is excluded there.
+        if not args.owned:
+            for cr in rooms.list_roster_cache(conn):
+                rid = str(cr["room_id"])
+                if rid in led_ids:
+                    continue
+                items.append({
+                    "room_id": rid, "name": None,
+                    "leader": rooms.cached_leader(cr),
+                    "epoch": int(cr["epoch"]), "status": None,
+                    "role": "member", "source": "roster-cache",
+                })
     finally:
         conn.close()
     if args.json:
@@ -320,8 +337,12 @@ def cmd_list(args: argparse.Namespace) -> int:
         info("no rooms" + (" owned by this node" if args.owned else ""))
         return 0
     for it in items:
-        out(f"{it['room_id']}  epoch={it['epoch']}  leader={it['leader']}  "
-            f"name={it['name']!r}  status={it['status']}")
+        if it["source"] == "roster-cache":
+            out(f"{it['room_id']}  epoch={it['epoch']}  leader={it['leader']}  "
+                f"role=member (cached)")
+        else:
+            out(f"{it['room_id']}  epoch={it['epoch']}  leader={it['leader']}  "
+                f"name={it['name']!r}  status={it['status']}")
     return 0
 
 
@@ -333,7 +354,15 @@ def cmd_show(args: argparse.Namespace) -> int:
     try:
         room = rooms.get_room(conn, args.room_id)
         if room is None:
-            return die(f"room not found: {args.room_id}", code=1)
+            # Member-side fallback (P4.5): this node does not LEAD the room, but
+            # may have JOINED it — in which case `room_roster_cache` holds the
+            # applied leader-MAC roster (the same cache `room talk` reads). Show
+            # that cached view read-only, clearly marked role=member /
+            # source=roster-cache, rather than the misleading "not found".
+            cache_row = rooms.get_roster_cache(conn, args.room_id)
+            if cache_row is None:
+                return die(f"room not found: {args.room_id}", code=1)
+            return _show_cached_room(args, cache_row)
         roster = rooms.roster_for(conn, args.room_id)
         pending = [
             {"agent": r["agent"], "node": r["node"], "status": r["status"]}
@@ -350,6 +379,8 @@ def cmd_show(args: argparse.Namespace) -> int:
         "status": room["status"],
         "members": roster["members"],
         "pending_join_requests": pending,
+        "role": "leader",
+        "source": "rooms",
     }
     if args.json:
         out(json.dumps(payload))
@@ -363,6 +394,39 @@ def cmd_show(args: argparse.Namespace) -> int:
         out("pending join requests:")
         for p in pending:
             out(f"  - {p['agent']}@{p['node']}")
+    return 0
+
+
+def _show_cached_room(args: argparse.Namespace,
+                      cache_row: Any) -> int:
+    """Render a member-side cached room view (P4.5) read-only.
+
+    The cache holds what the leader broadcast and this node verified+applied:
+    members (with role), epoch, and the leader node. It does NOT hold leader-only
+    fields (room name, status, the live pending-join queue) — those live only in
+    the leader's `rooms`/`room_join_requests` tables — so we surface ONLY what
+    the cache actually contains and never fabricate the rest.
+    """
+    members = rooms.cached_roster_members(cache_row)
+    if members is None:
+        return die(f"local roster cache for room {args.room_id} is corrupt",
+                   code=1)
+    payload = {
+        "room_id": str(cache_row["room_id"]),
+        "leader": rooms.cached_leader(cache_row),
+        "epoch": int(cache_row["epoch"]),
+        "members": members,
+        "role": "member",
+        "source": "roster-cache",
+    }
+    if args.json:
+        out(json.dumps(payload))
+        return 0
+    info(f"room {payload['room_id']} (epoch {payload['epoch']}, "
+         f"leader {payload['leader']}) [member-side cached view]")
+    out("members:")
+    for m in payload["members"]:
+        out(f"  - {m['agent']}@{m['node']} ({m['role']})")
     return 0
 
 

--- a/bridge-rooms.py
+++ b/bridge-rooms.py
@@ -658,6 +658,255 @@ def _broadcast_roster_to_members(room_id: str, roster: dict,
     return {"delivered": delivered, "failed": failed}
 
 
+# --------------------------------------------------------------------------
+# room talk — room-scoped cross-node member messaging (A2A Rooms P4.3, §11)
+# --------------------------------------------------------------------------
+
+def _post_room_talk(*, member_node: str, room_id: str, room_epoch: int,
+                    sender_agent: str, target_agent: str, title: str,
+                    body: str, priority: str, timeout: float = 30.0,
+                    ) -> tuple[int, bytes]:
+    """POST a ROOM-SCOPED A2A enqueue message to ONE other member node (P4.3).
+
+    Routes over the EXISTING `/enqueue` A2A path (NOT a new endpoint) so the
+    receiver's full auth preamble + durable dedupe run unchanged; the room-scope
+    is carried in the envelope (`room_id` + `room_epoch`), and the receiver's
+    fail-closed `room_scoped_check` (the P4.3 leader-MAC roster-cache gate)
+    decides delivery. The body is signed with the SAME per-peer node-link HMAC
+    secret every other A2A send uses — membership is NOT asserted on the wire,
+    it is proven by the receiver against its OWN cached leader-MAC roster.
+
+    `sender_agent` is the OS-actor-anchored agent id (the CALLER resolved it via
+    `caller_agent`/`resolve_os_actor`) — NEVER a `--from`/env value. `room_epoch`
+    is the sender's LOCALLY-cached epoch for the room (the caller read it from
+    its own `room_roster_cache`); a hostile epoch cannot be conjured because the
+    receiver requires it to EQUAL its own cached epoch. Returns
+    (http_status, response_body).
+
+    Reuses the SAME paired-flag test seam (BRIDGE_ROOMS_TEST_POST_HOOK) the join
+    / roster-broadcast senders use — the hook captures the signed request; the
+    smoke replays it through the real receiver. NEVER honored in production.
+    """
+    if a2a is None:  # pragma: no cover - a2a always ships beside this
+        raise rooms.RoomsError(
+            "room talk requires the A2A module + node-link config",
+            code="a2a_unavailable",
+        )
+    cfg = a2a.load_config()
+    local_bridge_id = str(cfg.get("bridge_id", "") or "").strip()
+    if not local_bridge_id:
+        raise rooms.RoomsError(
+            "config has no 'bridge_id' — cannot identify this node for a "
+            "room-scoped send", code="no_bridge_id",
+        )
+    peer = a2a.find_peer(cfg, member_node)
+    secret = a2a.peer_send_secret(peer)
+    message_id = a2a.new_message_id(local_bridge_id)
+    envelope = a2a.build_envelope(
+        message_id=message_id,
+        sender_bridge=local_bridge_id,
+        sender_agent=sender_agent,
+        target_agent=target_agent,
+        priority=priority,
+        title=title,
+        body=body,
+        reply_peer=local_bridge_id,
+        reply_agent=sender_agent,
+        room_id=room_id,
+        room_epoch=int(room_epoch),
+    )
+    body_bytes = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
+    path = peer.get("enqueue_path",
+                    cfg.get("listen", {}).get("enqueue_path", "/enqueue"))
+    timestamp = str(a2a.now_ts())
+    body_hash = a2a.body_sha256(body_bytes)
+    canonical = a2a.canonical_string(
+        "POST", path, local_bridge_id, message_id, timestamp, body_hash)
+    signature = a2a.sign(secret, canonical)
+    headers = {
+        "Content-Type": "application/json",
+        "X-AGB-Protocol": a2a.PROTOCOL_VERSION,
+        "X-AGB-Peer": local_bridge_id,
+        "X-AGB-Message-Id": message_id,
+        "X-AGB-Timestamp": timestamp,
+        "X-AGB-Body-SHA256": body_hash,
+        "X-AGB-Signature": signature,
+    }
+
+    if _test_post_hook_allowed():
+        return _invoke_test_post_hook(path=path, headers=headers,
+                                      body_bytes=body_bytes)
+
+    address = a2a.resolve_peer_address(peer)
+    port = int(peer.get("port", cfg.get("listen", {}).get("port", 8787)))
+    if not address:
+        raise rooms.RoomsError(
+            f"member node {member_node!r} has no resolvable address",
+            code="no_member_address",
+        )
+    import urllib.request
+
+    url = f"http://{address}:{port}{path}"
+    req = urllib.request.Request(url, data=body_bytes, method="POST")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:  # type: ignore[attr-defined]
+        return exc.code, (exc.read() or b"")
+
+
+def _talk_target_pairs(members: list, sender_agent: str,
+                       sender_node: str, local_node_id: str,
+                       only_to: str = "") -> list:
+    """The (agent, node) pairs a room-talk send targets, from the CACHED roster.
+
+    Every cached member EXCEPT the sender itself, on a node that is NOT this
+    sender's own node (a same-node member is reachable through the local queue,
+    not a node-link hop — P4.3 is cross-node messaging). `only_to`
+    (`agent` or `agent@node`) narrows to a single recipient. Deterministically
+    ordered for reproducible sends.
+    """
+    want_agent, _, want_node = (only_to or "").partition("@")
+    want_agent = want_agent.strip()
+    want_node = want_node.strip()
+    pairs: list = []
+    for m in members:
+        magent = str(m.get("agent", "") or "")
+        mnode = str(m.get("node", "") or "")
+        if magent == sender_agent and mnode == sender_node:
+            continue  # never send to self
+        if not mnode or mnode == local_node_id:
+            continue  # same node → local queue, not a cross-node room-talk hop
+        if only_to:
+            if magent != want_agent:
+                continue
+            if want_node and mnode != want_node:
+                continue
+        pair = (magent, mnode)
+        if pair not in pairs:
+            pairs.append(pair)
+    return sorted(pairs)
+
+
+def cmd_talk(args: argparse.Namespace) -> int:
+    """Send a ROOM-SCOPED message to the room's OTHER member nodes (P4.3).
+
+    The sender identity is the OS-actor-anchored trusted agent (NEVER
+    --from/env). The send stamps the room_id + the sender's LOCALLY-cached epoch
+    and routes a room-scoped A2A enqueue to each other member node over the
+    node-link. Membership is enforced by the RECEIVER against its own leader-MAC
+    roster cache — this command only sends to members the sender's OWN cache
+    already knows, and refuses to send at all if the sender is not itself a
+    cached member (fail-closed symmetry with the receiver gate).
+    """
+    room_id = args.room_id
+    agent = caller_agent(args)
+    node = local_node()
+
+    # Resolve body from --body / --body-file / stdin.
+    if args.body is not None and args.body_file is not None:
+        return die("pass only one of --body / --body-file", code=1)
+    if args.body_file is not None:
+        body_src = args.body_file
+        if not os.path.isfile(body_src):
+            return die(f"--body-file not found: {body_src}", code=1)
+        try:
+            with open(body_src, encoding="utf-8") as fh:
+                body_text = fh.read()
+        except OSError as exc:
+            return die(f"--body-file unreadable: {body_src}: {exc}", code=1)
+    elif args.body is not None:
+        body_text = args.body
+    else:
+        body_text = sys.stdin.read() if not sys.stdin.isatty() else ""
+
+    if not args.title:
+        return die("--title is required", code=1)
+    if not body_text and not args.allow_empty_body:
+        return die("body is empty; pass --body/--body-file or "
+                   "--allow-empty-body", code=1)
+    priority = args.priority
+    if a2a is not None and priority not in a2a.VALID_PRIORITIES:
+        return die(f"invalid --priority: {priority}", code=1)
+
+    # Read the sender's OWN locally-cached leader-MAC roster for this room. A
+    # room-talk send is only meaningful once this node holds a verified roster
+    # cache (from a P4.2 broadcast) — and the sender must itself be a cached
+    # member, else there is nothing it is authorized to address.
+    conn = rooms.open_rooms_readonly()
+    if conn is None:
+        return die(f"no local roster cache for room {room_id} — join the room "
+                   "and wait for the leader's roster broadcast first", code=1)
+    try:
+        row = rooms.get_roster_cache(conn, room_id)
+    finally:
+        conn.close()
+    if row is None:
+        return die(f"no local roster cache for room {room_id} — join the room "
+                   "and wait for the leader's roster broadcast first", code=1)
+    cached_epoch = int(row["epoch"])
+    members = rooms._cached_members(row)
+    if members is None:
+        return die(f"local roster cache for room {room_id} is corrupt", code=1)
+    member_pairs = {(m["agent"], m["node"]) for m in members}
+    if (agent, node) not in member_pairs:
+        return die(f"{agent}@{node} is not a member of room {room_id} per the "
+                   "local roster cache — refusing to send", code=1)
+
+    targets = _talk_target_pairs(members, agent, node, node,
+                                 only_to=getattr(args, "to", "") or "")
+    if not targets:
+        return die(f"no other-node members to send to in room {room_id} "
+                   "(roster has no cross-node recipients matching the filter)",
+                   code=1)
+
+    delivered: list = []
+    failed: list = []
+    for tagent, tnode in targets:
+        try:
+            status, resp = _post_room_talk(
+                member_node=tnode, room_id=room_id, room_epoch=cached_epoch,
+                sender_agent=agent, target_agent=tagent, title=args.title,
+                body=body_text, priority=priority,
+            )
+        except rooms.RoomsError as exc:
+            failed.append({"agent": tagent, "node": tnode, "error": str(exc)})
+            continue
+        except Exception as exc:  # noqa: BLE001 - transport/config failure
+            failed.append({"agent": tagent, "node": tnode,
+                           "error": f"room talk failed: {exc}"})
+            continue
+        if 200 <= status < 300:
+            delivered.append({"agent": tagent, "node": tnode})
+        else:
+            detail = ""
+            try:
+                detail = resp.decode("utf-8", "replace")[:200]
+            except Exception:  # noqa: BLE001
+                detail = ""
+            failed.append({"agent": tagent, "node": tnode,
+                           "status": status, "detail": detail})
+
+    payload = {
+        "room_id": room_id, "epoch": cached_epoch,
+        "from": f"{agent}@{node}",
+        "delivered": delivered, "failed": failed,
+    }
+    if args.json:
+        out(json.dumps(payload))
+    else:
+        info(f"room talk on {room_id} (epoch {cached_epoch}) from {agent}@{node}: "
+             f"{len(delivered)} delivered, {len(failed)} failed")
+        for f in failed:
+            info(f"  FAILED {f['agent']}@{f['node']}: "
+                 f"{f.get('error') or f.get('status')}")
+    # A partial failure is a non-zero exit so callers/cron notice, but a fully
+    # delivered send (or an all-targets dry filter) returns 0.
+    return 0 if not failed else 2
+
+
 def cmd_join(args: argparse.Namespace) -> int:
     parsed = rooms.parse_invite_link(args.link)
     room_id = parsed.get("room", "")
@@ -1131,6 +1380,22 @@ def build_parser() -> argparse.ArgumentParser:
     p_leave.add_argument("room_id")
     _add_common(p_leave)
     p_leave.set_defaults(func=cmd_leave)
+
+    p_talk = sub.add_parser(
+        "talk",
+        help="send a room-scoped message to the room's other member nodes")
+    p_talk.add_argument("room_id")
+    p_talk.add_argument("--title", required=True)
+    p_talk.add_argument("--body", default=None)
+    p_talk.add_argument("--body-file", dest="body_file", default=None)
+    p_talk.add_argument("--to", default="",
+                        help="narrow to one recipient (agent or agent@node); "
+                             "default = every other-node member")
+    p_talk.add_argument("--priority", default="normal")
+    p_talk.add_argument("--allow-empty-body", action="store_true",
+                        dest="allow_empty_body")
+    _add_common(p_talk)
+    p_talk.set_defaults(func=cmd_talk)
 
     p_adopt = sub.add_parser(
         "adopt-all",

--- a/bridge-rooms.py
+++ b/bridge-rooms.py
@@ -530,6 +530,134 @@ def _invoke_test_post_hook(*, path: str, headers: dict,
     return 200, (proc.stdout or "").encode("utf-8")
 
 
+def _post_room_roster_broadcast(*, member_node: str, room_id: str,
+                                room_epoch: int, members: list,
+                                leader_node: str, timeout: float = 30.0,
+                                ) -> tuple[int, bytes]:
+    """POST the leader-signed roster broadcast to ONE member node (P4.2).
+
+    `member_node` names the A2A peer to deliver to; the body is signed with the
+    leader-node↔member-node PAIRWISE node-link HMAC (the existing per-peer
+    secret), so the member can verify the roster came from the leader and a
+    member that lacks the leader↔Z secret cannot forge a roster node Z accepts
+    (§14 R2). `members` MUST be the canonical sorted roster. `leader_node` is the
+    local node (this leader's node id). Returns (http_status, response_body).
+
+    Reuses the SAME paired-flag test seam as the join sender
+    (BRIDGE_ROOMS_TEST_POST_HOOK) — the hook captures the signed request; the
+    smoke replays it through the real member-side receiver handler. NEVER honored
+    in production (the paired flags are unset there).
+    """
+    if a2a is None:  # pragma: no cover - a2a always ships beside this
+        raise rooms.RoomsError(
+            "roster broadcast requires the A2A module + node-link config",
+            code="a2a_unavailable",
+        )
+    cfg = a2a.load_config()
+    local_bridge_id = str(cfg.get("bridge_id", "") or "").strip()
+    if not local_bridge_id:
+        raise rooms.RoomsError(
+            "config has no 'bridge_id' — cannot identify this leader node for a "
+            "roster broadcast", code="no_bridge_id",
+        )
+    peer = a2a.find_peer(cfg, member_node)
+    secret = a2a.peer_send_secret(peer)
+    body = a2a.build_room_roster_broadcast(
+        room_id=room_id, room_epoch=room_epoch, members=members,
+        leader_node=leader_node,
+    )
+    body_bytes = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    message_id = a2a.new_message_id(local_bridge_id)
+    path = peer.get("room_roster_path", a2a.ROOM_ROSTER_PATH)
+    timestamp = str(a2a.now_ts())
+    body_hash = a2a.body_sha256(body_bytes)
+    canonical = a2a.canonical_string(
+        "POST", path, local_bridge_id, message_id, timestamp, body_hash)
+    signature = a2a.sign(secret, canonical)
+    headers = {
+        "Content-Type": "application/json",
+        "X-AGB-Protocol": a2a.ROOM_ROSTER_PROTOCOL_VERSION,
+        "X-AGB-Peer": local_bridge_id,
+        "X-AGB-Message-Id": message_id,
+        "X-AGB-Timestamp": timestamp,
+        "X-AGB-Body-SHA256": body_hash,
+        "X-AGB-Signature": signature,
+    }
+
+    if _test_post_hook_allowed():
+        return _invoke_test_post_hook(path=path, headers=headers,
+                                      body_bytes=body_bytes)
+
+    address = a2a.resolve_peer_address(peer)
+    port = int(peer.get("port", cfg.get("listen", {}).get("port", 8787)))
+    if not address:
+        raise rooms.RoomsError(
+            f"member node {member_node!r} has no resolvable address",
+            code="no_member_address",
+        )
+    import urllib.request
+
+    url = f"http://{address}:{port}{path}"
+    req = urllib.request.Request(url, data=body_bytes, method="POST")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:  # type: ignore[attr-defined]
+        return exc.code, (exc.read() or b"")
+
+
+def _member_nodes_for_broadcast(roster: dict, leader_node: str) -> list:
+    """The DISTINCT remote member nodes a roster broadcast targets.
+
+    Every member node that is NOT the leader's own node (the leader's local
+    members already see the authoritative rooms.db — no node-link hop). The
+    leader node is excluded so the leader never POSTs a roster to itself.
+    Deterministically ordered for reproducible broadcasts.
+    """
+    nodes: list = []
+    for m in roster.get("members", []):
+        mnode = str(m.get("node", "") or "")
+        if mnode and mnode != leader_node and mnode not in nodes:
+            nodes.append(mnode)
+    return sorted(nodes)
+
+
+def _broadcast_roster_to_members(room_id: str, roster: dict,
+                                 leader_node: str) -> dict:
+    """Broadcast the leader-signed canonical roster to every remote member node.
+
+    One signed POST per member node (§14 R2). Returns a summary
+    {delivered:[...], failed:[{node,status}...]} so the CLI can report partial
+    failures (a member-node outage does not unwind the already-committed local
+    approve — the leader's rooms.db is authoritative; the roster broadcast is
+    durable/retryable, design §14 R2). Broadcast failures are reported, never
+    fatal to the approve.
+    """
+    delivered: list = []
+    failed: list = []
+    member_nodes = _member_nodes_for_broadcast(roster, leader_node)
+    for mnode in member_nodes:
+        try:
+            status, _resp = _post_room_roster_broadcast(
+                member_node=mnode, room_id=room_id,
+                room_epoch=int(roster["epoch"]), members=roster["members"],
+                leader_node=leader_node,
+            )
+        except rooms.RoomsError as exc:
+            failed.append({"node": mnode, "error": str(exc)})
+            continue
+        except Exception as exc:  # noqa: BLE001 - transport/config failure
+            failed.append({"node": mnode, "error": f"broadcast failed: {exc}"})
+            continue
+        if 200 <= status < 300:
+            delivered.append(mnode)
+        else:
+            failed.append({"node": mnode, "status": status})
+    return {"delivered": delivered, "failed": failed}
+
+
 def cmd_join(args: argparse.Namespace) -> int:
     parsed = rooms.parse_invite_link(args.link)
     room_id = parsed.get("room", "")
@@ -567,6 +695,42 @@ def cmd_join(args: argparse.Namespace) -> int:
                 detail = ""
             return die(f"leader node rejected the join (HTTP {status}): {detail}",
                        code=1)
+        # P4.2 FIRST-ROSTER binding anchor: record the member's OWN outbound
+        # join intent locally (room_id + the leader_node it posted to). This is
+        # the un-spoofable proof that THIS node chose THIS room+leader, so the
+        # member can later accept the leader's FIRST roster broadcast for this
+        # room — and REFUSE a roster for a room it never tried to join (the
+        # anti-rogue-leader-minting defense, accept_roster_broadcast contract
+        # 3c). We record ONLY when the leader's 2xx response CONFIRMS it
+        # persisted a pending row (`status==pending`) or already had one
+        # (`duplicate==true`) — a bare 200 with no such confirmation does NOT
+        # mint a local binding (so a non-committal/stub response cannot seed a
+        # spurious intent).
+        leader_confirmed_pending = False
+        try:
+            ack = json.loads(resp.decode("utf-8", "replace") or "{}")
+            if isinstance(ack, dict):
+                leader_confirmed_pending = (
+                    ack.get("status") == rooms.JOIN_PENDING
+                    or ack.get("duplicate") is True)
+        except (ValueError, json.JSONDecodeError):
+            leader_confirmed_pending = False
+        if leader_confirmed_pending:
+            try:
+                mconn = rooms.open_rooms()
+                try:
+                    rooms.record_local_join_intent(
+                        mconn, room_id, agent, node, leader_node=leader_node)
+                finally:
+                    mconn.close()
+            except rooms.RoomsError as exc:
+                # The leader already accepted the join; failing to record the
+                # local binding is non-fatal but means the first roster will be
+                # refused until re-joined. Surface it without unwinding the
+                # accepted join.
+                info(f"WARNING: cross-node join accepted but local binding not "
+                     f"recorded ({exc}); the first roster broadcast may be "
+                     "refused until you re-run join")
         if args.json:
             out(json.dumps({"room_id": room_id,
                             "agent": f"{agent}@{node}",
@@ -608,17 +772,32 @@ def cmd_approve(args: argparse.Namespace) -> int:
     node = local_node()
     agent, anode = split_agent_node(args.target, node)
     conn = rooms.open_rooms()
+    roster_snapshot: Optional[dict] = None
     try:
         room = _require_leader_conn(conn, args.room_id, args)
-        # A join must have been requested (the two-factor gate: token =>
-        # request => leader approval). Approving an unrequested agent is a
-        # leader-initiated add, which we allow but note.
-        epoch = rooms.approve_join(conn, args.room_id, agent, anode)
+        leader_node = str(room["leader_node"] or "")
+        # P4.2 contract 1/6: a CROSS-NODE approve (admitting a REMOTE agent whose
+        # node != this leader node) REQUIRES a P4.1 verified pending row — the
+        # receiver only creates that AFTER the node-link HMAC + token + TTL/
+        # revocation verification passed. The LOCAL leader-add path (admitting an
+        # agent on this leader's OWN node) stays a SEPARATE path that does NOT
+        # claim that token/two-factor gate. The two paths are kept distinct here.
+        is_cross_node = bool(anode) and bool(leader_node) and anode != leader_node
+        if is_cross_node:
+            epoch = rooms.approve_cross_node(conn, args.room_id, agent, anode)
+        else:
+            # P1 local path: a leader-initiated add of a local agent (no verified-
+            # pending-row requirement — the leader is OS-authenticated and the
+            # agent shares this node).
+            epoch = rooms.approve_join(conn, args.room_id, agent, anode)
         if room["invite_once"]:
             rooms.burn_invite_token(conn, args.room_id)
             burned = True
         else:
             burned = False
+        # Snapshot the NEW canonical roster (post-approve, post-epoch-bump) while
+        # the connection is open, so we can broadcast it after closing the db.
+        roster_snapshot = rooms.roster_for(conn, args.room_id)
     except rooms.RoomsError as exc:
         conn.close()
         return die(str(exc), code=1)
@@ -627,12 +806,32 @@ def cmd_approve(args: argparse.Namespace) -> int:
             conn.close()
         except Exception:  # noqa: BLE001
             pass
+
+    # Broadcast the leader-signed canonical roster to every REMOTE member node
+    # over the node-link (§14 R2). The local approve is already committed +
+    # authoritative; a member-node delivery failure is reported, never fatal
+    # (roster broadcasts are durable/retryable). No-op when there are no remote
+    # member nodes (a pure single-node room).
+    broadcast = {"delivered": [], "failed": []}
+    if roster_snapshot is not None and leader_node:
+        broadcast = _broadcast_roster_to_members(
+            args.room_id, roster_snapshot, leader_node)
+
     if args.json:
         out(json.dumps({"room_id": args.room_id, "approved": f"{agent}@{anode}",
-                        "epoch": epoch, "invite_burned": burned}))
+                        "epoch": epoch, "invite_burned": burned,
+                        "cross_node": is_cross_node,
+                        "roster_broadcast": broadcast}))
     else:
         info(f"approved {agent}@{anode} into {args.room_id} (epoch {epoch})"
              + (" — single-use invite burned" if burned else ""))
+        if broadcast["delivered"]:
+            info(f"roster broadcast delivered to: "
+                 f"{', '.join(broadcast['delivered'])}")
+        if broadcast["failed"]:
+            info(f"WARNING: roster broadcast failed for: "
+                 f"{broadcast['failed']} (durable/retryable — the local approve "
+                 "is committed)")
     return 0
 
 

--- a/bridge-rooms.py
+++ b/bridge-rooms.py
@@ -270,11 +270,12 @@ def cmd_create(args: argparse.Namespace) -> int:
     node = local_node()
     leader = caller_agent(args)
     token = rooms.mint_invite_token()
+    ttl = max(0, int(getattr(args, "ttl", 0) or 0))
     conn = rooms.open_rooms()
     try:
         room_id = rooms.create_room(
             conn, name=args.name or "", leader_agent=leader,
-            leader_node=node, token=token, once=False,
+            leader_node=node, token=token, once=False, ttl=ttl,
         )
     finally:
         conn.close()
@@ -380,11 +381,12 @@ def _require_leader_conn(conn: Any, room_id: str,
 
 def cmd_invite(args: argparse.Namespace) -> int:
     node = local_node()
+    ttl = max(0, int(getattr(args, "ttl", 0) or 0))
     conn = rooms.open_rooms()
     try:
         _require_leader_conn(conn, args.room_id, args)
         token = rooms.mint_invite_token()
-        rooms.set_invite_token(conn, args.room_id, token, once=args.once)
+        rooms.set_invite_token(conn, args.room_id, token, once=args.once, ttl=ttl)
     finally:
         conn.close()
     link = rooms.make_invite_link(args.room_id, node, token)
@@ -405,20 +407,182 @@ def cmd_rotate_invite(args: argparse.Namespace) -> int:
     return cmd_invite(args)
 
 
+def _post_room_join_request(*, leader_node: str, room_id: str, token: str,
+                            joiner_agent: str, timeout: float = 30.0,
+                            ) -> tuple[int, bytes]:
+    """POST a signed cross-node room-join-request to the leader's node (P4.1).
+
+    The leader's node id (`leader_node`) names the A2A peer to deliver to. We
+    resolve that peer from the local A2A config, sign the body with the node-link
+    HMAC secret, and POST to the leader's `room_join_path`. The wire carries
+    sha256(token) ONLY (hash_token) — the raw token never leaves this process.
+    `joiner_agent` is the OS-actor-anchored agent id (resolved by the CALLER via
+    caller_agent / resolve_os_actor) — NEVER a --from/env value. Returns
+    (http_status, response_body).
+
+    A test seam (BRIDGE_ROOMS_TEST_POST_HOOK, gated by the paired
+    BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1 + BRIDGE_A2A_ALLOW_TEST_BIND=1 flags) lets
+    the smoke capture the signed request + stub the transport so no real
+    Tailscale / live receiver is needed. It is NEVER honored in production (the
+    paired flags are unset there).
+    """
+    if a2a is None:  # pragma: no cover - a2a always ships beside this
+        raise rooms.RoomsError(
+            "cross-node join requires the A2A module + node-link config",
+            code="a2a_unavailable",
+        )
+    cfg = a2a.load_config()
+    local_bridge_id = str(cfg.get("bridge_id", "") or "").strip()
+    if not local_bridge_id:
+        raise rooms.RoomsError(
+            "config has no 'bridge_id' — cannot identify this node for a "
+            "cross-node join", code="no_bridge_id",
+        )
+    peer = a2a.find_peer(cfg, leader_node)
+    secret = a2a.peer_send_secret(peer)
+    token_hash = rooms.hash_token(token)
+    body = a2a.build_room_join_request(
+        room_id=room_id, join_token_sha256=token_hash, joiner_agent=joiner_agent,
+    )
+    body_bytes = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    message_id = a2a.new_message_id(local_bridge_id)
+    path = peer.get("room_join_path", a2a.ROOM_JOIN_PATH)
+    timestamp = str(a2a.now_ts())
+    body_hash = a2a.body_sha256(body_bytes)
+    canonical = a2a.canonical_string(
+        "POST", path, local_bridge_id, message_id, timestamp, body_hash)
+    signature = a2a.sign(secret, canonical)
+    headers = {
+        "Content-Type": "application/json",
+        "X-AGB-Protocol": a2a.ROOM_JOIN_PROTOCOL_VERSION,
+        "X-AGB-Peer": local_bridge_id,
+        "X-AGB-Message-Id": message_id,
+        "X-AGB-Timestamp": timestamp,
+        "X-AGB-Body-SHA256": body_hash,
+        "X-AGB-Signature": signature,
+    }
+
+    # Test seam: capture the fully-signed request + return a stubbed response,
+    # so the smoke exercises the real sender (signing, OS-actor joiner id, hash-
+    # only body) against the real receiver WITHOUT a live socket / Tailscale.
+    if _test_post_hook_allowed():
+        return _invoke_test_post_hook(path=path, headers=headers,
+                                      body_bytes=body_bytes)
+
+    address = a2a.resolve_peer_address(peer)
+    port = int(peer.get("port", cfg.get("listen", {}).get("port", 8787)))
+    if not address:
+        raise rooms.RoomsError(
+            f"leader node {leader_node!r} has no resolvable address",
+            code="no_leader_address",
+        )
+    import urllib.request
+
+    url = f"http://{address}:{port}{path}"
+    req = urllib.request.Request(url, data=body_bytes, method="POST")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:  # type: ignore[attr-defined]
+        return exc.code, (exc.read() or b"")
+
+
+def _test_post_hook_allowed() -> bool:
+    """Paired-flag gate for the cross-node POST test seam (prod-inert)."""
+    # noqa markers: these are plain env-VAR reads (test-seam gating), NOT
+    # isolated `.env` FILE access — the iso-helper-ratchet pattern matches the
+    # `.env` substring inside `os.environ`, a false positive here.
+    return (os.environ.get("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP") == "1"  # noqa: iso-helper-boundary - env var, not a .env file
+            and os.environ.get("BRIDGE_A2A_ALLOW_TEST_BIND") == "1"  # noqa: iso-helper-boundary - env var, not a .env file
+            and bool(os.environ.get("BRIDGE_ROOMS_TEST_POST_HOOK")))  # noqa: iso-helper-boundary - env var, not a .env file
+
+
+def _invoke_test_post_hook(*, path: str, headers: dict,
+                           body_bytes: bytes) -> tuple[int, bytes]:
+    """Write the signed request to the hook file + return a stubbed 200.
+
+    The hook value is a file path the smoke reads to assert on the signed
+    request (it can then replay it against the real receiver handler). Returns a
+    synthetic 200 so the CLI reports the pending post as sent.
+    """
+    import subprocess
+
+    hook = os.environ["BRIDGE_ROOMS_TEST_POST_HOOK"]  # noqa: iso-helper-boundary - env var, not a .env file
+    payload = {
+        "path": path, "headers": headers,
+        "body": body_bytes.decode("utf-8"),
+    }
+    # The hook is a script invoked with the JSON payload on argv (file-as-argv,
+    # never stdin — footgun #11 hygiene). Its stdout (if any) is the stubbed
+    # response body; a non-zero exit surfaces as a 503 to the caller.
+    try:
+        proc = subprocess.run(
+            [hook, json.dumps(payload)], capture_output=True, text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise rooms.RoomsError(f"test post hook failed: {exc}",
+                               code="test_hook_error")
+    if proc.returncode != 0:
+        return 503, (proc.stderr or "test hook non-zero").encode("utf-8")
+    return 200, (proc.stdout or "").encode("utf-8")
+
+
 def cmd_join(args: argparse.Namespace) -> int:
     parsed = rooms.parse_invite_link(args.link)
     room_id = parsed.get("room", "")
     token = parsed.get("t", "")
+    leader_node = parsed.get("leader", "")
+    # THE joiner identity (contract 2): the OS-actor-anchored trusted agent
+    # (resolve_os_actor / pwd.getpwuid), NEVER --from / BRIDGE_AGENT_ID / USER.
+    # The SAME anchor single-node uses — so a hostile --from/env cannot change
+    # the recorded joiner on either path.
     agent = caller_agent(args)
     node = local_node()
+    if not token:
+        return die("invite link carries no token (t=...) — a join needs "
+                   "the token-bearing link, not a bare room id", code=1)
+
+    # Cross-node (P4.1): the link names a leader node that is NOT this node.
+    # Post the join-request to the leader's node over the node-link; the leader
+    # verifies + persists the pending row (no local rooms.db write here — this
+    # node is not the leader's node and has no authority over the room).
+    if leader_node and leader_node != node:
+        try:
+            status, resp = _post_room_join_request(
+                leader_node=leader_node, room_id=room_id, token=token,
+                joiner_agent=agent,
+            )
+        except rooms.RoomsError as exc:
+            return die(str(exc), code=1)
+        except Exception as exc:  # noqa: BLE001 - transport/config failure
+            return die(f"cross-node join failed: {exc}", code=1)
+        if not (200 <= status < 300):
+            detail = ""
+            try:
+                detail = resp.decode("utf-8", "replace")[:200]
+            except Exception:  # noqa: BLE001
+                detail = ""
+            return die(f"leader node rejected the join (HTTP {status}): {detail}",
+                       code=1)
+        if args.json:
+            out(json.dumps({"room_id": room_id,
+                            "agent": f"{agent}@{node}",
+                            "leader_node": leader_node,
+                            "status": rooms.JOIN_PENDING, "cross_node": True}))
+        else:
+            info(f"cross-node join request posted for {agent}@{node} on "
+                 f"{room_id} to leader node {leader_node} (pending approval)")
+        return 0
+
+    # Single-node (P1) path: joiner + leader share this node.
     conn = rooms.open_rooms()
     try:
         room = rooms.get_room(conn, room_id)
         if room is None:
             return die(f"room not found: {room_id}", code=1)
-        if not token:
-            return die("invite link carries no token (t=...) — a join needs "
-                       "the token-bearing link, not a bare room id", code=1)
         # Rate-limit per token + source BEFORE the hash compare so a brute
         # force on the token is bounded, then verify the token hash.
         try:
@@ -426,8 +590,8 @@ def cmd_join(args: argparse.Namespace) -> int:
         except rooms.RoomsError as exc:
             return die(str(exc), code=1)
         if not rooms.verify_invite_token(room, token):
-            return die("invalid invite token for this room (hash mismatch)",
-                       code=1)
+            return die("invalid invite token for this room (hash mismatch, "
+                       "expired, or revoked)", code=1)
         rooms.post_join_request(conn, room_id, agent, node)
     finally:
         conn.close()
@@ -707,6 +871,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_create = sub.add_parser("create", help="create a room (you are leader)")
     p_create.add_argument("--name", default="", help="human room name")
+    p_create.add_argument(
+        "--ttl", type=int, default=0,
+        help="invite-token lifetime in seconds (0 = no expiry, the default). "
+             "A cross-node join (P4.1) with an expired token is refused.")
     _add_common(p_create)
     p_create.set_defaults(func=cmd_create)
 
@@ -725,6 +893,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_invite.add_argument("room_id")
     p_invite.add_argument("--once", action="store_true",
                           help="single-use token (burned after one approval)")
+    p_invite.add_argument(
+        "--ttl", type=int, default=0,
+        help="invite-token lifetime in seconds (0 = no expiry, the default).")
     _add_common(p_invite)
     p_invite.set_defaults(func=cmd_invite)
 

--- a/bridge_a2a_common.py
+++ b/bridge_a2a_common.py
@@ -1154,18 +1154,118 @@ CREATE INDEX IF NOT EXISTS idx_outbox_status ON outbox(status, next_attempt_ts);
 CREATE INDEX IF NOT EXISTS idx_outbox_peer ON outbox(peer, status);
 """
 
+# A2A Rooms P4.3 (codex review): the inbox dedupe ledger is scoped to the
+# AUTHENTICATED peer via a COMPOSITE (peer, message_id) PRIMARY KEY — mirrors
+# P4.1's room_join_dedupe fix. `message_id` is sender-chosen (the `<bridge>:uuid`
+# convention is NOT enforced on the wire), so a message_id-ONLY PK let one
+# authenticated peer pre-seed / block another peer's message_id (a fresh row
+# with that id, or a same-id/different-body row → the victim's later legitimate
+# message is mis-classified as a 409 conflict and suppressed). The composite PK
+# isolates each peer's dedupe namespace: a (peerB, "nodeA:uuid") row can never
+# collide with (peerA, "nodeA:uuid"). Room-talk rides this same /enqueue dedupe,
+# so contract 6 (peer-scoped dedupe + replay protection) is satisfied here for
+# room messages too — without a separate ledger.
 _INBOX_SCHEMA = """
 CREATE TABLE IF NOT EXISTS inbox_dedupe (
-  message_id      TEXT PRIMARY KEY,
+  message_id      TEXT NOT NULL,
   peer            TEXT NOT NULL,
   body_sha256     TEXT NOT NULL,
   created_task_id TEXT,
   first_seen_ts   INTEGER NOT NULL,
   last_seen_ts    INTEGER NOT NULL,
-  delivery_count  INTEGER NOT NULL DEFAULT 1
+  delivery_count  INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (peer, message_id)
 );
 CREATE INDEX IF NOT EXISTS idx_inbox_peer ON inbox_dedupe(peer, first_seen_ts);
 """
+
+
+def _migrate_inbox_schema(conn: sqlite3.Connection) -> None:
+    """Idempotently rebuild a legacy single-column-PK inbox_dedupe to the
+    composite (peer, message_id) PK (A2A Rooms P4.3, codex review).
+
+    `CREATE TABLE IF NOT EXISTS` never alters an existing table, so an inbox.db
+    created before this change keeps `message_id TEXT PRIMARY KEY`. SQLite cannot
+    `ALTER TABLE ... ADD PRIMARY KEY`, so we detect the old shape (the
+    `message_id` column declared `pk=1` while `peer` is not part of the PK) and
+    rebuild: create the new table, copy rows (collapsing any pre-existing
+    cross-peer id collisions to the FIRST-seen row per (peer, message_id) — which
+    the old global PK could not even have stored, so there is nothing to lose in
+    practice), swap, reindex. The whole rebuild is one transaction; on any error
+    it rolls back and leaves the legacy table intact (fail-safe — dedupe still
+    works, just globally, until the next open retries the migration). NEVER drops
+    rows for a peer.
+    """
+    try:
+        cols = conn.execute("PRAGMA table_info(inbox_dedupe)").fetchall()
+    except sqlite3.Error:
+        return
+    if not cols:
+        return
+    # Map column name -> pk position (0 = not part of pk).
+    pk_of = {row[1]: int(row[5]) for row in cols}
+    # Legacy shape: message_id is the sole PK (pk==1) and peer is NOT in the PK.
+    legacy = pk_of.get("message_id", 0) == 1 and pk_of.get("peer", 0) == 0
+    if not legacy:
+        return
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("""
+            CREATE TABLE inbox_dedupe_p43 (
+              message_id      TEXT NOT NULL,
+              peer            TEXT NOT NULL,
+              body_sha256     TEXT NOT NULL,
+              created_task_id TEXT,
+              first_seen_ts   INTEGER NOT NULL,
+              last_seen_ts    INTEGER NOT NULL,
+              delivery_count  INTEGER NOT NULL DEFAULT 1,
+              PRIMARY KEY (peer, message_id)
+            )
+        """)
+        # INSERT OR IGNORE collapses to one row per (peer, message_id); with a
+        # global PK there can be at most one row per message_id anyway, so this
+        # is a faithful 1:1 copy. Order by first_seen_ts so the earliest wins.
+        conn.execute("""
+            INSERT OR IGNORE INTO inbox_dedupe_p43
+              (message_id, peer, body_sha256, created_task_id, first_seen_ts,
+               last_seen_ts, delivery_count)
+            SELECT message_id, peer, body_sha256, created_task_id, first_seen_ts,
+                   last_seen_ts, delivery_count
+            FROM inbox_dedupe ORDER BY first_seen_ts
+        """)
+        conn.execute("DROP TABLE inbox_dedupe")
+        conn.execute("ALTER TABLE inbox_dedupe_p43 RENAME TO inbox_dedupe")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_inbox_peer "
+            "ON inbox_dedupe(peer, first_seen_ts)")
+        conn.commit()
+    except sqlite3.Error:
+        # Leave the legacy table intact (no row loss) and roll back the partial
+        # rebuild. The CALLER (open_inbox) re-verifies the PK shape and FAILS
+        # CLOSED if the table is still legacy (codex P4.3 r2) — it must NOT hand
+        # back a connection on which a cross-peer same-id message could pass the
+        # peer-scoped lookup yet collide only at the post-enqueue INSERT (which
+        # would let a task be staged against a global-PK ledger).
+        conn.rollback()
+
+
+def _inbox_pk_is_composite(conn: sqlite3.Connection) -> bool:
+    """True iff inbox_dedupe carries the composite (peer, message_id) PK.
+
+    The post-migration verification gate (codex P4.3 r2). Reads PRAGMA
+    table_info: both `peer` and `message_id` must be part of the PRIMARY KEY (pk
+    position > 0). A legacy single-column-PK table (message_id pk=1, peer pk=0)
+    returns False so open_inbox can fail closed rather than serve cross-peer
+    dedupe on a global-PK ledger.
+    """
+    try:
+        cols = conn.execute("PRAGMA table_info(inbox_dedupe)").fetchall()
+    except sqlite3.Error:
+        return False
+    if not cols:
+        return False
+    pk_of = {row[1]: int(row[5]) for row in cols}
+    return pk_of.get("peer", 0) > 0 and pk_of.get("message_id", 0) > 0
 
 
 def _connect(path: Path, schema: str) -> sqlite3.Connection:
@@ -1187,7 +1287,24 @@ def open_outbox() -> sqlite3.Connection:
 
 
 def open_inbox() -> sqlite3.Connection:
-    return _connect(inbox_db_path(), _INBOX_SCHEMA)
+    conn = _connect(inbox_db_path(), _INBOX_SCHEMA)
+    _migrate_inbox_schema(conn)
+    # FAIL CLOSED if the dedupe ledger is still the legacy global-PK shape
+    # (a fresh db is created composite; an upgraded db is migrated above; only a
+    # FAILED migration leaves it legacy). Returning a legacy-PK connection would
+    # let a cross-peer same-message_id request pass the peer-scoped lookup and
+    # reach enqueue, then collide only at the post-enqueue INSERT — so we refuse
+    # to serve dedupe on it. The caller's try/except turns this into a 500
+    # BEFORE any staging/enqueue (codex P4.3 r2).
+    if not _inbox_pk_is_composite(conn):
+        conn.close()
+        raise A2AError(
+            "inbox_dedupe is still the legacy global-PK shape after migration — "
+            "refusing to serve peer-scoped dedupe on it (retry after the rebuild "
+            "succeeds)",
+            code="inbox_dedupe_legacy_pk",
+        )
+    return conn
 
 
 def outbox_total_bytes(conn: sqlite3.Connection) -> int:

--- a/bridge_a2a_common.py
+++ b/bridge_a2a_common.py
@@ -64,6 +64,26 @@ ROOM_JOIN_PROTOCOL_VERSION = "a2a-room-join-v1"
 ROOM_JOIN_ENVELOPE_PROTOCOL = "agent-bridge.a2a.room-join.v1"
 ROOM_JOIN_PATH = "/room-join-request"
 
+# A2A Rooms P4.2 (design §6 / §11 / §14 R2): the signed cross-node
+# `room-roster-broadcast` control message. After the leader (on node A) approves
+# a member it bumps the room epoch and broadcasts the canonical, leader-signed
+# roster to EACH member node over THAT node's existing node-link, MAC'd with the
+# leader-node↔member-node ordered-pair secret (one signed POST per member-link —
+# §14 R2 "Member X knows only the leader↔X secret, never leader↔Z, so X cannot
+# forge a roster node Z would accept"). Like the join-request it is a DISTINCT
+# protocol routed to a SEPARATE handler with the SAME fail-closed auth preamble
+# (remote_addr -> HMAC -> skew -> dedupe); its terminal action is a member-local
+# room_roster_cache write — it NEVER reaches the enqueue/allowlist/queue
+# boundary, carries no queue task, and admits nothing. The pairwise HMAC IS the
+# leader signature: the X-AGB-Signature header is computed over the canonical
+# request string (which binds method+path+peer+message_id+timestamp+body-hash)
+# with the leader↔member secret, so a member cannot forge a roster for a peer
+# whose secret it does not hold. The body carries ONLY the canonical roster
+# (room_id, room_epoch, sorted members, leader_node) — no token, no secret.
+ROOM_ROSTER_PROTOCOL_VERSION = "a2a-room-roster-v1"
+ROOM_ROSTER_ENVELOPE_PROTOCOL = "agent-bridge.a2a.room-roster.v1"
+ROOM_ROSTER_PATH = "/room-roster-broadcast"
+
 # Default per-peer caps. Receiver config may override per peer.
 DEFAULT_MAX_BODY_BYTES = 256 * 1024
 DEFAULT_MAX_TITLE_BYTES = 1024
@@ -975,6 +995,134 @@ def parse_room_join_request(raw: bytes) -> dict[str, Any]:
             "room-join-request join_token_sha256 must be a sha256 hex digest",
             code="bad_room_join",
         )
+    return body
+
+
+# --------------------------------------------------------------------------
+# Cross-node room-roster-broadcast control message (A2A Rooms P4.2, design §6/§14 R2)
+# --------------------------------------------------------------------------
+#
+# The body a leader's node A signs (over the per-member node-link HMAC) + each
+# member node re-validates. It carries the CANONICAL, leader-authoritative
+# roster for one room:
+#   - room_id:     the room.
+#   - room_epoch:  the monotonic epoch the broadcast carries (the freshness /
+#                  split-brain tiebreaker; a member ignores a lower-or-same epoch
+#                  unless it is a byte-identical idempotent duplicate).
+#   - members:     the roster, CANONICALLY sorted by (agent, node) — the exact
+#                  bytes the leader signed; any verifier recomputes the same MAC
+#                  string. Each entry is {agent, node, role}.
+#   - leader_node: the node that leads the room. CRITICAL (contract 3a): the
+#                  member accepts a roster ONLY when the authenticated X-AGB-Peer
+#                  (the node-link sender) EQUALS this leader_node — a roster from
+#                  any non-leader authenticated peer is rejected, persisting
+#                  nothing. There is deliberately NO leader_agent-on-the-wire
+#                  trust beyond what the roster members list itself carries.
+# The leader's signature is the node-link HMAC header (X-AGB-Signature) over the
+# canonical request string — the body carries no separate `sig` field because
+# the pairwise HMAC over the body hash IS the per-member signature (§14 R2: one
+# signature per member-link). No token, no secret ever crosses this wire.
+
+
+def build_room_roster_broadcast(
+    *,
+    room_id: str,
+    room_epoch: int,
+    members: list[dict[str, Any]],
+    leader_node: str,
+) -> dict[str, Any]:
+    """Build the cross-node room-roster-broadcast control body.
+
+    `members` MUST already be the CANONICAL sorted roster (sorted by (agent,
+    node) — `bridge_rooms_common._sorted_members` / `roster_for`). The caller
+    signs the resulting body bytes with the leader-node↔member-node pairwise
+    HMAC (the node-link secret) for EACH member node it broadcasts to, so a
+    member cannot forge a roster for a peer whose secret it does not hold. The
+    body carries NO `sig` field — the X-AGB-Signature header IS the per-link
+    signature (§14 R2).
+    """
+    return {
+        "protocol": ROOM_ROSTER_ENVELOPE_PROTOCOL,
+        "room_id": room_id,
+        "room_epoch": int(room_epoch),
+        "members": members,
+        "leader_node": leader_node,
+    }
+
+
+def parse_room_roster_broadcast(raw: bytes) -> dict[str, Any]:
+    """Parse + shape-validate a cross-node room-roster-broadcast control body.
+
+    Validates only the WIRE shape: a JSON object with the right protocol tag,
+    non-empty string `room_id` + `leader_node`, a non-negative int `room_epoch`,
+    and a `members` LIST whose every entry is an object with non-empty string
+    `agent` + string `node` (+ optional string `role`). A malformed/garbage
+    value is refused at the boundary, never half-trusted. It does NOT verify the
+    leader-authority binding (the receiver checks the authenticated peer ==
+    leader_node and the pairwise HMAC) and does NOT trust the roster beyond the
+    node-link auth the receiver already enforced.
+    """
+    try:
+        body = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise A2AError(
+            f"room-roster-broadcast is not valid JSON: {exc}",
+            code="bad_room_roster",
+        ) from exc
+    if not isinstance(body, dict):
+        raise A2AError(
+            "room-roster-broadcast root must be a JSON object",
+            code="bad_room_roster",
+        )
+    if body.get("protocol") != ROOM_ROSTER_ENVELOPE_PROTOCOL:
+        raise A2AError(
+            f"unsupported room-roster-broadcast protocol: {body.get('protocol')!r}",
+            code="bad_room_roster_protocol",
+        )
+    for field in ("room_id", "leader_node"):
+        val = body.get(field)
+        if not isinstance(val, str) or not val:
+            raise A2AError(
+                f"room-roster-broadcast missing required string field: {field}",
+                code="bad_room_roster",
+            )
+    epoch = body.get("room_epoch")
+    # bool is an int subclass — reject it explicitly so `true`/`false` cannot
+    # masquerade as an epoch.
+    if not isinstance(epoch, int) or isinstance(epoch, bool) or epoch < 0:
+        raise A2AError(
+            "room-roster-broadcast room_epoch must be a non-negative integer",
+            code="bad_room_roster",
+        )
+    members = body.get("members")
+    if not isinstance(members, list):
+        raise A2AError(
+            "room-roster-broadcast members must be a list", code="bad_room_roster",
+        )
+    for entry in members:
+        if not isinstance(entry, dict):
+            raise A2AError(
+                "room-roster-broadcast member entries must be objects",
+                code="bad_room_roster",
+            )
+        agent = entry.get("agent")
+        node = entry.get("node", "")
+        role = entry.get("role", "")
+        if not isinstance(agent, str) or not agent:
+            raise A2AError(
+                "room-roster-broadcast member missing string 'agent'",
+                code="bad_room_roster",
+            )
+        if not isinstance(node, str):
+            raise A2AError(
+                "room-roster-broadcast member 'node' must be a string",
+                code="bad_room_roster",
+            )
+        if not isinstance(role, str):
+            raise A2AError(
+                "room-roster-broadcast member 'role' must be a string",
+                code="bad_room_roster",
+            )
     return body
 
 

--- a/bridge_a2a_common.py
+++ b/bridge_a2a_common.py
@@ -51,6 +51,19 @@ IDENTITY_UPDATE_ENVELOPE_PROTOCOL = "agent-bridge.a2a.identity-update.v1"
 # and vice versa.
 IDENTITY_UPDATE_PATH = "/peer-identity-update"
 
+# A2A Rooms P4.1 (design §11 / §14 R3): the signed cross-node `room-join-request`
+# control message. A member on node B posts this to the leader's node A over the
+# EXISTING node-link so node A can verify the invite token + persist a PENDING
+# join request. Like the identity-update message it is a DISTINCT protocol routed
+# to a SEPARATE handler with its own fail-closed stack — it NEVER reaches the
+# enqueue/allowlist/queue boundary, NEVER carries a queue task, and NEVER
+# auto-admits. The wire carries `sha256(join_token)` ONLY (never the raw token,
+# §14 R3) and the joiner *agent* claim; the joiner *node* is bound by the
+# receiver to the HMAC-authenticated sender bridge (never wire-asserted).
+ROOM_JOIN_PROTOCOL_VERSION = "a2a-room-join-v1"
+ROOM_JOIN_ENVELOPE_PROTOCOL = "agent-bridge.a2a.room-join.v1"
+ROOM_JOIN_PATH = "/room-join-request"
+
 # Default per-peer caps. Receiver config may override per peer.
 DEFAULT_MAX_BODY_BYTES = 256 * 1024
 DEFAULT_MAX_TITLE_BYTES = 1024
@@ -876,6 +889,91 @@ def parse_identity_update(raw: bytes) -> dict[str, Any]:
             "identity-update must carry at least one of node_id / "
             "tailscale_name",
             code="bad_identity_update",
+        )
+    return body
+
+
+# --------------------------------------------------------------------------
+# Cross-node room-join-request control message (A2A Rooms P4.1, design §11)
+# --------------------------------------------------------------------------
+#
+# The body a node-B member signs (over the node-link HMAC) + the leader's node A
+# receiver re-validates. It carries:
+#   - room_id:          the room the joiner wants into.
+#   - join_token_sha256: sha256(raw_token) — the HASH ONLY. The raw token NEVER
+#                        crosses the wire (§14 R3); the leader hash-compares it
+#                        against the stored `invite_token_sha256`.
+#   - joiner_agent:      the joiner's agent id as attested by node B. CRITICAL
+#                        (contract 2): node B MUST derive this from its local
+#                        OS-actor / gateway-credential regime (resolve_os_actor),
+#                        NEVER from --from / BRIDGE_AGENT_ID / USER. The node-link
+#                        HMAC authenticates the NODE; the leader binds the joiner
+#                        *node* to the authenticated sender bridge (NOT to any
+#                        wire-asserted node field) and accepts `joiner_agent` only
+#                        as that authenticated node's OS-actor-anchored attestation.
+# There is deliberately NO `joiner_node` field: a wire-asserted node would be
+# spoofable, so the receiver uses the HMAC-authenticated `X-AGB-Peer` as the node.
+
+
+def build_room_join_request(
+    *,
+    room_id: str,
+    join_token_sha256: str,
+    joiner_agent: str,
+) -> dict[str, Any]:
+    """Build the cross-node room-join-request control body.
+
+    `join_token_sha256` MUST already be the hash (the caller hashes the raw
+    token with `bridge_rooms_common.hash_token` before this is built) — the raw
+    token must never reach this function or the wire. `joiner_agent` MUST be the
+    OS-actor-anchored agent id (see the section header), never a caller flag.
+    """
+    return {
+        "protocol": ROOM_JOIN_ENVELOPE_PROTOCOL,
+        "room_id": room_id,
+        "join_token_sha256": join_token_sha256,
+        "joiner_agent": joiner_agent,
+    }
+
+
+def parse_room_join_request(raw: bytes) -> dict[str, Any]:
+    """Parse + shape-validate a cross-node room-join-request control body.
+
+    Validates only the WIRE shape: a JSON object with the right protocol tag and
+    non-empty string `room_id`, `join_token_sha256`, `joiner_agent`. The token
+    hash must look like a sha256 hex digest (64 lowercase hex chars) so a
+    malformed/garbage value is refused at the boundary, never half-trusted. It
+    does NOT verify the token (the leader hash-compares + TTL/revocation-checks
+    against rooms.db) and does NOT trust the joiner identity beyond the
+    node-link auth the receiver already enforced.
+    """
+    try:
+        body = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise A2AError(
+            f"room-join-request is not valid JSON: {exc}", code="bad_room_join",
+        ) from exc
+    if not isinstance(body, dict):
+        raise A2AError(
+            "room-join-request root must be a JSON object", code="bad_room_join",
+        )
+    if body.get("protocol") != ROOM_JOIN_ENVELOPE_PROTOCOL:
+        raise A2AError(
+            f"unsupported room-join-request protocol: {body.get('protocol')!r}",
+            code="bad_room_join_protocol",
+        )
+    for field in ("room_id", "join_token_sha256", "joiner_agent"):
+        val = body.get(field)
+        if not isinstance(val, str) or not val:
+            raise A2AError(
+                f"room-join-request missing required string field: {field}",
+                code="bad_room_join",
+            )
+    th = body["join_token_sha256"]
+    if len(th) != 64 or any(c not in "0123456789abcdef" for c in th):
+        raise A2AError(
+            "room-join-request join_token_sha256 must be a sha256 hex digest",
+            code="bad_room_join",
         )
     return body
 

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -523,6 +523,11 @@ CREATE TABLE IF NOT EXISTS rooms (
   epoch              INTEGER NOT NULL DEFAULT 0,
   invite_token_sha256 TEXT,
   invite_token_ts    INTEGER NOT NULL DEFAULT 0,
+  -- P4.1 (§14 R3): TTL in seconds for the current invite token. 0 == no
+  -- expiry (the P1 default, back-compat: an existing room created before
+  -- this column simply gets 0 and never expires). verify_invite_token
+  -- enforces `invite_token_ts + invite_token_ttl >= now` when ttl > 0.
+  invite_token_ttl   INTEGER NOT NULL DEFAULT 0,
   invite_once        INTEGER NOT NULL DEFAULT 0,
   status             TEXT NOT NULL DEFAULT 'active',
   created_ts         INTEGER NOT NULL,
@@ -545,6 +550,25 @@ CREATE TABLE IF NOT EXISTS room_join_requests (
   node         TEXT NOT NULL DEFAULT '',
   requested_ts INTEGER NOT NULL,
   status       TEXT NOT NULL DEFAULT 'pending',
+  -- P4.1 (§11, §14 R3) cross-node forward-contract columns. They carry ONLY
+  -- verified METADATA, NEVER the reusable token hash (contract 5: the hash is
+  -- bearer-equivalent and is never persisted in any row):
+  --   verified  : 1 when this pending row was created by the receiver AFTER
+  --               the node-link HMAC + token-hash + TTL/revocation verification
+  --               passed. A future cross-node `approve` (P4.2) REQUIRES a row
+  --               with verified=1 (the local leader-initiated add path stays
+  --               separate and does NOT claim this gate — contract 6).
+  --   via_node  : the HMAC-authenticated node-link peer the request arrived
+  --               over (the joiner's node, bound to the authenticated sender
+  --               bridge — never a wire-asserted node).
+  --   ttl_expiry: absolute unix ts after which this pending request is stale.
+  --               0 == no expiry. Forward-contract for P4.2 cleanup.
+  -- Existing P1 rows get verified=0 / via_node='' / ttl_expiry=0 on migration,
+  -- which correctly reads as "a local single-node request, not a verified
+  -- cross-node one".
+  verified     INTEGER NOT NULL DEFAULT 0,
+  via_node     TEXT NOT NULL DEFAULT '',
+  ttl_expiry   INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (room_id, agent, node)
 );
 
@@ -572,11 +596,57 @@ CREATE TABLE IF NOT EXISTS room_join_rate (
   last_ts      INTEGER NOT NULL,
   PRIMARY KEY (token_sha256, source)
 );
+
+-- P4.1 (codex r2): cross-node room-join-request dedupe ledger. It lives in
+-- rooms.db (NOT the A2A inbox.db) so the dedupe reservation and the
+-- room_join_requests pending row commit in ONE transaction — "a dedupe row
+-- exists" is then ATOMIC with "a pending row exists", closing the window where
+-- a reservation could survive a failed pending write and let a replay return a
+-- bogus idempotent-200 with no pending row. message_id is the idempotency key;
+-- body_sha256 distinguishes an exact replay (duplicate) from id-reuse
+-- (conflict). It carries NO token / token-hash (contract 5).
+CREATE TABLE IF NOT EXISTS room_join_dedupe (
+  message_id   TEXT NOT NULL,
+  peer         TEXT NOT NULL DEFAULT '',
+  body_sha256  TEXT NOT NULL,
+  created_ts   INTEGER NOT NULL,
+  -- codex P4.1 Phase-4: dedupe is scoped to the AUTHENTICATED peer. A
+  -- composite (peer, message_id) PK means one authenticated peer cannot
+  -- consume/block another peer's join id by reusing a message_id (the
+  -- earlier message_id-only PK let nodeC pre-reserve nodeB's id).
+  PRIMARY KEY (peer, message_id)
+);
 """
 
 
 def now_ts() -> int:
     return int(time.time())
+
+
+def _migrate_schema(conn: sqlite3.Connection) -> None:
+    """Idempotently add columns introduced AFTER P1 to an existing rooms.db.
+
+    `CREATE TABLE IF NOT EXISTS` never alters an existing table, so a rooms.db
+    created by P1 lacks the P4.1 columns (rooms.invite_token_ttl,
+    room_join_requests.{verified,via_node,ttl_expiry}). We add them with the
+    same defaults the schema declares, so a migrated P1 row reads identically to
+    a freshly-created one. ALTER TABLE ADD COLUMN is cheap + non-rewriting in
+    SQLite; the per-column try/except makes re-runs (column already present) a
+    no-op rather than an error. NEVER drops/rewrites data.
+    """
+    migrations = (
+        "ALTER TABLE rooms ADD COLUMN invite_token_ttl INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE room_join_requests ADD COLUMN verified INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE room_join_requests ADD COLUMN via_node TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE room_join_requests ADD COLUMN ttl_expiry INTEGER NOT NULL DEFAULT 0",
+    )
+    for stmt in migrations:
+        try:
+            conn.execute(stmt)
+        except sqlite3.OperationalError:
+            # duplicate column name (already migrated) → idempotent no-op.
+            pass
+    conn.commit()
 
 
 def _connect(path: Path, schema: str) -> sqlite3.Connection:
@@ -587,6 +657,7 @@ def _connect(path: Path, schema: str) -> sqlite3.Connection:
     conn.execute("PRAGMA busy_timeout=30000")
     conn.execute("PRAGMA foreign_keys=ON")
     conn.executescript(schema)
+    _migrate_schema(conn)
     try:
         os.chmod(path, 0o600)
     except OSError:
@@ -792,22 +863,23 @@ def list_rooms(conn: sqlite3.Connection,
 
 def create_room(conn: sqlite3.Connection, *, name: str, leader_agent: str,
                 leader_node: str, token: str,
-                once: bool = False) -> str:
+                once: bool = False, ttl: int = 0) -> str:
     """Create a room led by `leader_agent@leader_node`; seed leader member row.
 
     `epoch` starts at 0. The leader row is role='leader'. Only the token HASH
-    is stored. Returns the minted room_id. The caller is responsible for
-    printing the one-time invite link (it holds the raw token).
+    is stored. `ttl` (seconds, P4.1) is the invite-token lifetime; 0 == no
+    expiry (the P1 default). Returns the minted room_id. The caller is
+    responsible for printing the one-time invite link (it holds the raw token).
     """
     room_id = mint_room_id()
     ts = now_ts()
     conn.execute(
         "INSERT INTO rooms (room_id, name, leader_agent, leader_node, epoch, "
-        "invite_token_sha256, invite_token_ts, invite_once, status, "
-        "created_ts, updated_ts) "
-        "VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?)",
+        "invite_token_sha256, invite_token_ts, invite_token_ttl, invite_once, "
+        "status, created_ts, updated_ts) "
+        "VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)",
         (room_id, name, leader_agent, leader_node, hash_token(token), ts,
-         1 if once else 0, ROOM_ACTIVE, ts, ts),
+         max(0, int(ttl)), 1 if once else 0, ROOM_ACTIVE, ts, ts),
     )
     conn.execute(
         "INSERT INTO room_members (room_id, agent, node, role, joined_ts) "
@@ -852,13 +924,21 @@ def require_leader(room: sqlite3.Row, caller_agent: str,
 # --------------------------------------------------------------------------
 
 def set_invite_token(conn: sqlite3.Connection, room_id: str, token: str,
-                     once: bool = False) -> None:
-    """Store a fresh token hash, INVALIDATING any prior token for the room."""
+                     once: bool = False, ttl: int = 0) -> None:
+    """Store a fresh token hash, INVALIDATING any prior token for the room.
+
+    `ttl` (seconds, P4.1 §14 R3) is the lifetime of THIS token; 0 == no expiry
+    (the P1 default). Setting/rotating a token resets `invite_token_ts` to now,
+    so the TTL clock restarts on every rotate — and because the prior hash is
+    overwritten, a rotate also REVOKES the old token (verify hash-compares the
+    new one). `ttl` is stored alongside so verify_invite_token can enforce
+    `invite_token_ts + ttl >= now`.
+    """
     ts = now_ts()
     conn.execute(
         "UPDATE rooms SET invite_token_sha256=?, invite_token_ts=?, "
-        "invite_once=?, updated_ts=? WHERE room_id=?",
-        (hash_token(token), ts, 1 if once else 0, ts, room_id),
+        "invite_token_ttl=?, invite_once=?, updated_ts=? WHERE room_id=?",
+        (hash_token(token), ts, max(0, int(ttl)), 1 if once else 0, ts, room_id),
     )
     # A rotated token invalidates prior rate-counters too (fresh budget).
     conn.execute(
@@ -868,14 +948,64 @@ def set_invite_token(conn: sqlite3.Connection, room_id: str, token: str,
     conn.commit()
 
 
-def verify_invite_token(room: sqlite3.Row, token: str) -> bool:
-    """Constant-time compare of `sha256(token)` against the room's stored hash."""
-    stored = room["invite_token_sha256"]
-    if not stored:
-        return False
+# Stable outcome codes for the token check (audit-safe — never carry the token).
+TOKEN_OK = "ok"
+TOKEN_MISMATCH = "mismatch"       # hash does not match (wrong/forged token)
+TOKEN_REVOKED = "revoked"         # no token set (rotated/burned away)
+TOKEN_EXPIRED = "expired"         # hash matches but TTL elapsed
+
+
+def verify_invite_token_outcome(room: sqlite3.Row, token: str,
+                                now: Optional[int] = None) -> str:
+    """Verify the invite token against the room, enforcing TTL + revocation.
+
+    Returns one of the TOKEN_* codes (NEVER the token itself, so the caller can
+    audit the outcome safely — contract 5). The order is:
+      1. revocation — a NULL/empty stored hash means the token was rotated or
+         burned away → TOKEN_REVOKED (nothing to match).
+      2. hash compare — constant-time `sha256(token)` vs the stored hash. A
+         mismatch is TOKEN_MISMATCH (wrong/forged token). We compare BEFORE the
+         TTL check so an attacker presenting a garbage token cannot learn the
+         room's TTL state via a timing/branch difference.
+      3. TTL (§14 R3) — when `invite_token_ttl` > 0, the token is valid only
+         while `invite_token_ts + ttl >= now`; past that it is TOKEN_EXPIRED.
+         A ttl of 0 means no expiry (P1 back-compat).
+    """
     import hmac as _hmac
 
-    return _hmac.compare_digest(stored, hash_token(token))
+    stored = room["invite_token_sha256"]
+    if not stored:
+        return TOKEN_REVOKED
+    if not _hmac.compare_digest(str(stored), hash_token(token)):
+        return TOKEN_MISMATCH
+    # Hash matched — now enforce TTL. Use a defensive getattr-style read so a
+    # row from an unmigrated/partial source (no ttl column) is treated as "no
+    # expiry" rather than raising.
+    try:
+        ttl = int(room["invite_token_ttl"])
+    except (KeyError, IndexError, TypeError, ValueError):
+        ttl = 0
+    if ttl > 0:
+        try:
+            issued = int(room["invite_token_ts"])
+        except (KeyError, IndexError, TypeError, ValueError):
+            issued = 0
+        if now is None:
+            now = now_ts()
+        if issued + ttl < int(now):
+            return TOKEN_EXPIRED
+    return TOKEN_OK
+
+
+def verify_invite_token(room: sqlite3.Row, token: str,
+                        now: Optional[int] = None) -> bool:
+    """Boolean form of `verify_invite_token_outcome` (True iff TOKEN_OK).
+
+    Now enforces TTL + revocation in addition to the hash compare, so every
+    existing caller (single-node `cmd_join`, the smokes) transparently gains the
+    P4.1 expiry/revocation gate without a signature change.
+    """
+    return verify_invite_token_outcome(room, token, now=now) == TOKEN_OK
 
 
 def burn_invite_token(conn: sqlite3.Connection, room_id: str) -> None:
@@ -1035,12 +1165,168 @@ def shared_rooms(conn: sqlite3.Connection, agent1: str, node1: str,
 
 def post_join_request(conn: sqlite3.Connection, room_id: str, agent: str,
                       node: str = "") -> None:
+    """Persist a LOCAL (single-node P1) pending join request.
+
+    verified stays 0 / via_node='' (this is not a node-link-attested cross-node
+    request). INSERT OR REPLACE re-affirms a re-requested pending row.
+    """
     conn.execute(
         "INSERT OR REPLACE INTO room_join_requests (room_id, agent, node, "
-        "requested_ts, status) VALUES (?, ?, ?, ?, ?)",
+        "requested_ts, status, verified, via_node, ttl_expiry) "
+        "VALUES (?, ?, ?, ?, ?, 0, '', 0)",
         (room_id, agent, node, now_ts(), JOIN_PENDING),
     )
     conn.commit()
+
+
+def record_verified_cross_node_join_request(
+    conn: sqlite3.Connection, room_id: str, agent: str, node: str,
+    *, via_node: str, ttl_expiry: int = 0,
+) -> None:
+    """Persist a VERIFIED cross-node (P4.1) pending join request.
+
+    Called by the leader-node receiver ONLY after the node-link HMAC +
+    token-hash + TTL/revocation verification has passed (contract 4). The row
+    carries verified METADATA — the joiner `agent@node`, the verified flag, the
+    HMAC-authenticated node-link peer (`via_node`), and an optional `ttl_expiry`
+    — but NEVER the reusable token hash (contract 5: the hash is bearer-
+    equivalent and is never persisted in any row). NO membership is added and NO
+    leader task is created here: admission is a separate P4.2 `approve` that
+    REQUIRES a verified row (contract 6).
+
+    `node` is the joiner's node as bound by the receiver to the authenticated
+    sender bridge (NEVER a wire-asserted value). INSERT OR REPLACE keyed on
+    (room_id, agent, node) makes a duplicate request idempotent (refresh ts).
+
+    NOTE: prefer `record_verified_cross_node_join_request_atomic` on the receiver
+    path — it commits the dedupe reservation + this pending row in ONE
+    transaction. This bare helper is retained for the local/test path that does
+    not need the dedupe ledger.
+    """
+    conn.execute(
+        "INSERT OR REPLACE INTO room_join_requests (room_id, agent, node, "
+        "requested_ts, status, verified, via_node, ttl_expiry) "
+        "VALUES (?, ?, ?, ?, ?, 1, ?, ?)",
+        (room_id, agent, node, now_ts(), JOIN_PENDING, via_node,
+         max(0, int(ttl_expiry))),
+    )
+    conn.commit()
+
+
+# Stable outcomes for the atomic cross-node dedupe+persist (audit-safe codes).
+JOIN_DEDUPE_RESERVED = "reserved"   # new id → dedupe row + pending row committed
+JOIN_DEDUPE_DUPLICATE = "duplicate"  # same id + same body → already-accepted
+JOIN_DEDUPE_CONFLICT = "conflict"    # same id + different body → id reuse
+
+
+def room_join_dedupe_lookup(conn: sqlite3.Connection, peer: str,
+                            message_id: str, body_sha256: str) -> str:
+    """READ-ONLY dedupe check against rooms.db. Returns one of:
+    'new' (no row), JOIN_DEDUPE_DUPLICATE (same id+body), JOIN_DEDUPE_CONFLICT
+    (same id, different body). A row exists ONLY for a PREVIOUSLY-ACCEPTED
+    cross-node join (the reservation is atomic with the pending row), so a hit
+    here means the request was already accepted. Never writes.
+
+    On an UPGRADED P1 rooms.db the `room_join_dedupe` table may not exist yet
+    when this read-only path runs (codex P4.1 r3 #2): `open_rooms_readonly`
+    deliberately does NOT run schema creation, and the migrating RW `open_rooms`
+    happens later on the accept path. A missing table therefore means "no
+    prior accepted request" → 'new'; the RW open on the accept path creates the
+    table before the reservation. Any OTHER operational error propagates.
+    """
+    try:
+        row = conn.execute(
+            "SELECT body_sha256 FROM room_join_dedupe "
+            "WHERE peer=? AND message_id=?",
+            (peer, message_id),
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return "new"
+        raise
+    if row is None:
+        return "new"
+    return (JOIN_DEDUPE_DUPLICATE if row["body_sha256"] == body_sha256
+            else JOIN_DEDUPE_CONFLICT)
+
+
+def record_verified_cross_node_join_request_atomic(
+    conn: sqlite3.Connection, *, message_id: str, body_sha256: str, peer: str,
+    room_id: str, agent: str, node: str, via_node: str, ttl_expiry: int = 0,
+) -> str:
+    """ATOMICALLY reserve the dedupe row AND persist the verified pending row.
+
+    The whole operation commits in ONE transaction (codex P4.1 r2): "a dedupe row
+    exists" is therefore equivalent to "a pending row exists", closing the window
+    where a surviving reservation could let a replay return a bogus idempotent
+    200 with no pending row. Returns:
+      - JOIN_DEDUPE_DUPLICATE : the message_id was already accepted with the SAME
+        body → idempotent, NOTHING re-written.
+      - JOIN_DEDUPE_CONFLICT  : the message_id was already used with a DIFFERENT
+        body → id reuse, NOTHING written.
+      - JOIN_DEDUPE_RESERVED  : a NEW id → the dedupe row + the pending row are
+        BOTH committed together.
+
+    The dedupe + pending writes are issued WITHOUT an intermediate commit, then a
+    single `conn.commit()` makes them durable atomically; a failure before the
+    commit (e.g. the pending INSERT raises) rolls BOTH back, so no orphan dedupe
+    row survives. Carries NO token / token-hash (contract 5).
+    """
+    # Re-check inside this call (the caller's read-only lookup may have raced).
+    # Scoped to the authenticated peer (codex P4.1 Phase-4 — composite PK).
+    existing = conn.execute(
+        "SELECT body_sha256 FROM room_join_dedupe "
+        "WHERE peer=? AND message_id=?",
+        (peer, message_id),
+    ).fetchone()
+    if existing is not None:
+        # A concurrent accept reserved first → resolve to the same outcome the
+        # lookup would have produced. No write (the pending row is already there
+        # from the first accept).
+        return (JOIN_DEDUPE_DUPLICATE if existing["body_sha256"] == body_sha256
+                else JOIN_DEDUPE_CONFLICT)
+    ts = now_ts()
+    try:
+        conn.execute(
+            "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+            "created_ts) VALUES (?, ?, ?, ?)",
+            (message_id, peer, body_sha256, ts),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO room_join_requests (room_id, agent, node, "
+            "requested_ts, status, verified, via_node, ttl_expiry) "
+            "VALUES (?, ?, ?, ?, ?, 1, ?, ?)",
+            (room_id, agent, node, ts, JOIN_PENDING, via_node,
+             max(0, int(ttl_expiry))),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError:
+        # CONCURRENCY (codex P4.1 r3 #1): two handlers both passed the pre-check
+        # SELECT before either committed; this one lost the message_id PK race.
+        # The dedupe row's PRIMARY KEY is the serialization point — roll back our
+        # partial write and re-query the winner's row, returning the SAME
+        # idempotent/conflict outcome the pre-check would have. The loser thus
+        # gets a clean duplicate/conflict, never a 500. (No orphan row: our
+        # INSERT was rolled back; the pending row, if any, belongs to the winner.)
+        conn.rollback()
+        winner = conn.execute(
+            "SELECT body_sha256 FROM room_join_dedupe "
+            "WHERE peer=? AND message_id=?",
+            (peer, message_id),
+        ).fetchone()
+        if winner is not None:
+            return (JOIN_DEDUPE_DUPLICATE
+                    if winner["body_sha256"] == body_sha256
+                    else JOIN_DEDUPE_CONFLICT)
+        # The PK violation came from somewhere other than a concurrent winner
+        # (should not happen) — surface it rather than silently swallow.
+        raise
+    except Exception:
+        # Roll BOTH writes back so a failed pending insert never leaves an
+        # orphan dedupe reservation (the r2 atomicity contract).
+        conn.rollback()
+        raise
+    return JOIN_DEDUPE_RESERVED
 
 
 def list_join_requests(conn: sqlite3.Connection, room_id: str,

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -1611,6 +1611,106 @@ def get_roster_cache(conn: sqlite3.Connection,
     ).fetchone()
 
 
+# --------------------------------------------------------------------------
+# Member-side room-scoped TALK gate (A2A Rooms P4.3, design §11)
+# --------------------------------------------------------------------------
+#
+# Once a member node holds a leader-MAC'd roster in `room_roster_cache` (written
+# by P4.2's `accept_roster_broadcast` after a pairwise-HMAC verify FROM the
+# leader), members on DIFFERENT nodes can exchange room-scoped messages WITHOUT
+# the leader being online — because each member validates membership against its
+# OWN local cache, never a live leader call. A room-scoped message carries
+# `room_id` + `room_epoch`; the receiver fail-closed-checks both the sender and
+# the local target against the locally-cached roster for that `room_id` at that
+# exact `room_epoch`. The receiver MUST NOT trust any membership claim inside the
+# inbound message — it consults ONLY this cache (the one P4.2 verified).
+
+# Stable, audit-safe room-talk membership outcome codes (contract 8: no
+# secret/token ever appears in them).
+ROOM_TALK_OK = "members_ok"
+ROOM_TALK_NO_CACHE = "no_roster_cache"        # no leader-MAC roster for this room
+ROOM_TALK_BAD_CACHE = "roster_cache_corrupt"  # cached members_json unparseable
+ROOM_TALK_EPOCH_MISMATCH = "epoch_mismatch"   # envelope epoch != cached epoch
+ROOM_TALK_SENDER_NOT_MEMBER = "sender_not_member"
+ROOM_TALK_TARGET_NOT_MEMBER = "target_not_member"
+
+
+def _cached_members(row: sqlite3.Row) -> Optional[list[dict[str, str]]]:
+    """Parse the cached `members_json` into a list of {agent,node} dicts.
+
+    Returns None if the stored JSON is not a list of objects (corrupt cache —
+    the caller fails closed). Each entry is normalized to plain strings so the
+    membership comparison never trips on a non-string node/agent.
+    """
+    try:
+        parsed = json.loads(str(row["members_json"] or "[]"))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(parsed, list):
+        return None
+    out: list[dict[str, str]] = []
+    for m in parsed:
+        if not isinstance(m, dict):
+            return None
+        out.append({
+            "agent": str(m.get("agent", "")),
+            "node": str(m.get("node", "")),
+        })
+    return out
+
+
+def roster_cache_membership_check(
+    conn: sqlite3.Connection, *, room_id: str, room_epoch: int,
+    sender_agent: str, sender_node: str, target_agent: str, target_node: str,
+) -> str:
+    """Fail-closed room-talk membership gate against the LOCAL roster cache (P4.3).
+
+    The member-side heart of P4.3 (brief contracts 2-4). The CALLER (the
+    receiver) has ALREADY run the full node-link auth preamble, so `sender_node`
+    is the node-link-AUTHENTICATED peer (un-spoofable) and `target_node` is THIS
+    receiver's own node id. This function applies the remaining room-scoped
+    delivery contracts and returns a ROOM_TALK_* code; the receiver delivers ONLY
+    on ROOM_TALK_OK.
+
+    Contracts enforced here (NEVER trusts any membership claim in the inbound
+    message — it reads ONLY the locally-cached leader-MAC roster):
+      - NO local roster cache for `room_id` → ROOM_TALK_NO_CACHE (contract 2: a
+        room with no leader-verified roster cannot validate membership → deny,
+        no delivery). A plain non-room send never reaches here, so it can NEITHER
+        be gated by this nor seed a cache.
+      - `room_epoch` must EQUAL the cached epoch (contract 3, fail-closed BOTH
+        ways): an envelope epoch lower OR higher than the cache → ROOM_TALK_
+        EPOCH_MISMATCH. We refuse to deliver against a roster we cannot confirm
+        the sender belongs to AT THAT EPOCH (roster refresh on mismatch is P4.x,
+        deliberately out of scope — just fail closed).
+      - The authenticated SENDER `(sender_agent, sender_node)` MUST appear in the
+        cached roster (contract 2/4). Identity is OS-actor + node anchored: the
+        node is the un-spoofable authenticated peer, and a hostile wire
+        `sender_agent` can at most name an agent the leader ACTUALLY admitted on
+        that node — it cannot conjure a NON-member into the cache → ROOM_TALK_
+        SENDER_NOT_MEMBER otherwise.
+      - The local TARGET `(target_agent, target_node)` MUST also be a cached
+        member (you only deliver a room message to a local agent who is itself in
+        the room) → ROOM_TALK_TARGET_NOT_MEMBER otherwise.
+    """
+    row = get_roster_cache(conn, room_id)
+    if row is None:
+        return ROOM_TALK_NO_CACHE
+    if int(room_epoch) != int(row["epoch"]):
+        return ROOM_TALK_EPOCH_MISMATCH
+    members = _cached_members(row)
+    if members is None:
+        return ROOM_TALK_BAD_CACHE
+    sender_pair = (str(sender_agent), str(sender_node))
+    target_pair = (str(target_agent), str(target_node))
+    member_pairs = {(m["agent"], m["node"]) for m in members}
+    if sender_pair not in member_pairs:
+        return ROOM_TALK_SENDER_NOT_MEMBER
+    if target_pair not in member_pairs:
+        return ROOM_TALK_TARGET_NOT_MEMBER
+    return ROOM_TALK_OK
+
+
 def accept_roster_broadcast(
     conn: sqlite3.Connection, *, room_id: str, room_epoch: int,
     members: list[dict[str, Any]], leader_node: str, peer_id: str,

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -1611,6 +1611,67 @@ def get_roster_cache(conn: sqlite3.Connection,
     ).fetchone()
 
 
+def list_roster_cache(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    """All member-local cached roster rows (every room this node has joined).
+
+    The read-only counterpart to `get_roster_cache` for `agb room list` on a
+    NON-leader node: a member node holds a `room_roster_cache` row per room it
+    was admitted into (written by P4.2), but no `rooms` row (it does not LEAD
+    them). `list_rooms` only sees led rooms; this surfaces the joined-but-not-led
+    ones so they are visible alongside. Ordered by room_id for a stable view.
+    """
+    return conn.execute(
+        "SELECT room_id, epoch, members_json, from_node, mac, fetched_ts "
+        "FROM room_roster_cache ORDER BY room_id"
+    ).fetchall()
+
+
+def cached_roster_members(row: sqlite3.Row) -> Optional[list[dict[str, str]]]:
+    """Parse a roster-cache row's `members_json` for DISPLAY (keeps `role`).
+
+    Unlike `_cached_members` (the talk gate, which deliberately drops `role`
+    so the membership comparison only keys on agent+node), this preserves the
+    cached `role` so `room show`/`room list` can render a member-side view that
+    matches what a leader node shows. Returns None on a corrupt cache (caller
+    surfaces that read-only, never fabricates).
+    """
+    try:
+        parsed = json.loads(str(row["members_json"] or "[]"))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(parsed, list):
+        return None
+    out: list[dict[str, str]] = []
+    for m in parsed:
+        if not isinstance(m, dict):
+            return None
+        out.append({
+            "agent": str(m.get("agent", "")),
+            "node": str(m.get("node", "")),
+            "role": str(m.get("role", "member")) or "member",
+        })
+    return out
+
+
+def cached_leader(row: sqlite3.Row) -> str:
+    """Best-effort `leader_agent@leader_node` from a roster-cache row.
+
+    The cache stores the leader's NODE (`from_node`) but not the leader agent
+    name as a top-level field — so the leader agent is recovered from the cached
+    member whose `role == 'leader'` (the leader is always a roster member). If no
+    leader member is present (corrupt/partial cache), only the node is shown —
+    we never invent a leader agent the cache does not actually contain.
+    """
+    members = cached_roster_members(row)
+    leader_node = str(row["from_node"] or "")
+    if members:
+        for m in members:
+            if m["role"] == "leader":
+                node = m["node"] or leader_node
+                return f"{m['agent']}@{node}" if node else m["agent"]
+    return f"?@{leader_node}" if leader_node else "?"
+
+
 # --------------------------------------------------------------------------
 # Member-side room-scoped TALK gate (A2A Rooms P4.3, design §11)
 # --------------------------------------------------------------------------

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -1447,6 +1447,62 @@ def approve_join(conn: sqlite3.Connection, room_id: str, agent: str,
     return bump_epoch(conn, room_id)
 
 
+def has_verified_pending_request(conn: sqlite3.Connection, room_id: str,
+                                 agent: str, node: str) -> bool:
+    """True iff a VERIFIED, still-pending cross-node join row exists (P4.2).
+
+    The two-factor gate for a CROSS-NODE approve (contract 1): admitting a
+    REMOTE agent (one whose node != this leader node) REQUIRES a
+    `room_join_requests` row with `verified=1` AND `status='pending'` —
+    i.e. a row the receiver (P4.1) created only AFTER the node-link HMAC +
+    token-hash + TTL/revocation verification passed. A row that is denied/
+    approved/absent does NOT satisfy the gate. The LOCAL leader-initiated add
+    path (a leader admitting an agent on its OWN node) is a SEPARATE path that
+    does NOT consult this gate — see `approve_cross_node` vs `approve_join`.
+    """
+    row = conn.execute(
+        "SELECT verified, status FROM room_join_requests "
+        "WHERE room_id=? AND agent=? AND node=?",
+        (room_id, agent, node),
+    ).fetchone()
+    if row is None:
+        return False
+    try:
+        verified = int(row["verified"])
+    except (KeyError, IndexError, TypeError, ValueError):
+        verified = 0
+    return verified == 1 and str(row["status"]) == JOIN_PENDING
+
+
+def approve_cross_node(conn: sqlite3.Connection, room_id: str, agent: str,
+                       node: str) -> int:
+    """Admit a REMOTE (cross-node) member — REQUIRES a verified pending row.
+
+    The P4.2 cross-node admission path (contract 1). Unlike `approve_join` (the
+    P1 local path that admits a local agent with no pending-row requirement),
+    this REFUSES to add a remote member unless a P4.1 verified pending row
+    exists (`has_verified_pending_request`). This is the anti-forgery gate: a
+    leader cannot be tricked into broadcasting a roster that admits a remote
+    agent who never completed the node-link-authenticated, token-verified join.
+
+    Raises RoomsError(code='no_verified_request') when the gate is unmet (NO
+    membership add, NO epoch bump). On success: add member, mark the request
+    approved, bump the epoch (which re-persists the leader's authoritative
+    roster cache atomically). Returns the new epoch.
+    """
+    require_room(conn, room_id)
+    if not has_verified_pending_request(conn, room_id, agent, node):
+        raise RoomsError(
+            f"cross-node approve of {agent}@{node} on {room_id} requires a "
+            "verified pending join request (none found) — a remote agent must "
+            "complete the node-link-authenticated, token-verified join first",
+            code="no_verified_request",
+        )
+    add_member(conn, room_id, agent, node, role=ROLE_MEMBER)
+    set_join_request_status(conn, room_id, agent, node, JOIN_APPROVED)
+    return bump_epoch(conn, room_id)
+
+
 def remove_and_bump(conn: sqlite3.Connection, room_id: str, agent: str,
                     node: str = "") -> int:
     """Remove a member (leave/kick), bump epoch, recompute roster.
@@ -1463,6 +1519,358 @@ def remove_and_bump(conn: sqlite3.Connection, room_id: str, agent: str,
         )
     # bump_epoch re-persists room_roster_cache atomically (centralized in F2).
     return bump_epoch(conn, room_id)
+
+
+# --------------------------------------------------------------------------
+# Member-side roster broadcast acceptance (A2A Rooms P4.2, design §6/§14 R2)
+# --------------------------------------------------------------------------
+#
+# The leader (node A) signs the canonical roster with the leader↔member pairwise
+# HMAC and POSTs it to each member node. The member node verifies the node-link
+# HMAC (the receiver auth preamble does this) and then runs THIS acceptance
+# logic, which encodes the anti-spoof / anti-rogue-leader / monotonic-epoch
+# contracts. It writes the member-local `room_roster_cache` (the cache that lets
+# comms survive a leader outage — design §6 "Roster cache").
+#
+# Stable, audit-safe acceptance outcome codes (no secret/token ever in them).
+ROSTER_ACCEPTED = "accepted"            # cache written (first bind or higher epoch)
+ROSTER_DUPLICATE = "duplicate"          # byte-identical idempotent re-broadcast
+ROSTER_STALE_EPOCH = "stale_epoch"      # lower-or-same epoch (not a dup) → ignored
+ROSTER_NOT_LEADER = "not_leader"        # peer != body.leader_node → rejected
+ROSTER_NO_LOCAL_BINDING = "no_local_binding"  # first roster w/o local join state
+ROSTER_LEADER_MISMATCH = "leader_mismatch"  # peer != the ESTABLISHED cached leader
+ROSTER_DEDUPE_CONFLICT = "dedupe_conflict"  # same (peer,message_id), DIFFERENT body
+
+
+def _local_join_binding_for(conn: sqlite3.Connection, room_id: str,
+                            expected_leader_node: str) -> bool:
+    """True iff this node holds LOCAL outbound join state for `room_id` that
+    names `expected_leader_node` as the leader (the FIRST-ROSTER binding anchor).
+
+    The anti-rogue-leader contract (codex #9622 contract 2, brief contract 3c): a
+    member accepts its FIRST roster for a room ONLY if it already initiated a
+    join to THIS room naming THIS leader node. The member's own `room join`
+    (P4.2) records a LOCAL `room_join_requests` row (status pending/approved)
+    whose `via_node` is the leader node it posted to — that row is the proof the
+    member chose this room+leader, so an inbound roster claiming
+    `leader_node=<some configured peer>` cannot MINT a brand-new room cache out
+    of thin air (which would let any configured peer shape future room-scoped
+    allow decisions).
+
+    The binding requires:
+      - a `room_join_requests` row for `room_id`,
+      - status pending OR approved (a denied request is not a live intent),
+      - `via_node` == `expected_leader_node` (the member posted its join to THIS
+        leader node — an un-spoofable record of the member's own outbound choice,
+        NOT a wire-asserted value).
+    """
+    rows = conn.execute(
+        "SELECT status, via_node FROM room_join_requests WHERE room_id=?",
+        (room_id,),
+    ).fetchall()
+    for r in rows:
+        if str(r["status"]) not in (JOIN_PENDING, JOIN_APPROVED):
+            continue
+        if str(r["via_node"] or "") == expected_leader_node:
+            return True
+    return False
+
+
+def record_local_join_intent(conn: sqlite3.Connection, room_id: str, agent: str,
+                             node: str, *, leader_node: str) -> None:
+    """Record the member's OWN outbound cross-node join intent locally (P4.2).
+
+    Called on the MEMBER/sender node when it posts a cross-node `room join`, so
+    the member has a LOCAL record that it chose `room_id` with leader
+    `leader_node`. This row is the FIRST-ROSTER binding anchor
+    (`_local_join_binding_for`): it lets the member later accept the leader's
+    first roster broadcast for this room, while refusing a roster for a room it
+    never tried to join (the rogue-leader-minting defense).
+
+    `via_node` carries the leader node the member posted to (its own choice).
+    `verified` stays 0 — this is the member's local view, NOT the leader-side
+    receiver-verified row (that lives on the leader's node). INSERT OR REPLACE
+    keyed on (room_id, agent, node) re-affirms a re-issued join.
+    """
+    conn.execute(
+        "INSERT OR REPLACE INTO room_join_requests (room_id, agent, node, "
+        "requested_ts, status, verified, via_node, ttl_expiry) "
+        "VALUES (?, ?, ?, ?, ?, 0, ?, 0)",
+        (room_id, agent, node, now_ts(), JOIN_PENDING, leader_node),
+    )
+    conn.commit()
+
+
+def get_roster_cache(conn: sqlite3.Connection,
+                     room_id: str) -> Optional[sqlite3.Row]:
+    """The member-local cached roster row for a room (or None)."""
+    return conn.execute(
+        "SELECT room_id, epoch, members_json, from_node, mac, fetched_ts "
+        "FROM room_roster_cache WHERE room_id=?",
+        (room_id,),
+    ).fetchone()
+
+
+def accept_roster_broadcast(
+    conn: sqlite3.Connection, *, room_id: str, room_epoch: int,
+    members: list[dict[str, Any]], leader_node: str, peer_id: str,
+    message_id: str, body_sha256: str, mac: str = "",
+) -> str:
+    """Apply a verified leader roster broadcast to the member-local cache.
+
+    The member-side heart of P4.2. The CALLER (the receiver) has ALREADY verified
+    the node-link pairwise HMAC over the canonical request (so `peer_id` is the
+    authenticated sender node and the body is intact). This function encodes the
+    remaining security contracts and performs the ATOMIC dedupe-reserve + cache
+    write. Returns a ROSTER_* outcome code; raises RoomsError only on an
+    unexpected DB fault.
+
+    Contracts enforced here (brief §3):
+      a. LEADER-AUTHORITY (3a): accept ONLY when `peer_id == leader_node`. A
+         roster whose body `leader_node` != the authenticated sender →
+         ROSTER_NOT_LEADER, persists NOTHING. (The pairwise-HMAC verify in 3b is
+         the caller's job; a bad HMAC never reaches here.)
+      a'. LEADER PINNING (codex P4.2 r1 BLOCKING — close the rogue-leader
+         TAKEOVER of an EXISTING room): once a cache exists, the room's leader is
+         PINNED to the cached `from_node`. A DIFFERENT configured peer that
+         self-claims `leader_node=<itself>` + signs a higher epoch must NOT
+         overwrite the cache → ROSTER_LEADER_MISMATCH, persists NOTHING. Without
+         this, contract 3a alone (`peer_id == leader_node`) is trivially
+         satisfied by any peer naming itself leader, so the first-roster binding
+         would only protect the FIRST roster, not subsequent updates.
+      c. FIRST-ROSTER BINDING (3c): if NO cache row exists yet for this room, the
+         member accepts the first roster ONLY if it holds LOCAL outbound join
+         state for THIS room naming THIS leader_node
+         (`_local_join_binding_for`). Otherwise → ROSTER_NO_LOCAL_BINDING,
+         persists NOTHING. NEVER mint a room cache purely from an inbound roster.
+      d. MONOTONIC EPOCH (3d): with an existing cache (from the PINNED leader), a
+         STRICTLY-higher epoch updates; a lower-or-same epoch is IGNORED
+         (ROSTER_STALE_EPOCH) UNLESS the incoming roster is BYTE-IDENTICAL to the
+         cached one at the SAME epoch (ROSTER_DUPLICATE — idempotent, no write).
+      e. ATOMIC dedupe + update (3e + codex P4.2 r3 BLOCKING — close the TOCTOU
+         race): for any outcome that WRITES the cache (ACCEPTED), the peer-scoped
+         dedupe RESERVATION and the room_roster_cache WRITE commit in ONE
+         transaction (single serialization point). The dedupe reservation is the
+         `room_join_dedupe` PRIMARY KEY (peer, message_id), so:
+           - a fresh (peer, message_id) → reserve + write cache + commit together.
+           - a same (peer, message_id) with a DIFFERENT body_sha256 →
+             ROSTER_DEDUPE_CONFLICT, write NOTHING (rolled back). The receiver
+             answers 409. This holds EVEN under a check-then-write race: two
+             concurrent same-id deliveries cannot both pass + both write — the PK
+             serializes them and the loser is re-classified (IntegrityError →
+             re-query → conflict/duplicate), never a partial cache mutation.
+           - a same (peer, message_id) with the SAME body_sha256 →
+             ROSTER_DUPLICATE (idempotent — the cache already reflects it; no
+             double-apply).
+         A contract REJECT (not_leader / leader_mismatch / no_binding /
+         stale_epoch) reserves NO dedupe row, so a replay re-evaluates the
+         contracts (the stale/not-leader teeth hold on replay).
+
+    `members` MUST be the canonical sorted roster (the bytes the leader signed);
+    we re-canonicalize on store so the cached `members_json` is reproducible.
+    `mac` is the presented per-link signature (stored for audit/debug; the real
+    auth is the receiver's HMAC verify, already done). `message_id`/`body_sha256`
+    are the dedupe key (peer-scoped) the receiver carries from the wire headers.
+    """
+    # --- 3a: leader-authority binding — the authenticated sender must be the
+    # node the body names as leader. (peer_id is the un-spoofable HMAC-authed
+    # X-AGB-Peer; leader_node is the body's claim.) ---
+    if peer_id != leader_node:
+        return ROSTER_NOT_LEADER
+
+    incoming_members = _canonical_member_list(members)
+    incoming_json = json.dumps(incoming_members, separators=(",", ":"))
+    epoch = int(room_epoch)
+
+    existing = get_roster_cache(conn, room_id)
+    if existing is None:
+        # --- 3c: FIRST-ROSTER binding — never mint a cache from an inbound
+        # roster alone; the member must have chosen this room+leader locally. ---
+        if not _local_join_binding_for(conn, room_id, leader_node):
+            return ROSTER_NO_LOCAL_BINDING
+        # WRITE path → atomic dedupe-reserve + cache write (3e).
+        return _reserve_and_write_roster_cache(
+            conn, peer=peer_id, message_id=message_id, body_sha256=body_sha256,
+            room_id=room_id, epoch=epoch, members_json=incoming_json,
+            from_node=leader_node, mac=mac)
+
+    # --- 3a': LEADER PINNING — an existing cache fixes the room's leader to its
+    # established `from_node`. A roster signed by a DIFFERENT peer is a TAKEOVER
+    # attempt → reject, persist nothing (even at a higher epoch). The legitimate
+    # leader always signs with its own node id == the cached from_node, so this
+    # never blocks a genuine update from the real leader.
+    #
+    # The comparison is UNGUARDED by truthiness (codex P4.2 r2 BLOCKING): an
+    # existing cache whose `from_node` is "" is a SINGLE-NODE/local room (P1a
+    # seeds `from_node=leader_node`, which is "" when local_node() is empty). A
+    # remote peer arriving over a node-link ALWAYS has a non-empty authenticated
+    # `peer_id == leader_node`, so for any such inbound roster `leader_node !=
+    # "" == cached_from_node` → rejected. A remote node can therefore NEVER claim
+    # leadership of a local/single-node room via a roster broadcast. ---
+    cached_leader = str(existing["from_node"] or "")
+    if leader_node != cached_leader:
+        return ROSTER_LEADER_MISMATCH
+
+    # --- 3d: monotonic epoch (existing cache present, leader pinned) ---
+    cached_epoch = int(existing["epoch"])
+    if epoch > cached_epoch:
+        # WRITE path → atomic dedupe-reserve + cache write (3e).
+        return _reserve_and_write_roster_cache(
+            conn, peer=peer_id, message_id=message_id, body_sha256=body_sha256,
+            room_id=room_id, epoch=epoch, members_json=incoming_json,
+            from_node=leader_node, mac=mac)
+    # epoch <= cached_epoch: accept ONLY a byte-identical idempotent duplicate
+    # (same epoch AND same canonical members AND same leader node). Everything
+    # else (a lower epoch, or a same-epoch roster with DIFFERENT contents — a
+    # replay/forge attempt) is ignored without a write.
+    if (epoch == cached_epoch
+            and str(existing["members_json"]) == incoming_json
+            and str(existing["from_node"] or "") == leader_node):
+        # A byte-identical re-broadcast does NOT need a cache write (the cache
+        # already reflects it), but it MUST still BURN the (peer, message_id) in
+        # the dedupe ledger (codex P4.2 r3 BLOCKING): a terminal ROSTER_DUPLICATE
+        # that did not reserve the id would let a LATER (peer, SAME id, DIFFERENT
+        # body, higher epoch) reuse be treated as fresh and ACCEPTED. The
+        # reserve-only path records the id (or re-classifies a same-id/different-
+        # body reuse to ROSTER_DEDUPE_CONFLICT) WITHOUT touching the cache.
+        return _reserve_roster_dedupe_only(
+            conn, peer=peer_id, message_id=message_id, body_sha256=body_sha256)
+    return ROSTER_STALE_EPOCH
+
+
+def _reserve_and_write_roster_cache(
+    conn: sqlite3.Connection, *, peer: str, message_id: str, body_sha256: str,
+    room_id: str, epoch: int, members_json: str, from_node: str, mac: str,
+) -> str:
+    """ATOMICALLY reserve the peer-scoped dedupe row AND write the roster cache.
+
+    The single serialization point that closes the TOCTOU dedupe/cache race
+    (codex P4.2 r3 BLOCKING). Mirrors P4.1's
+    `record_verified_cross_node_join_request_atomic`: a pre-check + an
+    IntegrityError-on-PK fallback re-query, so two concurrent same-id deliveries
+    cannot both pass + both write. Both the `room_join_dedupe` reservation and
+    the `room_roster_cache` write are issued WITHOUT an intermediate commit, then
+    ONE commit makes them durable together; any failure before the commit rolls
+    BOTH back (no orphan dedupe row, no partial cache).
+
+    Returns:
+      - ROSTER_DEDUPE_CONFLICT : (peer, message_id) already used with a DIFFERENT
+        body → write NOTHING.
+      - ROSTER_DUPLICATE       : (peer, message_id) already reserved with the
+        SAME body → idempotent, write NOTHING (the cache already reflects it).
+      - ROSTER_ACCEPTED        : fresh id → dedupe row + cache row committed
+        together.
+    """
+    # Pre-check inside this call (the caller did no read-only dedupe check on the
+    # write path). Scoped to the authenticated peer (composite PK).
+    existing = conn.execute(
+        "SELECT body_sha256 FROM room_join_dedupe WHERE peer=? AND message_id=?",
+        (peer, message_id),
+    ).fetchone()
+    if existing is not None:
+        return (ROSTER_DUPLICATE if existing["body_sha256"] == body_sha256
+                else ROSTER_DEDUPE_CONFLICT)
+    try:
+        conn.execute(
+            "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+            "created_ts) VALUES (?, ?, ?, ?)",
+            (message_id, peer, body_sha256, now_ts()),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO room_roster_cache (room_id, epoch, "
+            "members_json, from_node, mac, fetched_ts) VALUES (?, ?, ?, ?, ?, ?)",
+            (room_id, epoch, members_json, from_node, mac, now_ts()),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError:
+        # Lost a concurrent (peer, message_id) PK race — roll BOTH writes back and
+        # re-query the winner's row, returning the SAME idempotent/conflict
+        # outcome the pre-check would have. The loser thus gets a clean
+        # duplicate/conflict (never a partial cache mutation, never a 500).
+        conn.rollback()
+        winner = conn.execute(
+            "SELECT body_sha256 FROM room_join_dedupe "
+            "WHERE peer=? AND message_id=?",
+            (peer, message_id),
+        ).fetchone()
+        if winner is not None:
+            return (ROSTER_DUPLICATE if winner["body_sha256"] == body_sha256
+                    else ROSTER_DEDUPE_CONFLICT)
+        # PK violation from somewhere other than a concurrent winner (should not
+        # happen) — surface it rather than silently swallow.
+        raise
+    except Exception:
+        # Roll BOTH writes back so a failed cache insert never leaves an orphan
+        # dedupe reservation (the atomicity contract).
+        conn.rollback()
+        raise
+    return ROSTER_ACCEPTED
+
+
+def _reserve_roster_dedupe_only(
+    conn: sqlite3.Connection, *, peer: str, message_id: str, body_sha256: str,
+) -> str:
+    """BURN a (peer, message_id) in the dedupe ledger WITHOUT writing the cache.
+
+    The reserve-only sibling of `_reserve_and_write_roster_cache` (codex P4.2 r3
+    BLOCKING — close the duplicate-branch id-reuse hole). Used by the byte-
+    identical-existing-cache ROSTER_DUPLICATE branch: the cache already reflects
+    the roster (no write needed), but the id MUST still be recorded so a LATER
+    same-(peer, message_id)/DIFFERENT-body reuse is a CONFLICT rather than a
+    fresh accept. Returns:
+      - ROSTER_DEDUPE_CONFLICT : (peer, message_id) already used with a DIFFERENT
+        body → caller answers 409.
+      - ROSTER_DUPLICATE       : a fresh reservation OR a same-body re-reservation
+        (idempotent) → the id is now burned, no cache change.
+    Uses the same IntegrityError-rollback-and-requery guard as the write helper
+    so a concurrent same-id duplicate cannot double-insert (the PK serializes).
+    """
+    existing = conn.execute(
+        "SELECT body_sha256 FROM room_join_dedupe WHERE peer=? AND message_id=?",
+        (peer, message_id),
+    ).fetchone()
+    if existing is not None:
+        return (ROSTER_DUPLICATE if existing["body_sha256"] == body_sha256
+                else ROSTER_DEDUPE_CONFLICT)
+    try:
+        conn.execute(
+            "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+            "created_ts) VALUES (?, ?, ?, ?)",
+            (message_id, peer, body_sha256, now_ts()),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError:
+        # Lost a concurrent (peer, message_id) PK race — roll back + re-query the
+        # winner, returning the SAME idempotent/conflict outcome the pre-check
+        # would have (never a raise, never a cache mutation — there is none here).
+        conn.rollback()
+        winner = conn.execute(
+            "SELECT body_sha256 FROM room_join_dedupe "
+            "WHERE peer=? AND message_id=?",
+            (peer, message_id),
+        ).fetchone()
+        if winner is not None:
+            return (ROSTER_DUPLICATE if winner["body_sha256"] == body_sha256
+                    else ROSTER_DEDUPE_CONFLICT)
+        raise
+    return ROSTER_DUPLICATE
+
+
+def _canonical_member_list(members: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Re-sort + normalize a roster member list to the canonical (agent,node)
+    ordering, so the stored cache bytes are reproducible regardless of the
+    wire order (defensive — the leader already sorts, but a verifier must not
+    depend on the sender's ordering for its stored canonical form)."""
+    norm = [
+        {
+            "agent": str(m.get("agent", "")),
+            "node": str(m.get("node", "")),
+            "role": str(m.get("role", "")),
+        }
+        for m in members
+    ]
+    norm.sort(key=lambda m: (m["agent"], m["node"]))
+    return norm
 
 
 # --------------------------------------------------------------------------

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -211,6 +211,20 @@ add_required a2a-rooms-1517-bootstrap
 # expired/revoked refused, no token/hash persisted anywhere, malformed/dup
 # handled) + the unweakened auth preamble + the non-leader-node refusal.
 add_required rooms-p4-1-cross-node-join
+# A2A rooms P4.2 (design §6 / §11 / §14 R2): leader APPROVE + roster broadcast.
+# On a cross-node approve the leader admits the member (REQUIRING a P4.1 verified
+# pending row), bumps the epoch, and broadcasts the leader-signed canonical
+# roster to every member node over the node-link; each member persists it to
+# room_roster_cache. Lives in bridge-handoffd.py (_handle_room_roster_broadcast),
+# bridge_a2a_common.py (build/parse_room_roster_broadcast), bridge_rooms_common.py
+# (approve_cross_node gate + accept_roster_broadcast member-side contracts +
+# reserve_roster_dedupe), and bridge-rooms.py (cross-approve gate + broadcast
+# sender + local-join-intent binding). Pins the 7 teeth: cross-approve requires a
+# verified pending row, a non-leader peer roster is rejected, an invalid pairwise
+# HMAC is rejected, a first roster with no local binding is refused (rogue-leader
+# mint prevented), epoch monotonicity, the cache update is atomic, and the
+# local-leader-add path stays distinct (no P4.1 regression).
+add_required rooms-p4-2-roster-broadcast
 
 
 }
@@ -876,7 +890,7 @@ select_for_path() {
       add_required queue a2a-rooms-p1b-acl
       ;;
 
-    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/install-handoffd-systemd.sh)
+    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/smoke/rooms-p4-2-roster-broadcast-helper.py|scripts/smoke/rooms-p4-2-post-hook.sh|scripts/install-handoffd-systemd.sh)
       # Issue #1032: A2A cross-bridge task handoff. Any move to the
       # receiver daemon, sender outbox/delivery-runner, shared protocol
       # module, lifecycle helper, or the smoke helper re-runs the
@@ -965,7 +979,17 @@ select_for_path() {
       # malformed/duplicate requests are handled — PLUS the auth preamble stays
       # unweakened (HMAC 401 / remote_addr 403 / unknown-peer 403). Pull on every
       # move to any of those files so the cross-node admission gate cannot regress.
-      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force rooms-p4-1-cross-node-join
+      # A2A Rooms P4.2 (design §6 / §14 R2): leader APPROVE + roster broadcast.
+      # The NEW remote surface is _handle_room_roster_broadcast in
+      # bridge-handoffd.py; the wire builder/parser is build/parse_room_roster_
+      # broadcast in bridge_a2a_common.py; the cross-approve gate + member-side
+      # acceptance (anti-rogue-leader binding + monotonic epoch + atomic cache) is
+      # in bridge_rooms_common.py; the broadcast sender + local-join-intent
+      # binding is in bridge-rooms.py. rooms-p4-2-roster-broadcast pins the 7
+      # teeth (cross-approve needs a verified row, non-leader roster rejected,
+      # bad pairwise HMAC rejected, first-roster-without-binding refused, epoch
+      # monotonicity, atomic cache, local-add path distinct). Pull on every move.
+      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force rooms-p4-1-cross-node-join rooms-p4-2-roster-broadcast
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -225,6 +225,21 @@ add_required rooms-p4-1-cross-node-join
 # mint prevented), epoch monotonicity, the cache update is atomic, and the
 # local-leader-add path stays distinct (no P4.1 regression).
 add_required rooms-p4-2-roster-broadcast
+# A2A rooms P4.3 (design §11): room-scoped TALK (cross-node member messaging).
+# Once a member node holds a leader-MAC'd roster in room_roster_cache (from P4.2),
+# members on DIFFERENT nodes exchange room-scoped messages WITHOUT the leader
+# online — each member validates membership against its OWN local cache + the
+# envelope's room_epoch, fail-closed. Lives in bridge-handoffd.py
+# (room_scoped_check — the P4.3 leader-MAC roster-cache gate on the enqueue path),
+# bridge_rooms_common.py (roster_cache_membership_check), and bridge-rooms.py
+# (`room talk` — OS-actor-anchored sender + cached-epoch stamp + room-scoped
+# enqueue over the node-link). Pins the 9 teeth: a member message is delivered, a
+# non-member sender is rejected, a mismatched epoch (stale AND ahead) is rejected
+# fail-closed, an unknown room (no cache) is rejected, a missing room_id/epoch is
+# 422, a plain non-room message is NOT room talk (delivered, no gate, no
+# membership), a hostile --from/env cannot impersonate, a replay is deduped /
+# same-id-diff-body is 409, and the auth preamble is unreachable pre-auth.
+add_required rooms-p4-3-room-talk
 
 
 }
@@ -890,7 +905,7 @@ select_for_path() {
       add_required queue a2a-rooms-p1b-acl
       ;;
 
-    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/smoke/rooms-p4-2-roster-broadcast-helper.py|scripts/smoke/rooms-p4-2-post-hook.sh|scripts/install-handoffd-systemd.sh)
+    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/smoke/rooms-p4-2-roster-broadcast-helper.py|scripts/smoke/rooms-p4-2-post-hook.sh|scripts/smoke/rooms-p4-3-room-talk-helper.py|scripts/smoke/rooms-p4-3-post-hook.sh|scripts/install-handoffd-systemd.sh)
       # Issue #1032: A2A cross-bridge task handoff. Any move to the
       # receiver daemon, sender outbox/delivery-runner, shared protocol
       # module, lifecycle helper, or the smoke helper re-runs the
@@ -989,7 +1004,18 @@ select_for_path() {
       # teeth (cross-approve needs a verified row, non-leader roster rejected,
       # bad pairwise HMAC rejected, first-roster-without-binding refused, epoch
       # monotonicity, atomic cache, local-add path distinct). Pull on every move.
-      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force rooms-p4-1-cross-node-join rooms-p4-2-roster-broadcast
+      # A2A Rooms P4.3 (design §11): room-scoped TALK. The membership gate is the
+      # P4.3 activation of room_scoped_check in bridge-handoffd.py (it now reads
+      # the member-local leader-MAC room_roster_cache + the envelope room_epoch,
+      # fail-closed, instead of a live is_member read); the cache-membership
+      # decision is roster_cache_membership_check in bridge_rooms_common.py; the
+      # `room talk` sender (OS-actor-anchored + cached-epoch stamp + room-scoped
+      # enqueue) is in bridge-rooms.py. rooms-p4-3-room-talk pins the 9 teeth
+      # (member delivered, non-member rejected, epoch mismatch stale/ahead
+      # rejected, unknown room rejected, missing room_id/epoch 422, plain message
+      # not room talk, hostile --from cannot impersonate, replay dedupe /
+      # same-id-diff-body 409, auth preamble unreachable pre-auth). Pull on move.
+      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force rooms-p4-1-cross-node-join rooms-p4-2-roster-broadcast rooms-p4-3-room-talk
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -198,6 +198,19 @@ add_required a2a-rooms-p1b-acl
 # controller), the env-redirect teeth (BRIDGE_A2A_ROOMS_DB does NOT relocate
 # the bootstrap), and idempotency (a 2nd create does not re-bootstrap/clobber).
 add_required a2a-rooms-1517-bootstrap
+# A2A rooms P4.1 (design §11 / §14 R3): the cross-node JOIN. Member on node B
+# posts a signed room-join-request to the leader's node A over the node-link;
+# node A re-runs the full fail-closed auth preamble (remote_addr -> HMAC -> skew
+# -> dedupe), verifies the invite token (HASH compare + TTL + revocation), and
+# persists a VERIFIED PENDING row (no auto-admit — approve is P4.2). In the full
+# static suite. Lives in bridge-handoffd.py (_handle_room_join_request),
+# bridge_a2a_common.py (build/parse_room_join_request), bridge_rooms_common.py
+# (verify_invite_token_outcome TTL/revocation + record_verified_cross_node_join_
+# request), and bridge-rooms.py (OS-actor-anchored joiner + cross-node send).
+# Pins the 5 teeth (hostile --from/env inert, no-cross-agent-impersonation,
+# expired/revoked refused, no token/hash persisted anywhere, malformed/dup
+# handled) + the unweakened auth preamble + the non-leader-node refusal.
+add_required rooms-p4-1-cross-node-join
 
 
 }
@@ -863,7 +876,7 @@ select_for_path() {
       add_required queue a2a-rooms-p1b-acl
       ;;
 
-    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/install-handoffd-systemd.sh)
+    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/install-handoffd-systemd.sh)
       # Issue #1032: A2A cross-bridge task handoff. Any move to the
       # receiver daemon, sender outbox/delivery-runner, shared protocol
       # module, lifecycle helper, or the smoke helper re-runs the
@@ -938,7 +951,21 @@ select_for_path() {
       # auth/dedupe gates upstream of the enqueue stay enforced. Pull on every
       # bridge-handoffd.py move so the force flag cannot regress to a 422 drop
       # or, worse, to a guard bypass that also weakens auth/dedupe.
-      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force
+      # A2A Rooms P4.1 (design §11 / §14 R3): the cross-node JOIN. A member on
+      # node B posts a signed room-join-request to the leader's node A; node A
+      # verifies (node-link HMAC + token-HASH + TTL + revocation) and persists a
+      # PENDING row (no auto-admit). The NEW remote surface is
+      # _handle_room_join_request in bridge-handoffd.py; the wire builder/parser
+      # is in bridge_a2a_common.py; the TTL/revocation verify + verified-pending
+      # persistence is in bridge_rooms_common.py; the OS-actor-anchored joiner +
+      # cross-node send is in bridge-rooms.py. rooms-p4-1-cross-node-join pins the
+      # 5 teeth: hostile --from/env cannot change the joiner, a node-B process
+      # cannot join as another B agent, expired/revoked tokens are refused, the
+      # raw token AND its hash never persist in any queue/audit/staged file, and
+      # malformed/duplicate requests are handled — PLUS the auth preamble stays
+      # unweakened (HMAC 401 / remote_addr 403 / unknown-peer 403). Pull on every
+      # move to any of those files so the cross-node admission gate cannot regress.
+      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force rooms-p4-1-cross-node-join
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -240,6 +240,18 @@ add_required rooms-p4-2-roster-broadcast
 # membership), a hostile --from/env cannot impersonate, a replay is deduped /
 # same-id-diff-body is 409, and the auth preamble is unreachable pre-auth.
 add_required rooms-p4-3-room-talk
+# A2A rooms P4.5 (design §11): two polish follow-ups from the P4.4 VM acceptance.
+# FIX 1 (UX completeness): a NON-leader node that joined a room now sees it via
+# `room show`/`room list` — cmd_show/cmd_list (bridge-rooms.py) fall back to the
+# member-side room_roster_cache (list_roster_cache / cached_roster_members /
+# cached_leader in bridge_rooms_common.py) instead of "not found". FIX 2 (info-
+# hygiene): enqueue_via_bridge_task (bridge-handoffd.py) returns a TERSE peer-
+# facing 422 detail ("unknown target '<agent>'") instead of echoing the
+# `bridge-task.sh` roster dump (agb-list engine/workdir/source columns) — the
+# full reason stays in the LOCAL audit only. Pins both teeth sets: member-side
+# show/list surfaces the cache, leader rooms unchanged, no-room/no-cache still
+# 404; unknown target -> 422 with no roster leak + full local audit recorded.
+add_required rooms-p4-5-polish
 
 
 }
@@ -905,7 +917,7 @@ select_for_path() {
       add_required queue a2a-rooms-p1b-acl
       ;;
 
-    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/smoke/rooms-p4-2-roster-broadcast-helper.py|scripts/smoke/rooms-p4-2-post-hook.sh|scripts/smoke/rooms-p4-3-room-talk-helper.py|scripts/smoke/rooms-p4-3-post-hook.sh|scripts/install-handoffd-systemd.sh)
+    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/smoke/rooms-p4-2-roster-broadcast-helper.py|scripts/smoke/rooms-p4-2-post-hook.sh|scripts/smoke/rooms-p4-3-room-talk-helper.py|scripts/smoke/rooms-p4-3-post-hook.sh|scripts/smoke/rooms-p4-5-polish.sh|scripts/smoke/rooms-p4-5-helper.py|scripts/install-handoffd-systemd.sh)
       # Issue #1032: A2A cross-bridge task handoff. Any move to the
       # receiver daemon, sender outbox/delivery-runner, shared protocol
       # module, lifecycle helper, or the smoke helper re-runs the
@@ -1015,7 +1027,17 @@ select_for_path() {
       # rejected, unknown room rejected, missing room_id/epoch 422, plain message
       # not room talk, hostile --from cannot impersonate, replay dedupe /
       # same-id-diff-body 409, auth preamble unreachable pre-auth). Pull on move.
-      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force rooms-p4-1-cross-node-join rooms-p4-2-roster-broadcast rooms-p4-3-room-talk
+      # A2A Rooms P4.5 (design §11): two follow-ups from the P4.4 VM acceptance.
+      # FIX 1 (UX): `cmd_show`/`cmd_list` in bridge-rooms.py now fall back to the
+      # member-side room_roster_cache (via list_roster_cache / cached_roster_
+      # members / cached_leader in bridge_rooms_common.py) so a NON-leader node
+      # sees a room it joined instead of "not found". FIX 2 (info-hygiene):
+      # enqueue_via_bridge_task in bridge-handoffd.py returns a TERSE peer-facing
+      # detail (no `agb list` roster dump) while the full reason stays in the
+      # local audit only. rooms-p4-5-polish pins both: member show/list surfaces
+      # the cache, leader rooms unchanged, unknown-room still 404; an unknown
+      # target -> terse 422 with no engine/workdir/source leak + full local audit.
+      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force rooms-p4-1-cross-node-join rooms-p4-2-roster-broadcast rooms-p4-3-room-talk rooms-p4-5-polish
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)

--- a/scripts/smoke/a2a-cross-bridge-helper.py
+++ b/scripts/smoke/a2a-cross-bridge-helper.py
@@ -148,6 +148,17 @@ def main(argv: list[str]) -> int:
         env = envelope("bridge-a:allowlist-1", "not-allowed", "blocked", "x")
         status, text = post(url=url, path=path, peer_id=peer_id, secret=secret,
                              envelope=env)
+    elif scenario == "unknown-target":
+        # P4.5 info-hygiene: a target that PASSES the inbound allowlist but is
+        # NOT in the local roster. The allowlist preamble admits it, then
+        # `bridge-task.sh create` fails with the full `agb list` roster dump on
+        # stderr. The receiver MUST return a TERSE 422 detail, never that dump.
+        # The target name is taken from argv[4] so the smoke can assert on it.
+        unknown = argv[4] if len(argv) > 4 else "ghost-agent"
+        env = envelope("bridge-a:unknown-target-1", unknown,
+                       "to an unknown target", "the body")
+        status, text = post(url=url, path=path, peer_id=peer_id, secret=secret,
+                             envelope=env)
     elif scenario == "ok":
         env = envelope("bridge-a:ok-1", "reviewer", "a2a smoke ok", "the body")
         status, text = post(url=url, path=path, peer_id=peer_id, secret=secret,

--- a/scripts/smoke/a2a-rooms-p1a-helper.py
+++ b/scripts/smoke/a2a-rooms-p1a-helper.py
@@ -169,6 +169,10 @@ def cmd_receiver_seam(repo_root: str) -> int:
     assert spec and spec.loader
     spec.loader.exec_module(hd)
 
+    # `bridge_id` is THIS receiver's node id — the membership gate pins the
+    # target to (target_agent, this_node). The cross-node sender (alice) is on
+    # nodeB so the room spans two nodes (the P4.3 cross-node case); bob is the
+    # local member on nodeA whom the message is delivered to.
     cfg = {"bridge_id": "nodeA"}
 
     # 1) non-room message -> pass (no-op).
@@ -183,7 +187,7 @@ def cmd_receiver_seam(repo_root: str) -> int:
 
     # 2) room-scoped but NO rooms.db -> fail closed.
     e2 = a2a.build_envelope(
-        message_id="m", sender_bridge="nodeA", sender_agent="alice",
+        message_id="m", sender_bridge="nodeB", sender_agent="alice",
         target_agent="bob", priority="normal", title="t", body="b",
         room_id="room-x", room_epoch=1,
     )
@@ -193,31 +197,68 @@ def cmd_receiver_seam(repo_root: str) -> int:
               file=sys.stderr)
         return 1
 
-    # Build a room with alice@nodeA (leader) + bob@nodeA member.
+    # A2A Rooms P4.3 (design §11): the seam now reads the member-local leader-MAC
+    # ROSTER CACHE + the envelope room_epoch (NOT a live is_member read). Seed a
+    # cache for `rid` at epoch 5 with the cross-node sender alice@nodeB (the
+    # leader's node) + the local member bob@nodeA — exactly what a P4.2 broadcast
+    # would have written on this member node.
     conn = rooms.open_rooms()
-    tok = rooms.mint_invite_token()
-    rid = rooms.create_room(
-        conn, name="t", leader_agent="alice", leader_node="nodeA", token=tok,
+    members = [
+        {"agent": "alice", "node": "nodeB", "role": "leader"},
+        {"agent": "bob", "node": "nodeA", "role": "member"},
+    ]
+    members_json = json.dumps(
+        sorted(members, key=lambda m: (m["agent"], m["node"])),
+        separators=(",", ":"))
+    rid = "room-p43-seam"
+    conn.execute(
+        "INSERT OR REPLACE INTO room_roster_cache (room_id, epoch, members_json, "
+        "from_node, mac, fetched_ts) VALUES (?, ?, ?, ?, ?, ?)",
+        (rid, 5, members_json, "nodeB", "leader-mac", rooms.now_ts()),
     )
-    rooms.add_member(conn, rid, "bob", "nodeA")
+    conn.commit()
     conn.close()
 
-    # 3) both members -> pass.
+    # 3) both members + matching epoch -> pass (cache-gated).
     e3 = a2a.build_envelope(
-        message_id="m", sender_bridge="nodeA", sender_agent="alice",
+        message_id="m", sender_bridge="nodeB", sender_agent="alice",
         target_agent="bob", priority="normal", title="t", body="b",
-        room_id=rid, room_epoch=1,
+        room_id=rid, room_epoch=5,
     )
     ok, reason = hd.room_scoped_check(e3, cfg)
     if not ok or reason != "members_ok":
         print(f"both-members must pass, got {(ok, reason)}", file=sys.stderr)
         return 1
 
+    # 3b) matching members but MISMATCHED epoch -> fail closed (P4.3 contract 3).
+    e3b = a2a.build_envelope(
+        message_id="m", sender_bridge="nodeB", sender_agent="alice",
+        target_agent="bob", priority="normal", title="t", body="b",
+        room_id=rid, room_epoch=4,
+    )
+    ok, reason = hd.room_scoped_check(e3b, cfg)
+    if ok or reason != "epoch_mismatch":
+        print(f"epoch-mismatch must fail closed, got {(ok, reason)}",
+              file=sys.stderr)
+        return 1
+
+    # 3c) a NON-member sender -> fail closed (P4.3 contract 2/4).
+    e3c = a2a.build_envelope(
+        message_id="m", sender_bridge="nodeB", sender_agent="mallory",
+        target_agent="bob", priority="normal", title="t", body="b",
+        room_id=rid, room_epoch=5,
+    )
+    ok, reason = hd.room_scoped_check(e3c, cfg)
+    if ok or reason != "sender_not_member":
+        print(f"non-member sender must fail closed, got {(ok, reason)}",
+              file=sys.stderr)
+        return 1
+
     # 4) target not a member -> fail closed.
     e4 = a2a.build_envelope(
-        message_id="m", sender_bridge="nodeA", sender_agent="alice",
+        message_id="m", sender_bridge="nodeB", sender_agent="alice",
         target_agent="carol", priority="normal", title="t", body="b",
-        room_id=rid, room_epoch=1,
+        room_id=rid, room_epoch=5,
     )
     ok, reason = hd.room_scoped_check(e4, cfg)
     if ok or reason != "target_not_member":
@@ -225,14 +266,14 @@ def cmd_receiver_seam(repo_root: str) -> int:
               file=sys.stderr)
         return 1
 
-    # 5) unknown room -> fail closed.
+    # 5) unknown room (no cache row) -> fail closed.
     e5 = a2a.build_envelope(
-        message_id="m", sender_bridge="nodeA", sender_agent="alice",
+        message_id="m", sender_bridge="nodeB", sender_agent="alice",
         target_agent="bob", priority="normal", title="t", body="b",
-        room_id="room-nope", room_epoch=1,
+        room_id="room-nope", room_epoch=5,
     )
     ok, reason = hd.room_scoped_check(e5, cfg)
-    if ok or reason != "room_unknown":
+    if ok or reason != "no_roster_cache":
         print(f"unknown-room must fail closed, got {(ok, reason)}",
               file=sys.stderr)
         return 1

--- a/scripts/smoke/a2a-rooms-p1a.sh
+++ b/scripts/smoke/a2a-rooms-p1a.sh
@@ -14,7 +14,8 @@
 #   - envelope contract: build/parse round-trip with room_id+room_epoch AND
 #     v1 (no room fields) back-compat
 #   - receiver seam: room_scoped_check fail-closed contract (non-room pass;
-#     room-scoped member ok; non-member / unknown-room / no-db deny)
+#     room-scoped member ok against the P4.3 leader-MAC roster cache + matching
+#     epoch; non-member / wrong-epoch / unknown-room / no-db deny)
 #   - rooms.db hygiene: mode 0600; absent-db reads degrade gracefully
 
 set -euo pipefail

--- a/scripts/smoke/rooms-p4-1-cross-node-join-helper.py
+++ b/scripts/smoke/rooms-p4-1-cross-node-join-helper.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Helper for the rooms-p4-1-cross-node-join smoke (A2A Rooms P4.1).
+
+File-as-argv sidecar (never a heredoc-stdin — footgun #11). Imports the REAL
+rooms / a2a / handoffd modules from the repo root so the smoke exercises the
+canonical sender (signing + OS-actor joiner id), the canonical receiver
+(`_handle_room_join_request` fail-closed stack + token verify + pending-row
+persist), and the canonical schema — WITHOUT a live socket or Tailscale.
+
+The transport is stubbed two ways:
+  - SENDER side: the cross-node `bridge-rooms.py join` POST is captured by the
+    paired-flag test hook (BRIDGE_ROOMS_TEST_POST_HOOK = this script's
+    `post-hook` subcommand), which writes the fully-signed request to a file.
+  - RECEIVER side: `deliver-to-receiver` reconstructs a minimal fake HTTP
+    request from that captured file and drives the REAL handler method, so the
+    actual auth preamble (protocol/peer/remote_addr/HMAC/skew/dedupe) + token
+    verify + persistence run end to end. The peer uses a literal `address`
+    (no node_id/tailscale_name) so resolve_peer_address returns it verbatim —
+    no Tailscale.
+
+Subcommands (argv[1]):
+  post-hook <json>                 (used as BRIDGE_ROOMS_TEST_POST_HOOK) — write
+                                   the signed request JSON to $CAPTURE_FILE and
+                                   echo a stub "{}" response.
+  captured-field <file> <key>      print headers[X-AGB-*] or body.<key> from a
+                                   captured request file.
+  deliver-to-receiver <repo_root> <cfg_json> <captured_file> [overrides_json]
+                                   replay the captured request through the real
+                                   receiver handler; print "status=<n> body=<json>".
+  make-config <out_path> <this_node> <peer_node> <peer_secret> <address>
+                                   write a minimal handoff config (loopback test
+                                   bind) the receiver loads.
+  pending-rows <db> <room_id>      print each pending join row as JSON lines.
+  dedupe-rows <db>                 print each room_join_dedupe row as JSON lines.
+  db-contains <db> <needle>        exit 0 iff <needle> appears in the db dump.
+  file-tree-contains <dir> <needle> exit 0 iff <needle> appears under <dir>.
+  drop-dedupe-table <db>           DROP room_join_dedupe (simulate unmigrated P1 db).
+  set-token-ts <db> <room_id> <ts> backdate invite_token_ts (drive TTL expiry).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import bridge_a2a_common as a2a  # noqa: E402
+import bridge_rooms_common as rooms  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# sender-side capture hook (invoked as BRIDGE_ROOMS_TEST_POST_HOOK)
+# ---------------------------------------------------------------------------
+def cmd_post_hook(payload_json: str) -> int:
+    """Write the signed cross-node request to $CAPTURE_FILE; stub a 200 body.
+
+    The CLI sender calls us with the JSON {path, headers, body}. We persist it
+    verbatim (so the smoke can assert on the OS-actor joiner id + hash-only
+    body, and replay it into the receiver). stdout is the stubbed response body.
+    """
+    capture = os.environ.get("CAPTURE_FILE")  # noqa: iso-helper-boundary - env var, not a .env file
+    if not capture:
+        print("CAPTURE_FILE unset", file=sys.stderr)
+        return 1
+    Path(capture).write_text(payload_json, encoding="utf-8")
+    print("{}")  # stub response body
+    return 0
+
+
+def cmd_captured_field(path: str, key: str) -> int:
+    doc = json.loads(Path(path).read_text(encoding="utf-8"))
+    if key.startswith("header:"):
+        val = doc.get("headers", {}).get(key[len("header:"):], "")
+    elif key.startswith("body:"):
+        body = json.loads(doc.get("body", "{}"))
+        val = body.get(key[len("body:"):], "")
+    elif key == "path":
+        val = doc.get("path", "")
+    else:
+        print(f"unknown captured key: {key}", file=sys.stderr)
+        return 1
+    print(val)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# receiver-side replay against the REAL handler
+# ---------------------------------------------------------------------------
+def _load_handoffd(repo_root: str):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "bridge_handoffd", os.path.join(repo_root, "bridge-handoffd.py"))
+    hd = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(hd)
+    return hd
+
+
+class _FakeHeaders:
+    def __init__(self, headers: dict):
+        self._h = headers
+
+    def get(self, key, default=None):
+        return self._h.get(key, default)
+
+
+class _FakeRFile:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0 or n >= len(self._data):
+            out, self._data = self._data, b""
+            return out
+        out, self._data = self._data[:n], self._data[n:]
+        return out
+
+
+class _FakeServer:
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self.config_path = ""
+
+
+def cmd_deliver_to_receiver(repo_root: str, cfg_json: str, captured: str,
+                            overrides_json: str = "{}") -> int:
+    """Replay a captured signed request through the REAL receiver handler.
+
+    `overrides_json` lets a tooth mutate the captured request to drive an edge:
+      {"client_ip": "...", "headers": {...override...},
+       "body": "<replacement json string>", "recompute_hash": true}
+    When `recompute_hash` is true the X-AGB-Body-SHA256 header is recomputed for
+    the (possibly mutated) body — used to simulate a 'same id, different body'
+    duplicate-conflict WITHOUT also tripping the body-hash gate.
+    """
+    hd = _load_handoffd(repo_root)
+    cfg = json.loads(cfg_json)
+    doc = json.loads(Path(captured).read_text(encoding="utf-8"))
+    overrides = json.loads(overrides_json) if overrides_json else {}
+
+    path = doc.get("path", a2a.ROOM_JOIN_PATH)
+    headers = dict(doc.get("headers", {}))
+    body = doc.get("body", "{}")
+
+    if "headers" in overrides:
+        headers.update(overrides["headers"])
+    if "body" in overrides:
+        body = overrides["body"]
+    body_bytes = body.encode("utf-8") if isinstance(body, str) else bytes(body)
+    if overrides.get("recompute_hash"):
+        headers["X-AGB-Body-SHA256"] = a2a.body_sha256(body_bytes)
+    # `resign`: recompute BOTH the body hash AND a VALID HMAC signature for the
+    # (mutated) body using the peer's configured secret. Used to test a code
+    # path DOWNSTREAM of the HMAC gate (e.g. the body PARSER) with a legitimately
+    # signed but malformed body — so the test exercises the parser, not the
+    # signature gate. It mirrors exactly what an authenticated node B could send.
+    if overrides.get("resign"):
+        peer_secret = ""
+        for p in cfg.get("peers", []):
+            if p.get("id") == headers.get("X-AGB-Peer", ""):
+                peer_secret = p.get("secret", "")
+                break
+        body_hash = a2a.body_sha256(body_bytes)
+        headers["X-AGB-Body-SHA256"] = body_hash
+        canonical = a2a.canonical_string(
+            "POST", path, headers.get("X-AGB-Peer", ""),
+            headers.get("X-AGB-Message-Id", ""),
+            headers.get("X-AGB-Timestamp", ""), body_hash)
+        headers["X-AGB-Signature"] = a2a.sign(peer_secret, canonical)
+    headers["Content-Length"] = str(len(body_bytes))
+
+    # The authenticated peer address: the receiver resolves the peer's literal
+    # `address`; the client_ip must match. Default to the peer's configured
+    # address so the remote_addr gate passes; a tooth can override.
+    peer_id = headers.get("X-AGB-Peer", "")
+    peer_addr = ""
+    for p in cfg.get("peers", []):
+        if p.get("id") == peer_id:
+            peer_addr = p.get("address", "")
+            break
+    client_ip = overrides.get("client_ip", peer_addr or "127.0.0.1")
+
+    handler = hd.HandoffHandler.__new__(hd.HandoffHandler)
+    handler.path = path
+    handler.headers = _FakeHeaders(headers)
+    handler.rfile = _FakeRFile(body_bytes)
+    handler.client_address = (client_ip, 0)
+    handler.server = _FakeServer(cfg)
+
+    captured_reply = {}
+
+    def _capture_reply(status, payload, extra_headers=None):
+        captured_reply["status"] = status
+        captured_reply["payload"] = payload
+
+    handler._reply = _capture_reply  # type: ignore[assignment]
+    handler._handle_room_join_request(cfg)
+
+    status = captured_reply.get("status", 0)
+    payload = captured_reply.get("payload", {})
+    print(f"status={status} body={json.dumps(payload)}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# config + db inspection
+# ---------------------------------------------------------------------------
+def cmd_make_config(out_path: str, this_node: str, peer_node: str,
+                    peer_secret: str, address: str) -> int:
+    cfg = {
+        "bridge_id": this_node,
+        "listen": {"host": "127.0.0.1", "port": 8787,
+                   "enqueue_path": "/enqueue"},
+        "timestamp_skew_seconds": 300,
+        "timestamp_skew_grace_seconds": 3600,
+        "peers": [
+            {
+                "id": peer_node,
+                "address": address,
+                "secret": peer_secret,
+                "inbound_allowlist": [],
+            }
+        ],
+    }
+    Path(out_path).write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    try:
+        os.chmod(out_path, 0o600)
+    except OSError:
+        pass
+    return 0
+
+
+def cmd_pending_rows(db: str, room_id: str) -> int:
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT room_id, agent, node, status, verified, via_node, "
+            "ttl_expiry FROM room_join_requests WHERE room_id=? "
+            "ORDER BY agent, node", (room_id,)
+        ).fetchall()
+    finally:
+        conn.close()
+    for r in rows:
+        print(json.dumps({k: r[k] for k in r.keys()}))
+    return 0
+
+
+def cmd_dedupe_rows(db: str) -> int:
+    """Print each room_join_dedupe row as a JSON line (P4.1 r2 ledger)."""
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT message_id, peer, body_sha256, created_ts "
+            "FROM room_join_dedupe ORDER BY created_ts"
+        ).fetchall()
+    finally:
+        conn.close()
+    for r in rows:
+        print(json.dumps({k: r[k] for k in r.keys()}))
+    return 0
+
+
+def cmd_db_contains(db: str, needle: str) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        dump = "\n".join(conn.iterdump())
+    finally:
+        conn.close()
+    return 0 if needle and needle in dump else 1
+
+
+def cmd_file_tree_contains(directory: str, needle: str) -> int:
+    base = Path(directory)
+    if not base.exists():
+        return 1
+    for p in base.rglob("*"):
+        if p.is_file():
+            try:
+                text = p.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if needle and needle in text:
+                print(f"FOUND in {p}", file=sys.stderr)
+                return 0
+    return 1
+
+
+def cmd_atomic_race_reclassify(db: str) -> int:
+    """Unit-drive record_verified_cross_node_join_request_atomic's race branch
+    (codex r3 #1). Proves a message_id PK collision is RECLASSIFIED to
+    duplicate/conflict (never an unhandled raise / 500).
+
+    We bypass the in-call pre-check by INSERTing the dedupe row through a SECOND
+    connection AFTER the function under test would have pre-checked — emulated
+    here by seeding the row first, then calling the function (its own pre-check
+    catches the seeded row → duplicate). To exercise the IntegrityError catch
+    branch specifically, we monkeypatch the pre-check SELECT to miss once, so the
+    INSERT collides and the except-branch re-queries. Output: a line per case.
+    """
+    import bridge_rooms_common as r
+
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(r._ROOMS_SCHEMA)
+    conn.commit()
+    mid = "nodeB:race-1"
+    body = "a" * 64
+    # Seed a winner row (same body) directly.
+    conn.execute(
+        "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+        "created_ts) VALUES (?, ?, ?, ?)", (mid, "nodeB", body, 1))
+    conn.commit()
+    # Pre-check path: the function sees the seeded row → DUPLICATE (same body).
+    out1 = r.record_verified_cross_node_join_request_atomic(
+        conn, message_id=mid, body_sha256=body, peer="nodeB",
+        room_id="room-x", agent="z", node="nodeB", via_node="nodeB")
+    print(f"precheck_same_body={out1}")
+    # Pre-check path with a DIFFERENT body → CONFLICT.
+    out2 = r.record_verified_cross_node_join_request_atomic(
+        conn, message_id=mid, body_sha256="b" * 64, peer="nodeB",
+        room_id="room-x", agent="z", node="nodeB", via_node="nodeB")
+    print(f"precheck_diff_body={out2}")
+
+    # IntegrityError branch: a thin proxy makes the FIRST pre-check SELECT for a
+    # NEW id miss (simulating the concurrent winner's row not yet visible to this
+    # reader), so the function proceeds to INSERT and collides on the PK, which
+    # it must catch + re-query + reclassify (NOT raise). `sqlite3.Connection`
+    # methods are read-only, so we wrap rather than monkeypatch.
+    mid2 = "nodeB:race-2"
+    conn.execute(
+        "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+        "created_ts) VALUES (?, ?, ?, ?)", (mid2, "nodeB", body, 1))
+    conn.commit()
+
+    class _Empty:
+        def fetchone(self):
+            return None
+
+    class _RaceProxy:
+        """Delegates to the real connection but forces the FIRST dedupe pre-check
+        SELECT to return empty, so the function's INSERT hits the live PK row."""
+
+        def __init__(self, real):
+            self._real = real
+            self._first_select = True
+
+        def execute(self, sql, params=()):
+            if (self._first_select
+                    and sql.strip().startswith(
+                        "SELECT body_sha256 FROM room_join_dedupe")):
+                self._first_select = False
+                return _Empty()
+            return self._real.execute(sql, params)
+
+        def commit(self):
+            return self._real.commit()
+
+        def rollback(self):
+            return self._real.rollback()
+
+    out3 = r.record_verified_cross_node_join_request_atomic(
+        _RaceProxy(conn), message_id=mid2, body_sha256=body, peer="nodeB",
+        room_id="room-x", agent="z", node="nodeB", via_node="nodeB")
+    print(f"integrityerror_reclassified={out3}")
+    conn.close()
+    return 0
+
+
+def cmd_cross_peer_dedupe(db: str) -> int:
+    """Prove the dedupe ledger is scoped to the AUTHENTICATED peer (codex P4.1
+    Phase-4 BLOCKING). The composite (peer, message_id) PK means one
+    authenticated peer cannot consume OR block another peer's join id by reusing
+    a message_id, while same-peer idempotency (same body -> duplicate) and
+    conflict (different body -> conflict) are preserved. One line per case.
+    """
+    import bridge_rooms_common as r
+
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(r._ROOMS_SCHEMA)
+    conn.commit()
+    mid = "nodeB:shared-id-1"
+    body1 = "a" * 64
+    body2 = "b" * 64
+    # nodeB reserves (its own dedupe + pending row, committed atomically).
+    out_b = r.record_verified_cross_node_join_request_atomic(
+        conn, message_id=mid, body_sha256=body1, peer="nodeB",
+        room_id="room-x", agent="bob", node="nodeB", via_node="nodeB")
+    print(f"nodeB_reserve={out_b}")
+    # nodeC, SAME message_id + SAME body -> NEW (NOT consumed by nodeB's row).
+    print("nodeC_same_body_lookup="
+          + r.room_join_dedupe_lookup(conn, "nodeC", mid, body1))
+    # nodeC, SAME message_id + DIFFERENT body -> NEW (no cross-peer conflict/409).
+    print("nodeC_diff_body_lookup="
+          + r.room_join_dedupe_lookup(conn, "nodeC", mid, body2))
+    # nodeB, SAME id + SAME body -> duplicate (same-peer idempotency preserved).
+    print("nodeB_same_body_lookup="
+          + r.room_join_dedupe_lookup(conn, "nodeB", mid, body1))
+    # nodeB, SAME id + DIFFERENT body -> conflict (same-peer conflict preserved).
+    print("nodeB_diff_body_lookup="
+          + r.room_join_dedupe_lookup(conn, "nodeB", mid, body2))
+    # nodeC can INDEPENDENTLY reserve the SAME message_id (its own row + pending).
+    out_c = r.record_verified_cross_node_join_request_atomic(
+        conn, message_id=mid, body_sha256=body2, peer="nodeC",
+        room_id="room-x", agent="carol", node="nodeC", via_node="nodeC")
+    print(f"nodeC_reserve={out_c}")
+    n_ded = conn.execute(
+        "SELECT COUNT(*) FROM room_join_dedupe WHERE message_id=?",
+        (mid,)).fetchone()[0]
+    print(f"dedupe_rows_for_shared_id={n_ded}")
+    n_pending = conn.execute(
+        "SELECT COUNT(*) FROM room_join_requests WHERE room_id=?",
+        ("room-x",)).fetchone()[0]
+    print(f"pending_rows_for_shared_id={n_pending}")
+    conn.close()
+    return 0
+
+
+def cmd_drop_dedupe_table(db: str) -> int:
+    """DROP room_join_dedupe to simulate an UPGRADED P1 rooms.db whose RW-open
+    migration has not yet recreated the table (codex P4.1 r3 #2 tooth)."""
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("DROP TABLE IF EXISTS room_join_dedupe")
+        conn.commit()
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_set_token_ts(db: str, room_id: str, ts: str) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("UPDATE rooms SET invite_token_ts=? WHERE room_id=?",
+                     (int(ts), room_id))
+        conn.commit()
+    finally:
+        conn.close()
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: rooms-p4-1-cross-node-join-helper.py <subcommand> [args]",
+              file=sys.stderr)
+        return 2
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "post-hook":
+        return cmd_post_hook(rest[0])
+    if cmd == "captured-field":
+        return cmd_captured_field(rest[0], rest[1])
+    if cmd == "deliver-to-receiver":
+        return cmd_deliver_to_receiver(rest[0], rest[1], rest[2],
+                                       rest[3] if len(rest) > 3 else "{}")
+    if cmd == "make-config":
+        return cmd_make_config(rest[0], rest[1], rest[2], rest[3], rest[4])
+    if cmd == "pending-rows":
+        return cmd_pending_rows(rest[0], rest[1])
+    if cmd == "dedupe-rows":
+        return cmd_dedupe_rows(rest[0])
+    if cmd == "db-contains":
+        return cmd_db_contains(rest[0], rest[1])
+    if cmd == "file-tree-contains":
+        return cmd_file_tree_contains(rest[0], rest[1])
+    if cmd == "drop-dedupe-table":
+        return cmd_drop_dedupe_table(rest[0])
+    if cmd == "atomic-race-reclassify":
+        return cmd_atomic_race_reclassify(rest[0])
+    if cmd == "cross-peer-dedupe":
+        return cmd_cross_peer_dedupe(rest[0])
+    if cmd == "set-token-ts":
+        return cmd_set_token_ts(rest[0], rest[1], rest[2])
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/smoke/rooms-p4-1-cross-node-join.sh
+++ b/scripts/smoke/rooms-p4-1-cross-node-join.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-1-cross-node-join.sh — A2A Rooms P4.1 cross-node JOIN.
+#
+# Exercises the FIRST cross-node rooms phase (design docs/design/
+# a2a-rooms-design.md §11 / §14 R3): a member on node B posts a signed
+# room-join-request to the leader's node A over the node-link; node A verifies
+# (node-link HMAC + token-hash + TTL + revocation) and persists a PENDING row
+# (no auto-admit — approve is P4.2). The transport is STUBBED end-to-end (no
+# real Tailscale / live socket): the sender's POST is captured by the paired-
+# flag test hook, then replayed through the REAL receiver handler.
+#
+# THE 5 REQUIRED TEETH (each proven below):
+#   T1  Hostile --from / BRIDGE_AGENT_ID / USER CANNOT change the recorded
+#       joiner — the joiner id is OS-actor-anchored (resolve_os_actor).
+#   T2  A process on node B cannot post a join-request as a *different* B agent
+#       (the joiner is the OS-uid-derived agent; the node is the HMAC-authed
+#       peer, never a wire field).
+#   T3  An expired (TTL) OR revoked (rotated) token is REFUSED — no pending row.
+#   T4  The raw token AND its hash never appear in any queue / task / audit /
+#       staged file.
+#   T5  A malformed / duplicate join-request is handled (no crash; dedupe).
+#
+# Plus a positive path: a valid cross-node request persists a verified=1 pending
+# row anchored to <joiner-os-agent>@<authenticated-peer-node>.
+
+set -euo pipefail
+
+SMOKE_NAME="rooms-p4-1-cross-node-join"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+HELPER="$SCRIPT_DIR/rooms-p4-1-cross-node-join-helper.py"
+POST_HOOK="$SCRIPT_DIR/rooms-p4-1-post-hook.sh"
+ROOMS_CLI="$SMOKE_REPO_ROOT/bridge-rooms.py"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+# The leader's rooms.db (node A) lives under the isolated state dir. Node B (the
+# joiner) never writes it — the cross-node path posts over the node-link.
+export BRIDGE_A2A_ROOMS_DB="$BRIDGE_STATE_DIR/handoff/rooms.db"
+mkdir -p "$BRIDGE_STATE_DIR/handoff"
+
+NODE_A="nodeA"
+NODE_B="nodeB"
+SECRET="test-pair-secret-aaaaaaaaaaaaaaaaaaaa"
+ADDR="127.0.0.1"     # literal peer address → resolve_peer_address returns it (no Tailscale)
+
+# Node-A receiver config (bridge_id=nodeA, peer nodeB) — used by deliver-to-receiver.
+CFG_A="$SMOKE_TMP_ROOT/handoff-A.json"
+python3 "$HELPER" make-config "$CFG_A" "$NODE_A" "$NODE_B" "$SECRET" "$ADDR" >/dev/null
+CFG_A_JSON="$(cat "$CFG_A")"
+
+# Node-B sender config (bridge_id=nodeB, peer nodeA) — used by `room join`.
+CFG_B="$SMOKE_TMP_ROOT/handoff-B.json"
+python3 "$HELPER" make-config "$CFG_B" "$NODE_B" "$NODE_A" "$SECRET" "$ADDR" >/dev/null
+
+CAPTURE="$SMOKE_TMP_ROOT/captured-request.json"
+
+# Paired test-seam flags (gate the OS-user override AND the POST hook). Set
+# INLINE per-invocation, never exported, so nothing leaks. Mirrors P1a.
+TEST_FLAGS=("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1" "BRIDGE_A2A_ALLOW_TEST_BIND=1")
+
+# room_create_as <agent> <ttl> — create a room led by iso-user agent-bridge-<a>
+# on node A. Echoes the JSON. Runs against the node-A config so leader_node=nodeA.
+room_create_as() {
+  local who="$1" ttl="$2"
+  env "${TEST_FLAGS[@]}" "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+    python3 "$ROOMS_CLI" create --name team --ttl "$ttl" --json 2>/dev/null
+}
+
+# join_cross_node_as <os-agent> [extra env...] -- <join-args...>
+# Runs `room join` as iso-user agent-bridge-<os-agent> on node B, with the POST
+# hook capturing the signed request to $CAPTURE. Extra env (the hostile
+# --from/BRIDGE_AGENT_ID/USER spoof) is passed through. Returns the CLI rc.
+join_cross_node_as() {
+  local who="$1"; shift
+  local extra=()
+  while [[ "${1:-}" != "--" ]]; do extra+=("$1"); shift; done
+  shift  # drop the --
+  : >"$CAPTURE" || true
+  # `${extra[@]+...}` guards the empty-array-under-`set -u` footgun (a no-op on
+  # bash 5.x; required so bash 3.2 does not error on an empty TEST_FLAGS/extra).
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_B" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$POST_HOOK" \
+      "CAPTURE_FILE=$CAPTURE" \
+      ${extra[@]+"${extra[@]}"} \
+    python3 "$ROOMS_CLI" join "$@"
+}
+
+json_field() { python3 "$SCRIPT_DIR/a2a-rooms-p1a-helper.py" json-field "$1" "$2"; }
+
+# deliver <overrides_json> — replay $CAPTURE through the real node-A receiver.
+deliver() {
+  local overrides="${1:-}"
+  [[ -n "$overrides" ]] || overrides='{}'
+  python3 "$HELPER" deliver-to-receiver "$SMOKE_REPO_ROOT" "$CFG_A_JSON" \
+    "$CAPTURE" "$overrides"
+}
+
+ROOM=""
+LINK=""
+RAW_TOKEN=""
+TOKEN_HASH=""
+
+# ---------------------------------------------------------------------------
+# setup: a room on node A + capture a baseline valid cross-node join from B
+# ---------------------------------------------------------------------------
+test_setup_room_and_capture() {
+  local out
+  out="$(room_create_as alice 0)"
+  ROOM="$(json_field room_id "$out")"
+  LINK="$(json_field invite_link "$out")"
+  [[ -n "$ROOM" && -n "$LINK" ]] || smoke_fail "room create did not yield room/link"
+  smoke_assert_contains "$LINK" "leader=$NODE_A" "invite link carries leader=nodeA"
+  RAW_TOKEN="$(python3 "$SCRIPT_DIR/a2a-rooms-p1a-helper.py" token-from-link "$LINK")"
+  [[ -n "$RAW_TOKEN" ]] || smoke_fail "could not extract raw token from link"
+  TOKEN_HASH="$(python3 -c "import hashlib,sys;print(hashlib.sha256(sys.argv[1].encode()).hexdigest())" "$RAW_TOKEN")"
+}
+
+# ---------------------------------------------------------------------------
+# positive: a valid cross-node join persists a verified pending row
+# ---------------------------------------------------------------------------
+test_valid_cross_node_join_persists_pending() {
+  join_cross_node_as bob -- "$LINK" >/dev/null 2>&1 \
+    || smoke_fail "cross-node join (sender side) should succeed against the stub"
+  smoke_assert_file_exists "$CAPTURE" "the signed cross-node request was captured"
+  # Deliver to the real receiver → 200 pending.
+  local res
+  res="$(deliver)"
+  smoke_assert_contains "$res" "status=200" "valid cross-node join → 200 at the leader"
+  smoke_assert_contains "$res" "\"status\": \"pending\"" "leader records it as pending"
+  # The persisted row: verified=1, agent=bob (OS-actor), node=nodeB (authed peer).
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$ROOM")"
+  smoke_assert_contains "$rows" "\"agent\": \"bob\"" "pending row joiner agent is the OS-actor (bob)"
+  smoke_assert_contains "$rows" "\"node\": \"$NODE_B\"" "pending row joiner node is the AUTHENTICATED peer (nodeB)"
+  smoke_assert_contains "$rows" "\"verified\": 1" "pending row is marked verified (post node-link auth)"
+  smoke_assert_contains "$rows" "\"via_node\": \"$NODE_B\"" "via_node bound to the authenticated node-link peer"
+}
+
+# ---------------------------------------------------------------------------
+# T1: hostile --from / BRIDGE_AGENT_ID / USER cannot change the joiner
+# ---------------------------------------------------------------------------
+test_T1_hostile_from_env_cannot_change_joiner() {
+  # bob's iso uid joins, but the process screams "I am mallory" three ways.
+  join_cross_node_as bob \
+      "BRIDGE_AGENT_ID=mallory" "USER=mallory" \
+      -- "$LINK" --as mallory >/dev/null 2>&1 \
+    || smoke_fail "join should still succeed (the spoof is ignored, not fatal)"
+  # The WIRE joiner_agent must be bob (the OS-actor), NEVER mallory.
+  local wire_agent
+  wire_agent="$(python3 "$HELPER" captured-field "$CAPTURE" "body:joiner_agent")"
+  smoke_assert_eq "bob" "$wire_agent" \
+    "T1: wire joiner_agent is the OS-actor (bob), NOT the hostile --from/env (mallory)"
+  # And the receiver records bob, not mallory.
+  deliver >/dev/null
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$ROOM")"
+  smoke_assert_not_contains "$rows" "mallory" \
+    "T1: no 'mallory' row — the OS-actor anchor held end-to-end"
+}
+
+# ---------------------------------------------------------------------------
+# T2: a node-B process cannot join as a *different* node-B agent
+# ---------------------------------------------------------------------------
+test_T2_cannot_join_as_a_different_B_agent() {
+  # carol's iso uid joins while claiming to be bob every spoofable way.
+  join_cross_node_as carol \
+      "BRIDGE_AGENT_ID=bob" "USER=bob" \
+      -- "$LINK" --as bob >/dev/null 2>&1 \
+    || smoke_fail "join should succeed (claim ignored, not fatal)"
+  local wire_agent
+  wire_agent="$(python3 "$HELPER" captured-field "$CAPTURE" "body:joiner_agent")"
+  smoke_assert_eq "carol" "$wire_agent" \
+    "T2: a node-B process is bound to its OWN OS-actor (carol), cannot claim 'bob'"
+  # The wire carries NO joiner_node field at all — the node is the authed peer.
+  local wire_node
+  wire_node="$(python3 "$HELPER" captured-field "$CAPTURE" "body:joiner_node" 2>/dev/null || true)"
+  smoke_assert_eq "" "$wire_node" \
+    "T2: there is NO wire-asserted joiner_node (the node is bound to the HMAC peer)"
+  deliver >/dev/null
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$ROOM")"
+  smoke_assert_contains "$rows" "\"agent\": \"carol\"" "T2: carol recorded as herself"
+}
+
+# ---------------------------------------------------------------------------
+# T3: expired (TTL) OR revoked token is REFUSED — no pending row
+# ---------------------------------------------------------------------------
+test_T3a_expired_token_refused() {
+  # A room with a 1-second TTL; backdate the token ts so it is already expired.
+  local out room link
+  out="$(room_create_as dora 1)"
+  room="$(json_field room_id "$out")"
+  link="$(json_field invite_link "$out")"
+  python3 "$HELPER" set-token-ts "$BRIDGE_A2A_ROOMS_DB" "$room" 1 >/dev/null
+  join_cross_node_as erin -- "$link" >/dev/null 2>&1 \
+    || smoke_fail "sender side should succeed (the leader decides validity)"
+  local res
+  res="$(deliver)"
+  smoke_assert_contains "$res" "status=403" "T3: an EXPIRED token is refused (403)"
+  smoke_assert_contains "$res" "expired" "T3: refusal reason is 'expired'"
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$room")"
+  smoke_assert_not_contains "$rows" "erin" "T3: NO pending row for an expired-token join"
+  # codex P4.1 r1 regression: a REPLAY of the rejected expired request must STILL
+  # be 403 (it left NO dedupe row), never an idempotent 200.
+  local replay
+  replay="$(deliver)"
+  smoke_assert_contains "$replay" "status=403" \
+    "T3: a REPLAYED expired-token request is STILL 403 (no idempotent-200 bypass)"
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$room")"
+  smoke_assert_not_contains "$rows" "erin" "T3: replay still leaves NO pending row"
+}
+
+test_T3b_revoked_token_refused() {
+  # Rotate the lifecycle room's invite → the OLD captured token (from $LINK,
+  # already captured for $ROOM) is now revoked. Re-capture an old-token request
+  # then rotate, and deliver: the leader must refuse (hash no longer matches).
+  join_cross_node_as fred -- "$LINK" >/dev/null 2>&1 \
+    || smoke_fail "capture an old-token request before rotating"
+  # Leader rotates the invite (revokes the old token).
+  env "${TEST_FLAGS[@]}" "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-alice" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+    python3 "$ROOMS_CLI" rotate-invite "$ROOM" --json >/dev/null 2>&1 \
+    || smoke_fail "leader rotate-invite should succeed"
+  local res
+  res="$(deliver)"
+  smoke_assert_contains "$res" "status=403" "T3: a REVOKED (rotated-away) token is refused"
+  smoke_assert_contains "$res" "mismatch" "T3: revoked token reads as a hash mismatch"
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$ROOM")"
+  smoke_assert_not_contains "$rows" "fred" "T3: NO pending row for a revoked-token join"
+}
+
+# ---------------------------------------------------------------------------
+# T4: the raw token AND its hash never appear in any queue/task/audit/staged file
+# ---------------------------------------------------------------------------
+test_T4_no_token_or_hash_persisted_anywhere() {
+  # After the positive path persisted a verified row, scan every persistence
+  # surface for BOTH the raw token and its sha256 hash.
+  [[ -n "$RAW_TOKEN" && -n "$TOKEN_HASH" ]] || smoke_fail "token/hash not set up"
+
+  # 1) rooms.db — the row carries metadata only, NEVER the reusable hash.
+  if python3 "$HELPER" db-contains "$BRIDGE_A2A_ROOMS_DB" "$RAW_TOKEN"; then
+    smoke_fail "T4: raw token must NEVER appear in rooms.db"
+  fi
+  # The rooms.db stores invite_token_sha256 in the ROOMS table (that is correct
+  # and 0600-scoped). The contract is that the hash must not leak into the
+  # join-REQUEST row / audit / staged files. Assert the join_request row text
+  # contains neither.
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$ROOM")"
+  smoke_assert_not_contains "$rows" "$RAW_TOKEN" "T4: raw token not in a pending row"
+  smoke_assert_not_contains "$rows" "$TOKEN_HASH" "T4: token HASH not in a pending row (bearer-equivalent)"
+  # The P4.1 cross-node dedupe ledger (room_join_dedupe in rooms.db, codex r2)
+  # stores sha256(WIRE BODY) + message_id + peer — NOT the token or its hash.
+  local dledger
+  dledger="$(python3 "$HELPER" dedupe-rows "$BRIDGE_A2A_ROOMS_DB")"
+  smoke_assert_not_contains "$dledger" "$RAW_TOKEN" "T4: raw token not in the dedupe ledger"
+  smoke_assert_not_contains "$dledger" "$TOKEN_HASH" "T4: token HASH not in the dedupe ledger"
+
+  # 2) audit log — never the token or its hash.
+  local audit="$BRIDGE_LOG_DIR/a2a-handoff.jsonl"
+  if [[ -f "$audit" ]]; then
+    if grep -qF "$RAW_TOKEN" "$audit"; then smoke_fail "T4: raw token leaked into the audit log"; fi
+    if grep -qF "$TOKEN_HASH" "$audit"; then smoke_fail "T4: token hash leaked into the audit log"; fi
+  fi
+
+  # 3) inbox dedupe db (the queue-adjacent ledger) — never the token/hash.
+  local inbox="$BRIDGE_STATE_DIR/handoff/inbox.db"
+  if [[ -f "$inbox" ]]; then
+    if python3 "$HELPER" db-contains "$inbox" "$RAW_TOKEN"; then smoke_fail "T4: raw token in inbox.db"; fi
+    if python3 "$HELPER" db-contains "$inbox" "$TOKEN_HASH"; then smoke_fail "T4: token hash in inbox.db"; fi
+  fi
+
+  # 4) any staged file under the handoff/incoming tree — never the token/hash.
+  if python3 "$HELPER" file-tree-contains "$BRIDGE_STATE_DIR/handoff" "$RAW_TOKEN"; then
+    smoke_fail "T4: raw token found in a staged handoff file"
+  fi
+  if python3 "$HELPER" file-tree-contains "$BRIDGE_STATE_DIR/handoff" "$TOKEN_HASH"; then
+    # NOTE: rooms.db is UNDER handoff/ and legitimately holds the ROOM hash in
+    # the rooms table; the file-tree scan reads text, and the sqlite db is
+    # binary so the hex may or may not surface. To keep this assertion precise
+    # we only fail if the hash is in a STAGED .md/.json file, not the db blob.
+    if python3 "$HELPER" file-tree-contains "$BRIDGE_STATE_DIR/handoff/incoming" "$TOKEN_HASH" 2>/dev/null; then
+      smoke_fail "T4: token hash found in a staged incoming file"
+    fi
+  fi
+
+  # 5) no queue task was created at all (no leader task carrying a token).
+  if [[ -f "$BRIDGE_TASK_DB" ]]; then
+    if python3 "$HELPER" db-contains "$BRIDGE_TASK_DB" "$RAW_TOKEN"; then smoke_fail "T4: raw token in tasks.db"; fi
+    if python3 "$HELPER" db-contains "$BRIDGE_TASK_DB" "$TOKEN_HASH"; then smoke_fail "T4: token hash in tasks.db"; fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# T5: malformed / duplicate join-request handled (no crash; dedupe)
+# ---------------------------------------------------------------------------
+test_T5a_malformed_body_refused_no_crash() {
+  # Capture a valid signed request, then deliver MALFORMED bodies that are
+  # LEGITIMATELY RE-SIGNED (resign:true) — so the test exercises the receiver's
+  # body PARSER (downstream of the HMAC + dedupe gates), not the signature gate.
+  # Each malformed delivery uses a UNIQUE message_id so it passes dedupe ("new")
+  # and reaches the parser (the dedupe gate runs BEFORE parse by design).
+  local freshout freshlink
+  freshout="$(room_create_as helen 0)"
+  freshlink="$(json_field invite_link "$freshout")"
+  join_cross_node_as ivan -- "$freshlink" >/dev/null 2>&1 \
+    || smoke_fail "capture a valid request to mutate"
+  local res
+  # not-JSON body.
+  res="$(deliver '{"headers":{"X-AGB-Message-Id":"nodeB:malformed-1"},"body":"{not json","resign":true}')"
+  smoke_assert_contains "$res" "status=422" "T5: a non-JSON body is a 422 (parser refused, no crash)"
+  # codex P4.1 r1 regression: a REPLAY of the rejected malformed request must
+  # STILL be 422 (no dedupe row was reserved for a reject), never 200.
+  res="$(deliver '{"headers":{"X-AGB-Message-Id":"nodeB:malformed-1"},"body":"{not json","resign":true}')"
+  smoke_assert_contains "$res" "status=422" "T5: a REPLAYED malformed body is STILL 422 (no idempotent-200 bypass)"
+  # missing required fields.
+  res="$(deliver '{"headers":{"X-AGB-Message-Id":"nodeB:malformed-2"},"body":"{\"protocol\":\"agent-bridge.a2a.room-join.v1\"}","resign":true}')"
+  smoke_assert_contains "$res" "status=422" "T5: a missing-field body is a 422"
+  # bad token-hash shape (not 64 hex) → 422 at the parser.
+  res="$(deliver '{"headers":{"X-AGB-Message-Id":"nodeB:malformed-3"},"body":"{\"protocol\":\"agent-bridge.a2a.room-join.v1\",\"room_id\":\"r\",\"join_token_sha256\":\"xyz\",\"joiner_agent\":\"a\"}","resign":true}')"
+  smoke_assert_contains "$res" "status=422" "T5: a malformed token-hash is a 422"
+}
+
+test_T5b_duplicate_idempotent() {
+  # Capture one valid request; deliver it twice. Second is an idempotent dup.
+  local out room link
+  out="$(room_create_as jane 0)"
+  room="$(json_field room_id "$out")"
+  link="$(json_field invite_link "$out")"
+  join_cross_node_as kara -- "$link" >/dev/null 2>&1 \
+    || smoke_fail "capture a valid request for the dup test"
+  local first second
+  first="$(deliver)"
+  smoke_assert_contains "$first" "status=200" "T5: first delivery is 200"
+  second="$(deliver)"
+  smoke_assert_contains "$second" "status=200" "T5: a duplicate (same id+body) is idempotent 200"
+  smoke_assert_contains "$second" "\"duplicate\": true" "T5: the duplicate is flagged"
+  # codex P4.1 r2 atomicity: an idempotent-200 duplicate MUST correspond to a
+  # REAL pending row (dedupe row ⟺ pending row, committed atomically) — never a
+  # bogus 200 with no row.
+  local drows
+  drows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$room")"
+  smoke_assert_contains "$drows" "\"agent\": \"kara\"" \
+    "T5 atomicity: the duplicate-200 corresponds to a REAL pending row (kara)"
+  # Same id (the captured one), DIFFERENT but VALIDLY-SIGNED body → 409 conflict
+  # (security event), still no crash. resign keeps the HMAC valid so the
+  # conflict is detected at the dedupe ledger, not the signature gate.
+  local hex64
+  hex64="$(python3 -c "print('a'*64)")"
+  local conflict
+  conflict="$(deliver '{"body":"{\"protocol\":\"agent-bridge.a2a.room-join.v1\",\"room_id\":\"'"$room"'\",\"join_token_sha256\":\"'"$hex64"'\",\"joiner_agent\":\"kara\"}","resign":true}')"
+  smoke_assert_contains "$conflict" "status=409" "T5: same id + different body is a 409 conflict"
+}
+
+# ---------------------------------------------------------------------------
+# auth preamble teeth: a tampered signature / wrong source addr is refused
+# ---------------------------------------------------------------------------
+test_auth_preamble_unweakened() {
+  local out room link
+  out="$(room_create_as liam 0)"
+  room="$(json_field room_id "$out")"
+  link="$(json_field invite_link "$out")"
+  join_cross_node_as mike -- "$link" >/dev/null 2>&1 \
+    || smoke_fail "capture a valid request for the auth teeth"
+  # Tampered signature → 401 (HMAC unweakened).
+  local res
+  res="$(deliver '{"headers":{"X-AGB-Signature":"v1=deadbeef"}}')"
+  smoke_assert_contains "$res" "status=401" "auth: a bad signature is 401 (HMAC gate intact)"
+  # Wrong source address → 403 (remote_addr gate intact).
+  res="$(deliver '{"client_ip":"10.9.9.9"}')"
+  smoke_assert_contains "$res" "status=403" "auth: a wrong source address is 403 (remote_addr gate intact)"
+  # Unknown peer → 403.
+  res="$(deliver '{"headers":{"X-AGB-Peer":"nodeZ"}}')"
+  smoke_assert_contains "$res" "status=403" "auth: an unknown peer is 403"
+}
+
+# ---------------------------------------------------------------------------
+# not-leader-node: a node that does not lead the room records nothing
+# ---------------------------------------------------------------------------
+test_non_leader_node_refuses() {
+  # Deliver a valid request to a receiver whose bridge_id is NOT the leader node.
+  local out room link
+  out="$(room_create_as nora 0)"
+  room="$(json_field room_id "$out")"
+  link="$(json_field invite_link "$out")"
+  join_cross_node_as opal -- "$link" >/dev/null 2>&1 \
+    || smoke_fail "capture a valid request"
+  # A node-C config (bridge_id=nodeC) that still trusts nodeB as a peer, but the
+  # room's leader_node is nodeA → 404 not-leader-node, nothing persisted.
+  local cfg_c="$SMOKE_TMP_ROOT/handoff-C.json"
+  python3 "$HELPER" make-config "$cfg_c" "nodeC" "$NODE_B" "$SECRET" "$ADDR" >/dev/null
+  local res
+  res="$(python3 "$HELPER" deliver-to-receiver "$SMOKE_REPO_ROOT" "$(cat "$cfg_c")" "$CAPTURE")"
+  smoke_assert_contains "$res" "status=404" "a non-leader node refuses the join (404)"
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$room")"
+  smoke_assert_not_contains "$rows" "opal" "a non-leader node persists NO pending row"
+}
+
+# ---------------------------------------------------------------------------
+# upgraded P1 rooms.db: the read-only dedupe lookup tolerates a missing table
+# (codex r3 #2) — the RW accept-open recreates it; the join still succeeds.
+# ---------------------------------------------------------------------------
+test_upgraded_db_missing_dedupe_table() {
+  local out room link
+  out="$(room_create_as petra 0)"
+  room="$(json_field room_id "$out")"
+  link="$(json_field invite_link "$out")"
+  join_cross_node_as quinn -- "$link" >/dev/null 2>&1 \
+    || smoke_fail "capture a valid request"
+  # Simulate an UPGRADED P1 rooms.db whose RW migration has not yet recreated
+  # the new table: DROP it, then deliver. The RO step-h lookup must treat the
+  # missing table as 'new' (not a 500), and the RW accept-open must recreate it
+  # before reserving → 200 pending + a real row.
+  python3 "$HELPER" drop-dedupe-table "$BRIDGE_A2A_ROOMS_DB" >/dev/null
+  local res
+  res="$(deliver)"
+  smoke_assert_contains "$res" "status=200" \
+    "r3 #2: a join against an unmigrated P1 db (no dedupe table) still 200s (no 500)"
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$room")"
+  smoke_assert_contains "$rows" "\"agent\": \"quinn\"" \
+    "r3 #2: the accept-open recreated the dedupe table + persisted the pending row"
+}
+
+# ---------------------------------------------------------------------------
+# concurrency: a message_id PK race is RECLASSIFIED to duplicate/conflict, never
+# a 500 (codex r3 #1). Unit-drives the atomic helper's pre-check AND its
+# IntegrityError catch branch.
+# ---------------------------------------------------------------------------
+test_atomic_race_reclassified_not_500() {
+  local racedb="$SMOKE_TMP_ROOT/race.db"
+  local out
+  out="$(python3 "$HELPER" atomic-race-reclassify "$racedb" 2>&1)" \
+    || smoke_fail "atomic-race helper must not raise: $out"
+  smoke_assert_contains "$out" "precheck_same_body=duplicate" \
+    "r3 #1: a pre-checked same-body race resolves to duplicate"
+  smoke_assert_contains "$out" "precheck_diff_body=conflict" \
+    "r3 #1: a pre-checked different-body race resolves to conflict"
+  smoke_assert_contains "$out" "integrityerror_reclassified=duplicate" \
+    "r3 #1: a PK IntegrityError (lost the INSERT race) is reclassified, NOT a 500"
+}
+
+# ---------------------------------------------------------------------------
+# T6 (codex P4.1 Phase-4 BLOCKING): dedupe is scoped to the AUTHENTICATED peer.
+#     A second authenticated peer (nodeC) reusing nodeB's message_id must NOT
+#     consume or block nodeB's join id — composite (peer, message_id) PK. Same-
+#     peer idempotency (same body) + conflict (different body) are preserved.
+# ---------------------------------------------------------------------------
+test_T6_cross_peer_dedupe_isolation() {
+  local xdb="$SMOKE_TMP_ROOT/cross-peer.db"
+  local out
+  out="$(python3 "$HELPER" cross-peer-dedupe "$xdb" 2>&1)" \
+    || smoke_fail "cross-peer-dedupe helper must not raise: $out"
+  smoke_assert_contains "$out" "nodeB_reserve=reserved" \
+    "nodeB reserves its own dedupe + pending row"
+  smoke_assert_contains "$out" "nodeC_same_body_lookup=new" \
+    "T6: nodeC reusing nodeB's message_id (SAME body) is NEW — not consumed (cross-peer isolation)"
+  smoke_assert_contains "$out" "nodeC_diff_body_lookup=new" \
+    "T6: nodeC reusing nodeB's message_id (DIFFERENT body) is NEW — no cross-peer 409"
+  smoke_assert_contains "$out" "nodeB_same_body_lookup=duplicate" \
+    "T6: nodeB same id+body stays idempotent (duplicate) — same-peer dedupe preserved"
+  smoke_assert_contains "$out" "nodeB_diff_body_lookup=conflict" \
+    "T6: nodeB same id+different body stays a conflict — same-peer dedupe preserved"
+  smoke_assert_contains "$out" "nodeC_reserve=reserved" \
+    "T6: nodeC independently reserves the SAME message_id (its own row)"
+  smoke_assert_contains "$out" "dedupe_rows_for_shared_id=2" \
+    "T6: two authenticated peers => two independent dedupe rows for one message_id"
+  smoke_assert_contains "$out" "pending_rows_for_shared_id=2" \
+    "T6: two authenticated peers => two independent pending rows"
+}
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+smoke_run "setup: room on node A + baseline cross-node join captured" test_setup_room_and_capture
+smoke_run "positive: valid cross-node join persists a verified pending row" test_valid_cross_node_join_persists_pending
+smoke_run "T1: hostile --from/BRIDGE_AGENT_ID/USER cannot change the joiner" test_T1_hostile_from_env_cannot_change_joiner
+smoke_run "T2: a node-B process cannot join as a different B agent" test_T2_cannot_join_as_a_different_B_agent
+smoke_run "T3a: an expired (TTL) token is refused — no pending row" test_T3a_expired_token_refused
+smoke_run "T3b: a revoked (rotated) token is refused — no pending row" test_T3b_revoked_token_refused
+smoke_run "T4: raw token AND hash never persisted in queue/audit/staged" test_T4_no_token_or_hash_persisted_anywhere
+smoke_run "T5a: a malformed body is refused (422, no crash)" test_T5a_malformed_body_refused_no_crash
+smoke_run "T5b: a duplicate join is idempotent; id-reuse is a 409" test_T5b_duplicate_idempotent
+smoke_run "auth preamble unweakened (HMAC 401 / remote_addr 403 / unknown peer 403)" test_auth_preamble_unweakened
+smoke_run "a non-leader node refuses + persists nothing" test_non_leader_node_refuses
+smoke_run "r3 #2: unmigrated P1 db (missing dedupe table) still joins (no 500)" test_upgraded_db_missing_dedupe_table
+smoke_run "r3 #1: a message_id PK race is reclassified (dup/conflict), not a 500" test_atomic_race_reclassified_not_500
+smoke_run "T6: dedupe scoped to authenticated peer — one peer can't consume/block another's join id" test_T6_cross_peer_dedupe_isolation
+
+smoke_log "passed"

--- a/scripts/smoke/rooms-p4-1-post-hook.sh
+++ b/scripts/smoke/rooms-p4-1-post-hook.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-1-post-hook.sh — BRIDGE_ROOMS_TEST_POST_HOOK target.
+#
+# The cross-node `bridge-rooms.py join` test seam invokes this with the signed
+# request JSON as $1 (file-as-argv, never stdin — footgun #11). We delegate to
+# the helper's `post-hook` subcommand, which writes the captured request to
+# $CAPTURE_FILE and echoes a stub response body. Kept as a separate executable
+# so the CLI hook contract (`[hook, payload]`) is satisfied with a real argv[0].
+set -euo pipefail
+HERE="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 "$HERE/rooms-p4-1-cross-node-join-helper.py" post-hook "$1"

--- a/scripts/smoke/rooms-p4-2-post-hook.sh
+++ b/scripts/smoke/rooms-p4-2-post-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-2-post-hook.sh — BRIDGE_ROOMS_TEST_POST_HOOK target.
+#
+# The leader's `bridge-rooms.py approve` roster-broadcast test seam invokes this
+# with the signed request JSON as $1 (file-as-argv, never stdin — footgun #11).
+# We delegate to the helper's `post-hook` subcommand, which writes the captured
+# request to $CAPTURE_FILE and echoes a stub response body. Kept as a separate
+# executable so the CLI hook contract (`[hook, payload]`) is satisfied with a
+# real argv[0].
+set -euo pipefail
+HERE="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 "$HERE/rooms-p4-2-roster-broadcast-helper.py" post-hook "$1"

--- a/scripts/smoke/rooms-p4-2-roster-broadcast-helper.py
+++ b/scripts/smoke/rooms-p4-2-roster-broadcast-helper.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""Helper for the rooms-p4-2-roster-broadcast smoke (A2A Rooms P4.2).
+
+File-as-argv sidecar (never a heredoc-stdin — footgun #11). Imports the REAL
+rooms / a2a / handoffd modules from the repo root so the smoke exercises the
+canonical leader (cross-approve gate + signed roster broadcast), the canonical
+member-side receiver (`_handle_room_roster_broadcast` fail-closed auth preamble
++ the anti-rogue-leader / monotonic-epoch / atomic-cache contracts), and the
+canonical schema — WITHOUT a live socket or Tailscale.
+
+The transport is stubbed two ways (mirrors the P4.1 helper):
+  - SENDER side (the leader's `room approve` broadcast): the cross-node POST is
+    captured by the paired-flag test hook (BRIDGE_ROOMS_TEST_POST_HOOK = the
+    rooms-p4-2-post-hook.sh wrapper -> this script's `post-hook`), which writes
+    the fully-signed request to a file.
+  - RECEIVER side: `deliver-roster-to-receiver` reconstructs a minimal fake HTTP
+    request from that captured file and drives the REAL member-side handler, so
+    the actual auth preamble (protocol/peer/remote_addr/HMAC/skew/dedupe) + the
+    member-side acceptance logic + the cache write run end to end. The peer uses
+    a literal `address` so resolve_peer_address returns it verbatim — no
+    Tailscale.
+
+Subcommands (argv[1]):
+  post-hook <json>                 (BRIDGE_ROOMS_TEST_POST_HOOK target) — write
+                                   the signed request JSON to $CAPTURE_FILE and
+                                   echo a stub "{}" response.
+  captured-field <file> <key>      print headers[X-AGB-*] or body.<key> (a list/
+                                   dict value is JSON-encoded).
+  deliver-roster-to-receiver <repo_root> <cfg_json> <captured_file> [overrides]
+                                   replay the captured roster broadcast through
+                                   the real member-side receiver handler; print
+                                   "status=<n> body=<json>".
+  make-config <out_path> <this_node> <peer_node> <peer_secret> <address>
+                                   write a minimal handoff config the receiver
+                                   loads (member node trusts the leader peer).
+  make-member-db <db> <room_id> <leader_node> [member_agent] [member_node]
+                                   seed a member-local rooms.db with an OUTBOUND
+                                   join intent (the FIRST-ROSTER binding anchor)
+                                   so a first roster for <room_id> is acceptable.
+  cache-rows <db> [room_id]        print each room_roster_cache row as JSON.
+  set-cache-epoch <db> <room_id> <epoch>  force the cached epoch (drive monotonic).
+  cross-approve-gate <db>          unit-drive approve_cross_node: refuse w/o a
+                                   verified pending row; admit with one.
+  local-add-no-gate <db>           unit-drive approve_join (local path admits a
+                                   local agent with NO verified-row requirement).
+  member-accept-unit <db>          unit-drive accept_roster_broadcast contracts
+                                   (not-leader / no-binding / first-bind / higher
+                                   epoch / stale / duplicate / leader-pin).
+  empty-leader-takeover-unit <db>  unit-drive the empty-from_node takeover refusal.
+  dedupe-race-unit <db>            unit-drive the atomic dedupe/cache TOCTOU
+                                   contract (same-id/diff-body → conflict, no
+                                   cache write; same-id/same-body → duplicate).
+  duplicate-burns-id-unit <db>     unit-drive the duplicate-branch id-burn (a
+                                   same-state DUPLICATE still reserves the id, so
+                                   a later same-id/diff-body reuse is a conflict).
+  db-contains <db> <needle>        exit 0 iff <needle> appears in the db dump.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import bridge_a2a_common as a2a  # noqa: E402
+import bridge_rooms_common as rooms  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# sender-side capture hook (invoked as BRIDGE_ROOMS_TEST_POST_HOOK)
+# ---------------------------------------------------------------------------
+def cmd_post_hook(payload_json: str) -> int:
+    """Write the captured signed request to $CAPTURE_FILE; stub a response body.
+
+    The stub response models what a real leader/member receiver returns for the
+    request's endpoint, so the SENDER-side CLI logic that keys off the ack body
+    is exercised: a `room join` post (X-AGB-Protocol == room-join) gets a
+    pending ack (so the CLI records its FIRST-ROSTER local binding); a roster
+    broadcast post gets an applied ack. $POST_HOOK_ACK may override the body.
+    """
+    capture = os.environ.get("CAPTURE_FILE")  # noqa: iso-helper-boundary - env var, not a .env file
+    if not capture:
+        print("CAPTURE_FILE unset", file=sys.stderr)
+        return 1
+    Path(capture).write_text(payload_json, encoding="utf-8")
+    override = os.environ.get("POST_HOOK_ACK")  # noqa: iso-helper-boundary - env var, not a .env file
+    if override is not None:
+        print(override)
+        return 0
+    try:
+        doc = json.loads(payload_json)
+        proto = doc.get("headers", {}).get("X-AGB-Protocol", "")
+    except (ValueError, json.JSONDecodeError):
+        proto = ""
+    if proto == a2a.ROOM_JOIN_PROTOCOL_VERSION:
+        # Model the leader's pending ack so the member CLI records its binding.
+        print(json.dumps({"ok": True, "status": rooms.JOIN_PENDING}))
+    else:
+        print("{}")
+    return 0
+
+
+def cmd_captured_field(path: str, key: str) -> int:
+    doc = json.loads(Path(path).read_text(encoding="utf-8"))
+    if key.startswith("header:"):
+        val = doc.get("headers", {}).get(key[len("header:"):], "")
+    elif key.startswith("body:"):
+        body = json.loads(doc.get("body", "{}"))
+        val = body.get(key[len("body:"):], "")
+    elif key == "path":
+        val = doc.get("path", "")
+    else:
+        print(f"unknown captured key: {key}", file=sys.stderr)
+        return 1
+    if isinstance(val, (list, dict)):
+        print(json.dumps(val, separators=(",", ":")))
+    else:
+        print(val)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# receiver-side replay against the REAL member-side handler
+# ---------------------------------------------------------------------------
+def _load_handoffd(repo_root: str):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "bridge_handoffd", os.path.join(repo_root, "bridge-handoffd.py"))
+    hd = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(hd)
+    return hd
+
+
+class _FakeHeaders:
+    def __init__(self, headers: dict):
+        self._h = headers
+
+    def get(self, key, default=None):
+        return self._h.get(key, default)
+
+
+class _FakeRFile:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0 or n >= len(self._data):
+            out, self._data = self._data, b""
+            return out
+        out, self._data = self._data[:n], self._data[n:]
+        return out
+
+
+class _FakeServer:
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self.config_path = ""
+
+
+def cmd_deliver_roster_to_receiver(repo_root: str, cfg_json: str, captured: str,
+                                   overrides_json: str = "{}") -> int:
+    """Replay a captured signed roster broadcast through the REAL member-side
+    receiver handler. `overrides_json` lets a tooth mutate the captured request:
+      {"client_ip": "...", "headers": {...override...},
+       "body": "<replacement json string>", "recompute_hash": true,
+       "resign": true}
+    `resign` recomputes BOTH the body hash AND a VALID HMAC for the (mutated)
+    body using the peer's configured secret — to exercise a path DOWNSTREAM of
+    the HMAC gate (e.g. the body parser, or a contract check) with a
+    legitimately-signed body. `recompute_hash` recomputes only the body hash
+    (used to drive the same-id-different-body 409 WITHOUT tripping the body-hash
+    gate, while leaving the OLD signature -> still a 401 if not resigned).
+    """
+    hd = _load_handoffd(repo_root)
+    cfg = json.loads(cfg_json)
+    doc = json.loads(Path(captured).read_text(encoding="utf-8"))
+    overrides = json.loads(overrides_json) if overrides_json else {}
+
+    path = doc.get("path", a2a.ROOM_ROSTER_PATH)
+    headers = dict(doc.get("headers", {}))
+    body = doc.get("body", "{}")
+
+    if "headers" in overrides:
+        headers.update(overrides["headers"])
+    if "body" in overrides:
+        body = overrides["body"]
+    body_bytes = body.encode("utf-8") if isinstance(body, str) else bytes(body)
+    if overrides.get("recompute_hash"):
+        headers["X-AGB-Body-SHA256"] = a2a.body_sha256(body_bytes)
+    if overrides.get("resign"):
+        peer_secret = ""
+        for p in cfg.get("peers", []):
+            if p.get("id") == headers.get("X-AGB-Peer", ""):
+                peer_secret = p.get("secret", "")
+                break
+        body_hash = a2a.body_sha256(body_bytes)
+        headers["X-AGB-Body-SHA256"] = body_hash
+        canonical = a2a.canonical_string(
+            "POST", path, headers.get("X-AGB-Peer", ""),
+            headers.get("X-AGB-Message-Id", ""),
+            headers.get("X-AGB-Timestamp", ""), body_hash)
+        headers["X-AGB-Signature"] = a2a.sign(peer_secret, canonical)
+    headers["Content-Length"] = str(len(body_bytes))
+
+    peer_id = headers.get("X-AGB-Peer", "")
+    peer_addr = ""
+    for p in cfg.get("peers", []):
+        if p.get("id") == peer_id:
+            peer_addr = p.get("address", "")
+            break
+    client_ip = overrides.get("client_ip", peer_addr or "127.0.0.1")
+
+    handler = hd.HandoffHandler.__new__(hd.HandoffHandler)
+    handler.path = path
+    handler.headers = _FakeHeaders(headers)
+    handler.rfile = _FakeRFile(body_bytes)
+    handler.client_address = (client_ip, 0)
+    handler.server = _FakeServer(cfg)
+
+    captured_reply = {}
+
+    def _capture_reply(status, payload, extra_headers=None):
+        captured_reply["status"] = status
+        captured_reply["payload"] = payload
+
+    handler._reply = _capture_reply  # type: ignore[assignment]
+    handler._handle_room_roster_broadcast(cfg)
+
+    status = captured_reply.get("status", 0)
+    payload = captured_reply.get("payload", {})
+    print(f"status={status} body={json.dumps(payload)}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# config + db helpers
+# ---------------------------------------------------------------------------
+def cmd_make_config(out_path: str, this_node: str, peer_node: str,
+                    peer_secret: str, address: str) -> int:
+    cfg = {
+        "bridge_id": this_node,
+        "listen": {"host": "127.0.0.1", "port": 8787,
+                   "enqueue_path": "/enqueue"},
+        "timestamp_skew_seconds": 300,
+        "timestamp_skew_grace_seconds": 3600,
+        "peers": [
+            {
+                "id": peer_node,
+                "address": address,
+                "secret": peer_secret,
+                "inbound_allowlist": [],
+            }
+        ],
+    }
+    Path(out_path).write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    try:
+        os.chmod(out_path, 0o600)
+    except OSError:
+        pass
+    return 0
+
+
+def cmd_make_member_db(db: str, room_id: str, leader_node: str,
+                       member_agent: str = "bob",
+                       member_node: str = "nodeB") -> int:
+    """Seed a member-local rooms.db that holds an OUTBOUND join intent for
+    <room_id> naming <leader_node> — the FIRST-ROSTER binding anchor. Mirrors
+    what `room join` records via rooms.record_local_join_intent."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        rooms.record_local_join_intent(
+            conn, room_id, member_agent, member_node, leader_node=leader_node)
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_cache_rows(db: str, room_id: str = "") -> int:
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        if room_id:
+            rows = conn.execute(
+                "SELECT room_id, epoch, members_json, from_node, mac, "
+                "fetched_ts FROM room_roster_cache WHERE room_id=?",
+                (room_id,)).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT room_id, epoch, members_json, from_node, mac, "
+                "fetched_ts FROM room_roster_cache").fetchall()
+    finally:
+        conn.close()
+    for r in rows:
+        print(json.dumps({k: r[k] for k in r.keys()}))
+    return 0
+
+
+def cmd_set_cache_epoch(db: str, room_id: str, epoch: str) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("UPDATE room_roster_cache SET epoch=? WHERE room_id=?",
+                     (int(epoch), room_id))
+        conn.commit()
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_db_contains(db: str, needle: str) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        dump = "\n".join(conn.iterdump())
+    finally:
+        conn.close()
+    return 0 if needle and needle in dump else 1
+
+
+# ---------------------------------------------------------------------------
+# unit drivers — leader-side gate
+# ---------------------------------------------------------------------------
+def cmd_cross_approve_gate(db: str) -> int:
+    """Prove approve_cross_node REQUIRES a verified pending row (contract 1)."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        room_id = rooms.create_room(
+            conn, name="t", leader_agent="alice", leader_node="nodeA",
+            token="tok")
+        # 1) No pending row at all -> refused.
+        try:
+            rooms.approve_cross_node(conn, room_id, "bob", "nodeB")
+            print("no_row=ADMITTED")  # should not happen
+        except rooms.RoomsError as exc:
+            print(f"no_row=refused:{exc.code}")
+        # 2) A row that is pending but NOT verified (a local P1 row) -> refused.
+        rooms.post_join_request(conn, room_id, "carl", "nodeB")
+        try:
+            rooms.approve_cross_node(conn, room_id, "carl", "nodeB")
+            print("unverified_row=ADMITTED")
+        except rooms.RoomsError as exc:
+            print(f"unverified_row=refused:{exc.code}")
+        # 3) A verified pending row (what the P4.1 receiver creates) -> admitted.
+        rooms.record_verified_cross_node_join_request(
+            conn, room_id, "bob", "nodeB", via_node="nodeB")
+        epoch = rooms.approve_cross_node(conn, room_id, "bob", "nodeB")
+        admitted = rooms.is_member(conn, room_id, "bob", "nodeB")
+        print(f"verified_row=admitted:epoch={epoch}:member={admitted}")
+        # 4) The membership add did NOT also admit carl (the unverified one).
+        print(f"carl_member={rooms.is_member(conn, room_id, 'carl', 'nodeB')}")
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_local_add_no_gate(db: str) -> int:
+    """Prove approve_join (the LOCAL leader-add path) admits a LOCAL agent with
+    NO verified-pending-row requirement — the two paths stay distinct
+    (contract 1/6, the no-P4.1-regression tooth)."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        room_id = rooms.create_room(
+            conn, name="t", leader_agent="alice", leader_node="nodeA",
+            token="tok")
+        # A local agent (node == leader node) admitted via approve_join with NO
+        # pending row at all — the local path does NOT claim the token gate.
+        epoch = rooms.approve_join(conn, room_id, "dave", "nodeA")
+        admitted = rooms.is_member(conn, room_id, "dave", "nodeA")
+        print(f"local_add=admitted:epoch={epoch}:member={admitted}")
+        # And approve_cross_node would have REFUSED the same (no verified row),
+        # proving the two paths are genuinely distinct.
+        try:
+            rooms.approve_cross_node(conn, room_id, "erin", "nodeA")
+            print("cross_path_for_local=ADMITTED")
+        except rooms.RoomsError as exc:
+            print(f"cross_path_for_local=refused:{exc.code}")
+    finally:
+        conn.close()
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# unit driver — member-side acceptance contracts
+# ---------------------------------------------------------------------------
+def _accept(conn, *, room_id, room_epoch, members, leader_node, peer_id, mid):
+    """accept_roster_broadcast wrapper that supplies a per-call dedupe key.
+
+    `mid` is a UNIQUE message id per logical delivery; the body_sha256 is derived
+    from the actual canonical body bytes so a same-id replay of identical content
+    is a real duplicate while different content under the same id is a conflict —
+    exactly what the receiver sees on the wire."""
+    body = a2a.build_room_roster_broadcast(
+        room_id=room_id, room_epoch=room_epoch, members=members,
+        leader_node=leader_node)
+    body_bytes = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    return rooms.accept_roster_broadcast(
+        conn, room_id=room_id, room_epoch=room_epoch, members=members,
+        leader_node=leader_node, peer_id=peer_id, message_id=mid,
+        body_sha256=a2a.body_sha256(body_bytes))
+
+
+def cmd_member_accept_unit(db: str) -> int:
+    """Drive accept_roster_broadcast's full contract surface directly (a unit
+    test of the security-critical acceptance logic). One line per case. Each
+    logical delivery uses a UNIQUE message id so dedupe does not collide across
+    cases (the dedupe-race case has its own dedicated driver)."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        room_id = "room-unit"
+        leader = "nodeA"
+        members_v2 = [
+            {"agent": "alice", "node": "nodeA", "role": "leader"},
+            {"agent": "bob", "node": "nodeB", "role": "member"},
+        ]
+
+        # (3a) NOT-leader: an authenticated peer that is NOT the leader_node ->
+        # rejected, persists nothing — EVEN with a local binding present.
+        rooms.record_local_join_intent(
+            conn, room_id, "bob", "nodeB", leader_node=leader)
+        out = _accept(conn, room_id=room_id, room_epoch=2, members=members_v2,
+                      leader_node=leader, peer_id="nodeZ", mid="nodeZ:u1")
+        print(f"not_leader={out}")
+        print(f"not_leader_no_cache={rooms.get_roster_cache(conn, room_id) is None}")
+
+        # (3c) FIRST roster with NO local binding -> refused (rogue-leader mint
+        # prevented). Use a DIFFERENT room with no local intent.
+        out = _accept(conn, room_id="room-rogue", room_epoch=5,
+                      members=members_v2, leader_node=leader, peer_id=leader,
+                      mid="nodeA:u2")
+        print(f"no_binding={out}")
+        print("no_binding_no_cache="
+              f"{rooms.get_roster_cache(conn, 'room-rogue') is None}")
+
+        # (3c) FIRST roster WITH a local binding (recorded above) -> accepted.
+        out = _accept(conn, room_id=room_id, room_epoch=2, members=members_v2,
+                      leader_node=leader, peer_id=leader, mid="nodeA:u3")
+        cache = rooms.get_roster_cache(conn, room_id)
+        print(f"first_bind={out}:epoch={cache['epoch']}")
+
+        # (3d) a STRICTLY-higher epoch updates.
+        members_v3 = members_v2 + [
+            {"agent": "carol", "node": "nodeC", "role": "member"}]
+        out = _accept(conn, room_id=room_id, room_epoch=3, members=members_v3,
+                      leader_node=leader, peer_id=leader, mid="nodeA:u4")
+        cache = rooms.get_roster_cache(conn, room_id)
+        has_carol = "carol" in cache["members_json"]
+        print(f"higher_epoch={out}:epoch={cache['epoch']}:has_carol={has_carol}")
+
+        # (3d) a LOWER epoch is IGNORED (stale) — the cache keeps epoch 3.
+        out = _accept(conn, room_id=room_id, room_epoch=2, members=members_v2,
+                      leader_node=leader, peer_id=leader, mid="nodeA:u5")
+        cache = rooms.get_roster_cache(conn, room_id)
+        still_carol = "carol" in cache["members_json"]
+        print(f"lower_epoch={out}:epoch={cache['epoch']}:still_carol={still_carol}")
+
+        # (3d) the SAME epoch with DIFFERENT members is IGNORED (a forge/replay),
+        # NOT accepted — the cache is unchanged.
+        out = _accept(conn, room_id=room_id, room_epoch=3, members=members_v2,
+                      leader_node=leader, peer_id=leader, mid="nodeA:u6")
+        cache = rooms.get_roster_cache(conn, room_id)
+        same_still_carol = "carol" in cache["members_json"]
+        print(f"same_epoch_diff={out}:still_carol={same_still_carol}")
+
+        # (3d) a BYTE-IDENTICAL re-broadcast at the SAME epoch is an idempotent
+        # duplicate (accepted-as-noop). Use the SAME message id + body as the
+        # higher_epoch write (u4) so the dedupe ledger recognizes it as a replay.
+        out = _accept(conn, room_id=room_id, room_epoch=3, members=members_v3,
+                      leader_node=leader, peer_id=leader, mid="nodeA:u4")
+        print(f"idempotent_dup={out}")
+
+        # (3a' codex P4.2 r1 BLOCKING) LEADER-TAKEOVER of an EXISTING cache: a
+        # DIFFERENT configured peer (nodeC) self-claims leadership (peer_id ==
+        # leader_node == nodeC, so the literal 3a check passes) AND signs a
+        # strictly-HIGHER epoch. Without leader-pinning this would overwrite the
+        # cache. It MUST be refused (ROSTER_LEADER_MISMATCH) and leave the cache
+        # pinned to the original leader nodeA at the original epoch.
+        rogue_members = [
+            {"agent": "mallory", "node": "nodeC", "role": "leader"}]
+        out = _accept(conn, room_id=room_id, room_epoch=99,
+                      members=rogue_members, leader_node="nodeC",
+                      peer_id="nodeC", mid="nodeC:u7")
+        cache = rooms.get_roster_cache(conn, room_id)
+        print(f"takeover={out}:from_node={cache['from_node']}:"
+              f"epoch={cache['epoch']}:"
+              f"has_mallory={'mallory' in cache['members_json']}")
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_empty_leader_takeover_unit(db: str) -> int:
+    """Prove a SINGLE-NODE/local room (cache from_node="") cannot be taken over
+    by a remote peer self-claiming leadership (codex P4.2 r2 BLOCKING). One line
+    of output: outcome + the (unchanged) cached from_node + epoch."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        # A local room: leader_node="" → cache seeded with from_node="" at epoch 0.
+        room_id = rooms.create_room(
+            conn, name="local", leader_agent="alice", leader_node="", token="t")
+        before = rooms.get_roster_cache(conn, room_id)
+        # A remote peer nodeC (non-empty authenticated peer_id) self-claims
+        # leadership at a higher epoch. Must be refused (leader_mismatch).
+        out = _accept(
+            conn, room_id=room_id, room_epoch=99,
+            members=[{"agent": "mallory", "node": "nodeC", "role": "leader"}],
+            leader_node="nodeC", peer_id="nodeC", mid="nodeC:empty1")
+        after = rooms.get_roster_cache(conn, room_id)
+        unchanged = (str(before["from_node"]) == str(after["from_node"])
+                     and int(before["epoch"]) == int(after["epoch"]))
+        print(f"empty_takeover={out}:from_node='{after['from_node']}':"
+              f"epoch={after['epoch']}:unchanged={unchanged}:"
+              f"has_mallory={'mallory' in after['members_json']}")
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_dedupe_race_unit(db: str) -> int:
+    """Drive the atomic dedupe/cache TOCTOU contract directly (codex P4.2 r3
+    BLOCKING). Two deliveries reuse the SAME (peer, message_id) with DIFFERENT
+    bodies; the SECOND must be a CONFLICT with NO cache mutation (the cache still
+    holds the FIRST body). Then a byte-identical replay of the FIRST is a
+    DUPLICATE (no double-apply). One line per case.
+
+    The two bodies differ only in members (mallory vs trent), so a successful
+    takeover would be observable as the cache flipping to the second body. The
+    SAME message_id forces the second through the dedupe-conflict branch BEFORE
+    the cache write — proving the write does not precede the conflict detection.
+    """
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        room_id = "room-race"
+        leader = "nodeM"  # the (single) leader peer for this room
+        # The member chose this room+leader locally (first-roster binding).
+        rooms.record_local_join_intent(
+            conn, room_id, "self", "nodeSelf", leader_node=leader)
+        members_a = [{"agent": "mallory", "node": "nodeM", "role": "leader"}]
+        members_b = [{"agent": "trent", "node": "nodeM", "role": "leader"}]
+        mid = "nodeM:race-X"
+
+        # Delivery 1: (peer=nodeM, id=race-X, bodyA) → first-bind ACCEPTED.
+        out1 = _accept(conn, room_id=room_id, room_epoch=1, members=members_a,
+                       leader_node=leader, peer_id=leader, mid=mid)
+        print(f"first_accept={out1}")
+        # Delivery 2: SAME (peer, id) but DIFFERENT body (bodyB) at a HIGHER
+        # epoch — would otherwise pass leader-pin + monotonic-epoch and WRITE.
+        # The atomic dedupe reservation must catch it as a CONFLICT FIRST, with
+        # NO cache mutation.
+        out2 = _accept(conn, room_id=room_id, room_epoch=2, members=members_b,
+                       leader_node=leader, peer_id=leader, mid=mid)
+        cache = rooms.get_roster_cache(conn, room_id)
+        print(f"reuse_diff_body={out2}:epoch={cache['epoch']}:"
+              f"has_mallory={'mallory' in cache['members_json']}:"
+              f"has_trent={'trent' in cache['members_json']}")
+        # Delivery 3: a byte-identical replay of delivery 1 → idempotent DUPLICATE
+        # (no double-apply), cache unchanged.
+        out3 = _accept(conn, room_id=room_id, room_epoch=1, members=members_a,
+                       leader_node=leader, peer_id=leader, mid=mid)
+        print(f"replay_same_body={out3}")
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_duplicate_burns_id_unit(db: str) -> int:
+    """Drive the DUPLICATE-branch id-burn contract (codex P4.2 r3 deeper edge).
+
+    The byte-identical-existing-cache ROSTER_DUPLICATE branch MUST still reserve
+    the (peer, message_id) in the dedupe ledger, so a LATER same-id/DIFFERENT-body
+    reuse is a CONFLICT (not a fresh accept). Sequence (one line per case):
+      1. accept (peer, idX, bodyA, epoch 1) → ACCEPTED (first-bind).
+      2. deliver a byte-identical roster under a NEW id idY (same bytes/epoch) →
+         the cache already matches → DUPLICATE branch → MUST burn idY.
+      3. assert a dedupe row for idY now EXISTS (the id was burned).
+      4. deliver (peer, SAME idY, DIFFERENT body bodyB naming rogue 'trent',
+         HIGHER epoch, would otherwise pass leader-pin + monotonic-epoch) →
+         MUST be ROSTER_DEDUPE_CONFLICT, cache epoch unchanged, no 'trent'.
+    """
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        room_id = "room-dupburn"
+        leader = "nodeM"
+        rooms.record_local_join_intent(
+            conn, room_id, "self", "nodeSelf", leader_node=leader)
+        members_a = [{"agent": "mallory", "node": "nodeM", "role": "leader"}]
+        members_b = [{"agent": "trent", "node": "nodeM", "role": "leader"}]
+        id_x = "nodeM:burn-X"
+        id_y = "nodeM:burn-Y"
+
+        out1 = _accept(conn, room_id=room_id, room_epoch=1, members=members_a,
+                       leader_node=leader, peer_id=leader, mid=id_x)
+        print(f"first_accept={out1}")
+        # Byte-identical roster under a DIFFERENT id → reaches the DUPLICATE
+        # branch (cache already matches) → must BURN id_y.
+        out2 = _accept(conn, room_id=room_id, room_epoch=1, members=members_a,
+                       leader_node=leader, peer_id=leader, mid=id_y)
+        burned = conn.execute(
+            "SELECT 1 FROM room_join_dedupe WHERE peer=? AND message_id=?",
+            (leader, id_y)).fetchone() is not None
+        print(f"same_state_reuse_id={out2}:dedupe_after_same_state={burned}")
+        # Later: SAME id_y, DIFFERENT body, HIGHER epoch → must be CONFLICT.
+        out3 = _accept(conn, room_id=room_id, room_epoch=2, members=members_b,
+                       leader_node=leader, peer_id=leader, mid=id_y)
+        cache = rooms.get_roster_cache(conn, room_id)
+        print(f"later_same_id_diff_body={out3}:cache_epoch={cache['epoch']}:"
+              f"has_trent={'trent' in cache['members_json']}")
+    finally:
+        conn.close()
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: rooms-p4-2-roster-broadcast-helper.py <subcommand> [args]",
+              file=sys.stderr)
+        return 2
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "post-hook":
+        return cmd_post_hook(rest[0])
+    if cmd == "captured-field":
+        return cmd_captured_field(rest[0], rest[1])
+    if cmd == "deliver-roster-to-receiver":
+        return cmd_deliver_roster_to_receiver(
+            rest[0], rest[1], rest[2], rest[3] if len(rest) > 3 else "{}")
+    if cmd == "make-config":
+        return cmd_make_config(rest[0], rest[1], rest[2], rest[3], rest[4])
+    if cmd == "make-member-db":
+        return cmd_make_member_db(
+            rest[0], rest[1], rest[2],
+            rest[3] if len(rest) > 3 else "bob",
+            rest[4] if len(rest) > 4 else "nodeB")
+    if cmd == "cache-rows":
+        return cmd_cache_rows(rest[0], rest[1] if len(rest) > 1 else "")
+    if cmd == "set-cache-epoch":
+        return cmd_set_cache_epoch(rest[0], rest[1], rest[2])
+    if cmd == "cross-approve-gate":
+        return cmd_cross_approve_gate(rest[0])
+    if cmd == "local-add-no-gate":
+        return cmd_local_add_no_gate(rest[0])
+    if cmd == "member-accept-unit":
+        return cmd_member_accept_unit(rest[0])
+    if cmd == "empty-leader-takeover-unit":
+        return cmd_empty_leader_takeover_unit(rest[0])
+    if cmd == "dedupe-race-unit":
+        return cmd_dedupe_race_unit(rest[0])
+    if cmd == "duplicate-burns-id-unit":
+        return cmd_duplicate_burns_id_unit(rest[0])
+    if cmd == "db-contains":
+        return cmd_db_contains(rest[0], rest[1])
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/smoke/rooms-p4-2-roster-broadcast.sh
+++ b/scripts/smoke/rooms-p4-2-roster-broadcast.sh
@@ -1,0 +1,601 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-2-roster-broadcast.sh — A2A Rooms P4.2 leader APPROVE +
+# roster broadcast.
+#
+# Exercises the SECOND cross-node rooms phase (design docs/design/
+# a2a-rooms-design.md §6 / §11 / §14 R2): on a cross-node `room approve`, the
+# leader (node A) admits the member (REQUIRING a P4.1 verified pending row),
+# bumps the epoch, and broadcasts the leader-signed canonical roster to every
+# member node over the node-link; each member persists it to room_roster_cache.
+# The transport is STUBBED end-to-end (no real Tailscale / live socket): the
+# leader's broadcast POST is captured by the paired-flag test hook, then replayed
+# through the REAL member-side receiver handler.
+#
+# THE 7 REQUIRED TEETH (each proven below):
+#   T1  A cross-approve with NO matching verified pending row is refused (no
+#       membership add) — and the LOCAL leader-add path still admits a local
+#       agent WITHOUT claiming that gate (the two paths stay distinct).
+#   T2  A roster_broadcast from a NON-LEADER authenticated peer is rejected +
+#       persists nothing.
+#   T3  A roster with an INVALID pairwise HMAC is rejected (401, no persist).
+#   T4  A member with NO local pending/approved state for the room REJECTS a
+#       FIRST roster (rogue-leader minting prevented).
+#   T5  A lower-or-same epoch is ignored; a strictly-higher epoch updates; a
+#       byte-identical dup is idempotent.
+#   T6  The cache update is ATOMIC (an existing roster is never left partial; a
+#       rejected update leaves the PRIOR roster, not a half-written one).
+#   T7  The local-leader-add path still works for a LOCAL agent without claiming
+#       the token gate (no P4.1 regression).
+
+set -euo pipefail
+
+SMOKE_NAME="rooms-p4-2-roster-broadcast"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+HELPER="$SCRIPT_DIR/rooms-p4-2-roster-broadcast-helper.py"
+P41_HELPER="$SCRIPT_DIR/rooms-p4-1-cross-node-join-helper.py"
+POST_HOOK="$SCRIPT_DIR/rooms-p4-2-post-hook.sh"
+ROOMS_CLI="$SMOKE_REPO_ROOT/bridge-rooms.py"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+# The leader's rooms.db (node A) lives under the isolated state dir.
+export BRIDGE_A2A_ROOMS_DB="$BRIDGE_STATE_DIR/handoff/rooms.db"
+mkdir -p "$BRIDGE_STATE_DIR/handoff"
+
+NODE_A="nodeA"   # leader node
+NODE_B="nodeB"   # member node (the joiner)
+SECRET="test-pair-secret-aaaaaaaaaaaaaaaaaaaa"
+ADDR="127.0.0.1"
+
+# Node-A (leader) config: bridge_id=nodeA, peer nodeB. Used by `room create` /
+# `room approve` (the broadcast sender) and (for the join capture) the receiver.
+CFG_A="$SMOKE_TMP_ROOT/handoff-A.json"
+python3 "$HELPER" make-config "$CFG_A" "$NODE_A" "$NODE_B" "$SECRET" "$ADDR" >/dev/null
+CFG_A_JSON="$(cat "$CFG_A")"
+
+# Node-B (member) config: bridge_id=nodeB, peer nodeA. Used by the member-side
+# receiver replay (it must trust nodeA as the leader peer).
+CFG_B="$SMOKE_TMP_ROOT/handoff-B.json"
+python3 "$HELPER" make-config "$CFG_B" "$NODE_B" "$NODE_A" "$SECRET" "$ADDR" >/dev/null
+CFG_B_JSON="$(cat "$CFG_B")"
+
+# The member-local rooms.db (node B's own db) — the receiver writes its cache
+# here. Distinct from the leader's db.
+MEMBER_DB="$SMOKE_TMP_ROOT/member-rooms.db"
+
+CAPTURE="$SMOKE_TMP_ROOT/captured-roster.json"
+JOIN_CAPTURE="$SMOKE_TMP_ROOT/captured-join.json"
+
+# Paired test-seam flags (gate the OS-user override AND the POST hook). Set
+# INLINE per-invocation, never exported, so nothing leaks.
+TEST_FLAGS=("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1" "BRIDGE_A2A_ALLOW_TEST_BIND=1")
+
+json_field() { python3 "$SCRIPT_DIR/a2a-rooms-p1a-helper.py" json-field "$1" "$2"; }
+
+# room_create_as <agent> — create a room led by iso-user agent-bridge-<a> on
+# node A. Echoes the JSON.
+room_create_as() {
+  local who="$1"
+  env "${TEST_FLAGS[@]}" "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+    python3 "$ROOMS_CLI" create --name team --json 2>/dev/null
+}
+
+# Post a P4.1 cross-node join from node B → capture it → replay into the leader's
+# node-A receiver so a VERIFIED pending row exists for the approve gate.
+seed_verified_join() {
+  local who="$1" link="$2"
+  : >"$JOIN_CAPTURE" || true
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_B" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$SCRIPT_DIR/rooms-p4-1-post-hook.sh" \
+      "CAPTURE_FILE=$JOIN_CAPTURE" \
+    python3 "$ROOMS_CLI" join "$link" >/dev/null 2>&1 \
+    || smoke_fail "P4.1 cross-node join (sender) should succeed against the stub"
+  # Replay the join into the leader-node-A receiver → 200 pending (verified row).
+  python3 "$P41_HELPER" deliver-to-receiver "$SMOKE_REPO_ROOT" "$CFG_A_JSON" \
+    "$JOIN_CAPTURE" "{}" >/dev/null
+}
+
+# approve_as <agent> <room> <target> — run `room approve` as iso-user
+# agent-bridge-<a> on node A, with the roster-broadcast POST hook capturing the
+# signed broadcast to $CAPTURE. Echoes the CLI JSON output.
+approve_as() {
+  local who="$1" room="$2" target="$3"
+  : >"$CAPTURE" || true
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$POST_HOOK" \
+      "CAPTURE_FILE=$CAPTURE" \
+    python3 "$ROOMS_CLI" approve "$room" "$target" --json 2>/dev/null
+}
+
+# deliver_roster <member_cfg_json> <overrides_json> — replay $CAPTURE through the
+# REAL member-side receiver, writing the member-local cache into $MEMBER_DB.
+deliver_roster() {
+  local cfg_json="$1" overrides="${2:-}"
+  [[ -n "$overrides" ]] || overrides='{}'
+  env "BRIDGE_A2A_ROOMS_DB=$MEMBER_DB" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$cfg_json" "$CAPTURE" "$overrides"
+}
+
+ROOM=""
+LINK=""
+
+# ---------------------------------------------------------------------------
+# setup: a room on node A + a verified pending join from node B + the approve
+# that captures the leader-signed roster broadcast.
+# ---------------------------------------------------------------------------
+test_setup_room_join_approve_capture() {
+  local out
+  out="$(room_create_as alice)"
+  ROOM="$(json_field room_id "$out")"
+  LINK="$(json_field invite_link "$out")"
+  [[ -n "$ROOM" && -n "$LINK" ]] || smoke_fail "room create did not yield room/link"
+
+  # A P4.1 verified pending row for bob@nodeB so the cross-approve gate is met.
+  seed_verified_join bob "$LINK"
+
+  # The leader approves the cross-node member → broadcast captured.
+  local ap
+  ap="$(approve_as alice "$ROOM" "bob@$NODE_B")"
+  smoke_assert_contains "$ap" "\"cross_node\": true" "approve recognized a cross-node admit"
+  smoke_assert_file_exists "$CAPTURE" "the leader-signed roster broadcast was captured"
+
+  # The captured broadcast targets nodeB with the canonical roster + leader_node.
+  local proto leader_node room_in_body
+  proto="$(python3 "$HELPER" captured-field "$CAPTURE" "header:X-AGB-Protocol")"
+  smoke_assert_eq "a2a-room-roster-v1" "$proto" "broadcast carries the roster protocol tag"
+  leader_node="$(python3 "$HELPER" captured-field "$CAPTURE" "body:leader_node")"
+  smoke_assert_eq "$NODE_A" "$leader_node" "broadcast body names nodeA as leader_node"
+  room_in_body="$(python3 "$HELPER" captured-field "$CAPTURE" "body:room_id")"
+  smoke_assert_eq "$ROOM" "$room_in_body" "broadcast body carries the room id"
+}
+
+# ---------------------------------------------------------------------------
+# positive: a member with a local binding accepts the broadcast → cache written
+# ---------------------------------------------------------------------------
+test_member_accepts_first_roster_with_binding() {
+  # Seed the member-local binding (its OWN outbound join intent) so the first
+  # roster is acceptable (NOT minted from the inbound broadcast alone).
+  python3 "$HELPER" make-member-db "$MEMBER_DB" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  local res
+  res="$(deliver_roster "$CFG_B_JSON")"
+  smoke_assert_contains "$res" "status=200" "member accepts the leader roster (200)"
+  smoke_assert_contains "$res" "\"applied\": true" "the roster cache was applied"
+  local rows
+  rows="$(python3 "$HELPER" cache-rows "$MEMBER_DB" "$ROOM")"
+  smoke_assert_contains "$rows" "\"from_node\": \"$NODE_A\"" "cache records the leader node as source"
+  smoke_assert_contains "$rows" "bob" "cache roster contains the admitted member bob"
+  smoke_assert_contains "$rows" "alice" "cache roster contains the leader alice"
+}
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end: the REAL `room join` records the FIRST-ROSTER binding (driven
+# off the leader's pending ack), which then lets the member accept the leader's
+# first roster — proving the binding is not a test-only seed.
+# ---------------------------------------------------------------------------
+test_cli_join_records_binding_then_accepts() {
+  local mdb="$SMOKE_TMP_ROOT/member-cli.db"
+  # Run the REAL member-side cross-node `room join` (post stubbed). The stub
+  # returns a pending ack for a room-join post, so cmd_join records the local
+  # binding into the member's OWN rooms.db ($mdb).
+  : >"$JOIN_CAPTURE" || true
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-bob" \
+      "BRIDGE_A2A_CONFIG=$CFG_B" \
+      "BRIDGE_A2A_ROOMS_DB=$mdb" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$POST_HOOK" \
+      "CAPTURE_FILE=$JOIN_CAPTURE" \
+    python3 "$ROOMS_CLI" join "$LINK" >/dev/null 2>&1 \
+    || smoke_fail "member-side cross-node join (CLI) should succeed against the stub"
+  # The CLI recorded a local pending-intent row naming nodeA as the leader.
+  local rows
+  rows="$(python3 "$P41_HELPER" pending-rows "$mdb" "$ROOM")"
+  smoke_assert_contains "$rows" "\"via_node\": \"$NODE_A\"" \
+    "CLI join recorded a local binding naming the leader node"
+  # That binding now lets the member accept the leader's FIRST roster broadcast.
+  local res
+  res="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$res" "status=200" "CLI-bound member accepts the first roster (200)"
+  smoke_assert_contains "$res" "\"applied\": true" "the roster cache was applied for the CLI-bound member"
+}
+
+# ---------------------------------------------------------------------------
+# T1: a cross-approve with NO verified pending row is refused (no add); plus the
+# local-add path admits a local agent with no such requirement (distinct paths).
+# ---------------------------------------------------------------------------
+test_T1_cross_approve_requires_verified_pending() {
+  local gdb="$SMOKE_TMP_ROOT/gate.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" cross-approve-gate "$gdb" 2>&1)" \
+    || smoke_fail "cross-approve-gate helper must not raise: $out"
+  smoke_assert_contains "$out" "no_row=refused:no_verified_request" \
+    "T1: a cross-approve with NO pending row is refused"
+  smoke_assert_contains "$out" "unverified_row=refused:no_verified_request" \
+    "T1: a cross-approve with an UNVERIFIED (local) pending row is refused"
+  smoke_assert_contains "$out" "verified_row=admitted:" \
+    "T1: a cross-approve WITH a verified pending row admits the member"
+  smoke_assert_contains "$out" "member=True" "T1: the verified member is actually added"
+  smoke_assert_contains "$out" "carl_member=False" \
+    "T1: no unverified agent was admitted as a side effect"
+}
+
+# ---------------------------------------------------------------------------
+# T2: a roster_broadcast from a NON-LEADER authenticated peer is rejected.
+# ---------------------------------------------------------------------------
+test_T2_non_leader_peer_rejected() {
+  # A fresh member db with a binding to the leader nodeA, but deliver the
+  # broadcast over a config where the authenticated peer is nodeC (NOT the
+  # room's leader_node nodeA). The receiver must reject + persist nothing.
+  local mdb="$SMOKE_TMP_ROOT/member-t2.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  # nodeC config: the member trusts nodeC as a peer (so HMAC/addr pass), but the
+  # captured broadcast was signed by nodeA. We re-sign as nodeC so the HMAC gate
+  # passes and the test reaches the leader-authority contract (peer != leader).
+  local cfg_c="$SMOKE_TMP_ROOT/handoff-Cmember.json"
+  python3 "$HELPER" make-config "$cfg_c" "$NODE_B" "nodeC" "$SECRET" "$ADDR" >/dev/null
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$(cat "$cfg_c")" "$CAPTURE" \
+      '{"headers":{"X-AGB-Peer":"nodeC"},"resign":true}')"
+  smoke_assert_contains "$res" "status=403" "T2: a non-leader peer roster is 403"
+  smoke_assert_contains "$res" "not the room leader" "T2: refusal reason is non-leader"
+  local rows
+  rows="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "" "$rows" "T2: a non-leader roster persists NOTHING"
+}
+
+# ---------------------------------------------------------------------------
+# T3: a roster with an INVALID pairwise HMAC is rejected (401, no persist).
+# ---------------------------------------------------------------------------
+test_T3_invalid_hmac_rejected() {
+  local mdb="$SMOKE_TMP_ROOT/member-t3.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" \
+      '{"headers":{"X-AGB-Signature":"v1=deadbeefdeadbeef"}}')"
+  smoke_assert_contains "$res" "status=401" "T3: a bad pairwise HMAC is 401 (auth gate intact)"
+  local rows
+  rows="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "" "$rows" "T3: an HMAC-rejected roster persists NOTHING"
+}
+
+# ---------------------------------------------------------------------------
+# T4: a member with NO local binding REJECTS a FIRST roster (rogue-leader mint).
+# ---------------------------------------------------------------------------
+test_T4_first_roster_without_binding_refused() {
+  # A member db that has NEVER recorded a local join intent for $ROOM. Even a
+  # perfectly-signed roster from the real leader nodeA must be refused — the
+  # member never chose this room, so accepting would let a configured peer mint
+  # a rogue-leader room cache.
+  local mdb="$SMOKE_TMP_ROOT/member-nobind.db"
+  # Create the db but with a binding for a DIFFERENT room only, to prove the
+  # binding is room-specific (not a blanket "any local row").
+  python3 "$HELPER" make-member-db "$mdb" "room-other" "$NODE_A" bob "$NODE_B" >/dev/null
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE")"
+  smoke_assert_contains "$res" "status=403" "T4: a first roster with no local binding is 403"
+  smoke_assert_contains "$res" "no local join state" "T4: refusal cites the missing local binding"
+  local rows
+  rows="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "" "$rows" "T4: NO roster cache minted from the inbound broadcast"
+}
+
+# ---------------------------------------------------------------------------
+# T5: epoch monotonicity (lower/same ignored, higher updates, identical dup).
+# Unit-driven across the full contract surface for determinism.
+# ---------------------------------------------------------------------------
+test_T5_epoch_monotonicity() {
+  local udb="$SMOKE_TMP_ROOT/accept-unit.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" member-accept-unit "$udb" 2>&1)" \
+    || smoke_fail "member-accept-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "first_bind=accepted:epoch=2" \
+    "T5: a first bound roster is accepted at its epoch"
+  smoke_assert_contains "$out" "higher_epoch=accepted:epoch=3:has_carol=True" \
+    "T5: a strictly-higher epoch UPDATES the cache"
+  smoke_assert_contains "$out" "lower_epoch=stale_epoch:epoch=3:still_carol=True" \
+    "T5: a LOWER epoch is IGNORED (cache unchanged)"
+  smoke_assert_contains "$out" "same_epoch_diff=stale_epoch:still_carol=True" \
+    "T5: a SAME epoch with DIFFERENT members is IGNORED (forge/replay defense)"
+  smoke_assert_contains "$out" "idempotent_dup=duplicate" \
+    "T5: a byte-identical re-broadcast is an idempotent duplicate"
+  # Leader-pinning: a higher-epoch self-claim by a DIFFERENT peer is refused.
+  smoke_assert_contains "$out" "takeover=leader_mismatch:from_node=nodeA:epoch=3:has_mallory=False" \
+    "T5/pinning: a higher-epoch leader-TAKEOVER by a different peer is refused (cache stays pinned to nodeA)"
+}
+
+# ---------------------------------------------------------------------------
+# T2b (codex P4.2 r1 BLOCKING): leader-TAKEOVER of an EXISTING cache through the
+# REAL receiver. A configured peer nodeC self-claims leadership (leader_node=
+# nodeC, peer=nodeC, valid pairwise HMAC) at a HIGHER epoch against a member
+# whose cache for $ROOM is already pinned to nodeA → 403, no cache mutation.
+# ---------------------------------------------------------------------------
+test_T2b_existing_cache_leader_takeover_refused() {
+  local mdb="$SMOKE_TMP_ROOT/member-takeover.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  # Establish the legitimate nodeA cache first (the captured leader broadcast).
+  local first
+  first="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$first" "status=200" "T2b setup: the legitimate nodeA roster is cached"
+  local before
+  before="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  # nodeC self-claims leadership at a higher epoch, signed with a secret nodeC
+  # shares with this member. Build a rogue roster body + a member cfg that trusts
+  # nodeC, re-sign as nodeC so the HMAC gate passes and we reach the pin check.
+  local cfg_c="$SMOKE_TMP_ROOT/handoff-takeover.json"
+  python3 "$HELPER" make-config "$cfg_c" "$NODE_B" "nodeC" "$SECRET" "$ADDR" >/dev/null
+  local rogue_body
+  rogue_body='{"protocol":"agent-bridge.a2a.room-roster.v1","room_id":"'"$ROOM"'","room_epoch":99,"members":[{"agent":"mallory","node":"nodeC","role":"leader"}],"leader_node":"nodeC"}'
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$(cat "$cfg_c")" "$CAPTURE" \
+      '{"headers":{"X-AGB-Peer":"nodeC"},"body":'"$(python3 -c "import json,sys;print(json.dumps(sys.argv[1]))" "$rogue_body")"',"resign":true}')"
+  smoke_assert_contains "$res" "status=403" "T2b: a higher-epoch leader-takeover by nodeC is 403"
+  smoke_assert_contains "$res" "takeover refused" "T2b: refusal cites the takeover"
+  local after
+  after="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "$before" "$after" "T2b: the takeover left the nodeA cache byte-for-byte unchanged"
+  smoke_assert_not_contains "$after" "mallory" "T2b: no rogue member entered the cache"
+}
+
+# ---------------------------------------------------------------------------
+# T2c (codex P4.2 r2 BLOCKING): a SINGLE-NODE / local room whose cache from_node
+# is EMPTY (leader_node="") cannot be taken over by a remote peer self-claiming
+# leadership at a higher epoch — the leader pin rejects even an empty cached
+# leader (no truthiness guard).
+# ---------------------------------------------------------------------------
+test_T2c_empty_leader_takeover_refused() {
+  local edb="$SMOKE_TMP_ROOT/empty-leader.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" empty-leader-takeover-unit "$edb" 2>&1)" \
+    || smoke_fail "empty-leader-takeover-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "empty_takeover=leader_mismatch:from_node='':epoch=0:unchanged=True:has_mallory=False" \
+    "T2c: a remote higher-epoch self-claim against an empty-leader local cache is refused (unchanged)"
+}
+
+# ---------------------------------------------------------------------------
+# T6: the cache update is ATOMIC — a rejected update over an EXISTING roster
+# leaves the PRIOR roster intact, never a partial/half-written one.
+# ---------------------------------------------------------------------------
+test_T6_atomic_no_partial_roster() {
+  # Start from the positive-path member db (it holds an applied roster for $ROOM
+  # at the approved epoch with bob present). Capture its current state.
+  local before after
+  before="$(python3 "$HELPER" cache-rows "$MEMBER_DB" "$ROOM")"
+  [[ -n "$before" ]] || smoke_fail "T6 precondition: an existing cache row is required"
+  # Deliver a roster that will be REJECTED downstream of the cache (a non-leader
+  # peer) — the existing roster must be untouched (no partial write).
+  local cfg_c="$SMOKE_TMP_ROOT/handoff-Cmember2.json"
+  python3 "$HELPER" make-config "$cfg_c" "$NODE_B" "nodeC" "$SECRET" "$ADDR" >/dev/null
+  env "BRIDGE_A2A_ROOMS_DB=$MEMBER_DB" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$(cat "$cfg_c")" "$CAPTURE" \
+      '{"headers":{"X-AGB-Peer":"nodeC"},"resign":true}' >/dev/null
+  after="$(python3 "$HELPER" cache-rows "$MEMBER_DB" "$ROOM")"
+  smoke_assert_eq "$before" "$after" \
+    "T6: a rejected roster left the PRIOR cache byte-for-byte unchanged (atomic)"
+  # Also a stale-epoch update must not partially mutate the existing roster.
+  python3 "$HELPER" set-cache-epoch "$MEMBER_DB" "$ROOM" 99 >/dev/null
+  local hi
+  hi="$(python3 "$HELPER" cache-rows "$MEMBER_DB" "$ROOM")"
+  env "BRIDGE_A2A_ROOMS_DB=$MEMBER_DB" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" >/dev/null
+  local hi_after
+  hi_after="$(python3 "$HELPER" cache-rows "$MEMBER_DB" "$ROOM")"
+  smoke_assert_eq "$hi" "$hi_after" \
+    "T6: a stale-epoch broadcast left the higher-epoch cache intact (no partial write)"
+}
+
+# ---------------------------------------------------------------------------
+# T7: the local-leader-add path admits a LOCAL agent WITHOUT the token gate
+# (no P4.1 regression — the two approve paths stay distinct).
+# ---------------------------------------------------------------------------
+test_T7_local_add_no_token_gate() {
+  local ldb="$SMOKE_TMP_ROOT/local-add.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" local-add-no-gate "$ldb" 2>&1)" \
+    || smoke_fail "local-add-no-gate helper must not raise: $out"
+  smoke_assert_contains "$out" "local_add=admitted:" \
+    "T7: the LOCAL leader-add path admits a local agent with NO verified row"
+  smoke_assert_contains "$out" "member=True" "T7: the locally-added agent is a member"
+  smoke_assert_contains "$out" "cross_path_for_local=refused:no_verified_request" \
+    "T7: the cross-node path STILL requires a verified row (the paths are distinct)"
+}
+
+# ---------------------------------------------------------------------------
+# T8 (codex P4.2 r3 BLOCKING — TOCTOU dedupe/cache race): a same-(peer,
+# message_id) / DIFFERENT-body roster MUST be rejected (409 / conflict) with NO
+# cache mutation — the dedupe reservation + cache write are ONE atomic txn, so
+# the conflict is detected BEFORE any write. Driven two ways: a unit driver
+# (proves the atomic helper's conflict branch + no-write) and end-to-end through
+# the REAL receiver.
+# ---------------------------------------------------------------------------
+test_T8a_dedupe_race_unit() {
+  local rdb="$SMOKE_TMP_ROOT/dedupe-race.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" dedupe-race-unit "$rdb" 2>&1)" \
+    || smoke_fail "dedupe-race-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "first_accept=accepted" \
+    "T8a: the first delivery (peer,id,bodyA) is accepted"
+  smoke_assert_contains "$out" "reuse_diff_body=dedupe_conflict:epoch=1:has_mallory=True:has_trent=False" \
+    "T8a: a same-(peer,id)/DIFFERENT-body delivery is a CONFLICT with NO cache write (cache keeps bodyA)"
+  smoke_assert_contains "$out" "replay_same_body=duplicate" \
+    "T8a: a byte-identical replay of the first is an idempotent duplicate (no double-apply)"
+}
+
+test_T8b_dedupe_race_end_to_end() {
+  # Establish bodyA at the captured message_id through the REAL receiver, then
+  # re-deliver the SAME message_id with a DIFFERENT (validly-signed) body → the
+  # receiver MUST answer 409 and the cache MUST still hold bodyA (not bodyB).
+  local mdb="$SMOKE_TMP_ROOT/member-race-e2e.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  local first
+  first="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$first" "status=200" "T8b setup: bodyA accepted at the captured message_id"
+  local before
+  before="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  # A DIFFERENT body (adds a rogue member) under the SAME captured message_id,
+  # re-signed by the legit leader nodeA so the HMAC gate passes and the dedupe
+  # conflict is what stops it (NOT the signature gate).
+  local rogue_body
+  rogue_body='{"protocol":"agent-bridge.a2a.room-roster.v1","room_id":"'"$ROOM"'","room_epoch":50,"members":[{"agent":"trent","node":"'"$NODE_A"'","role":"member"}],"leader_node":"'"$NODE_A"'"}'
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" \
+      '{"body":'"$(python3 -c "import json,sys;print(json.dumps(sys.argv[1]))" "$rogue_body")"',"resign":true}')"
+  smoke_assert_contains "$res" "status=409" "T8b: a same-id/different-body roster is a 409 conflict"
+  local after
+  after="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "$before" "$after" "T8b: the conflicting delivery left the cache byte-for-byte unchanged (bodyA)"
+  smoke_assert_not_contains "$after" "trent" "T8b: the rogue different-body did NOT enter the cache (no pre-write race)"
+}
+
+# ---------------------------------------------------------------------------
+# T9 (codex P4.2 r3 deeper edge — the DUPLICATE branch must BURN the id): a
+# byte-identical same-state ROSTER_DUPLICATE that does NOT reserve the
+# (peer, message_id) would let a LATER same-id/DIFFERENT-body reuse be ACCEPTED.
+# Driven two ways: a unit driver (proves the reserve-only path + the later
+# conflict) and end-to-end through the REAL receiver.
+# ---------------------------------------------------------------------------
+test_T9a_duplicate_burns_id_unit() {
+  local ddb="$SMOKE_TMP_ROOT/dup-burn.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" duplicate-burns-id-unit "$ddb" 2>&1)" \
+    || smoke_fail "duplicate-burns-id-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "first_accept=accepted" \
+    "T9a: the first delivery is accepted"
+  smoke_assert_contains "$out" "same_state_reuse_id=duplicate:dedupe_after_same_state=True" \
+    "T9a: a same-state DUPLICATE under a new id STILL burns that id (dedupe row created)"
+  smoke_assert_contains "$out" "later_same_id_diff_body=dedupe_conflict:cache_epoch=1:has_trent=False" \
+    "T9a: a LATER same-id/diff-body reuse is a CONFLICT (not accepted); cache unchanged, no rogue member"
+}
+
+test_T9b_duplicate_burns_id_end_to_end() {
+  # Through the REAL receiver: establish bodyA at a DEDICATED new id (so the
+  # delivery reaches the DUPLICATE branch, not the captured-id path), confirm a
+  # same-state replay under that id is a duplicate, then a same-id/different-body
+  # reuse is a 409 with the cache untouched.
+  local mdb="$SMOKE_TMP_ROOT/member-dupburn-e2e.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  # 1) bodyA at the captured id → ACCEPTED (seeds the cache).
+  local d1
+  d1="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$d1" "status=200" "T9b setup: bodyA accepted (cache seeded)"
+  # 2) the SAME bodyA bytes under a NEW message id idY → reaches the DUPLICATE
+  # branch (cache already matches) → 200 duplicate AND burns idY.
+  local idY="nodeA:dupburn-Y"
+  local d2
+  d2="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" \
+      '{"headers":{"X-AGB-Message-Id":"'"$idY"'"},"resign":true}')"
+  smoke_assert_contains "$d2" "status=200" "T9b: a same-state roster under a new id is 200"
+  smoke_assert_contains "$d2" "\"duplicate\": true" "T9b: it is flagged a duplicate"
+  local before
+  before="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  # 3) the SAME idY but a DIFFERENT (validly-signed) body naming rogue 'trent',
+  # HIGHER epoch → MUST be 409 (the id was burned by step 2), cache untouched.
+  local rogue_body
+  rogue_body='{"protocol":"agent-bridge.a2a.room-roster.v1","room_id":"'"$ROOM"'","room_epoch":77,"members":[{"agent":"trent","node":"'"$NODE_A"'","role":"member"}],"leader_node":"'"$NODE_A"'"}'
+  local d3
+  d3="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" \
+      '{"headers":{"X-AGB-Message-Id":"'"$idY"'"},"body":'"$(python3 -c "import json,sys;print(json.dumps(sys.argv[1]))" "$rogue_body")"',"resign":true}')"
+  smoke_assert_contains "$d3" "status=409" "T9b: a later same-id/diff-body reuse is a 409 (the duplicate burned the id)"
+  local after
+  after="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "$before" "$after" "T9b: the conflicting reuse left the cache byte-for-byte unchanged"
+  smoke_assert_not_contains "$after" "trent" "T9b: no rogue member entered the cache after the duplicate"
+}
+
+# ---------------------------------------------------------------------------
+# auth preamble teeth: unknown peer / wrong source addr are refused (unweakened)
+# ---------------------------------------------------------------------------
+test_auth_preamble_unweakened() {
+  local mdb="$SMOKE_TMP_ROOT/member-auth.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  # Wrong source address → 403 (remote_addr gate intact).
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" '{"client_ip":"10.9.9.9"}')"
+  smoke_assert_contains "$res" "status=403" "auth: a wrong source address is 403"
+  # Unknown peer → 403.
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" '{"headers":{"X-AGB-Peer":"nodeZ"}}')"
+  smoke_assert_contains "$res" "status=403" "auth: an unknown peer is 403"
+}
+
+# ---------------------------------------------------------------------------
+# idempotent re-delivery: a byte-identical broadcast replays as an idempotent
+# 200 duplicate (peer-scoped dedupe), the cache unchanged.
+# ---------------------------------------------------------------------------
+test_idempotent_redelivery() {
+  local mdb="$SMOKE_TMP_ROOT/member-idem.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  local first second
+  first="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$first" "status=200" "idem: first delivery is 200 applied"
+  smoke_assert_contains "$first" "\"applied\": true" "idem: first delivery applied the cache"
+  second="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$second" "status=200" "idem: a byte-identical re-delivery is 200"
+  smoke_assert_contains "$second" "\"duplicate\": true" "idem: the replay is flagged duplicate"
+}
+
+# deliver_roster_into <db> <cfg_json> [overrides]
+deliver_roster_into() {
+  local db="$1" cfg_json="$2" overrides="${3:-}"
+  [[ -n "$overrides" ]] || overrides='{}'
+  env "BRIDGE_A2A_ROOMS_DB=$db" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$cfg_json" "$CAPTURE" "$overrides"
+}
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+smoke_run "setup: room + verified join + cross-approve broadcast captured" test_setup_room_join_approve_capture
+smoke_run "positive: a member with a local binding accepts the first roster" test_member_accepts_first_roster_with_binding
+smoke_run "CLI end-to-end: real join records the binding -> member accepts first roster" test_cli_join_records_binding_then_accepts
+smoke_run "T1: cross-approve REQUIRES a verified pending row (no add otherwise)" test_T1_cross_approve_requires_verified_pending
+smoke_run "T2: a non-leader peer roster is rejected + persists nothing" test_T2_non_leader_peer_rejected
+smoke_run "T2b: a higher-epoch leader-TAKEOVER of an existing cache is refused" test_T2b_existing_cache_leader_takeover_refused
+smoke_run "T2c: a remote takeover of an empty-leader local cache is refused" test_T2c_empty_leader_takeover_refused
+smoke_run "T3: an invalid pairwise HMAC is rejected (401, no persist)" test_T3_invalid_hmac_rejected
+smoke_run "T4: a first roster with NO local binding is refused (rogue-leader mint prevented)" test_T4_first_roster_without_binding_refused
+smoke_run "T5: epoch monotonicity (lower/same ignored, higher updates, dup idempotent)" test_T5_epoch_monotonicity
+smoke_run "T6: the cache update is atomic (a rejected update leaves the prior roster)" test_T6_atomic_no_partial_roster
+smoke_run "T7: the local-leader-add path admits a local agent without the token gate" test_T7_local_add_no_token_gate
+smoke_run "T8a: dedupe/cache TOCTOU — same-id/diff-body is a conflict, no cache write (unit)" test_T8a_dedupe_race_unit
+smoke_run "T8b: dedupe/cache TOCTOU — same-id/diff-body is 409 + cache unchanged (end-to-end)" test_T8b_dedupe_race_end_to_end
+smoke_run "T9a: a same-state DUPLICATE burns the id — later same-id/diff-body is a conflict (unit)" test_T9a_duplicate_burns_id_unit
+smoke_run "T9b: a same-state DUPLICATE burns the id — later same-id/diff-body is 409 (end-to-end)" test_T9b_duplicate_burns_id_end_to_end
+smoke_run "auth preamble unweakened (remote_addr 403 / unknown peer 403)" test_auth_preamble_unweakened
+smoke_run "idempotent re-delivery: a byte-identical broadcast is an idempotent 200" test_idempotent_redelivery
+
+smoke_log "passed"

--- a/scripts/smoke/rooms-p4-3-post-hook.sh
+++ b/scripts/smoke/rooms-p4-3-post-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-3-post-hook.sh — BRIDGE_ROOMS_TEST_POST_HOOK target.
+#
+# The sender's `bridge-rooms.py talk` room-scoped enqueue test seam invokes this
+# with the signed request JSON as $1 (file-as-argv, never stdin — footgun #11).
+# We delegate to the helper's `post-hook` subcommand, which writes the captured
+# request to $CAPTURE_FILE and echoes a stub response body. Kept as a separate
+# executable so the CLI hook contract (`[hook, payload]`) is satisfied with a
+# real argv[0].
+set -euo pipefail
+HERE="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 "$HERE/rooms-p4-3-room-talk-helper.py" post-hook "$1"

--- a/scripts/smoke/rooms-p4-3-room-talk-helper.py
+++ b/scripts/smoke/rooms-p4-3-room-talk-helper.py
@@ -282,7 +282,8 @@ def cmd_deliver_talk_to_receiver(repo_root: str, cfg_json: str, captured: str,
             "target": target, "sender_bridge": sender_bridge,
             "sender_agent": sender_agent, "priority": priority, "title": title,
         })
-        return True, "9999", "created task #9999"
+        # 4-tuple (ok, task_id, audit_detail, peer_detail) per P4.5.
+        return True, "9999", "created task #9999", "created task #9999"
 
     hd.enqueue_via_bridge_task = _fake_enqueue  # type: ignore[assignment]
 
@@ -509,7 +510,8 @@ def cmd_staged_race_unit(repo_root: str, cfg_a_json: str, cfg_b_json: str) -> in
         captured["sender_bridge"] = sender_bridge
         captured["sender_agent"] = sender_agent
         captured["body_file"] = str(body_file)
-        return True, "9999", "created task #9999"
+        # 4-tuple (ok, task_id, audit_detail, peer_detail) per P4.5.
+        return True, "9999", "created task #9999", "created task #9999"
 
     hd.enqueue_via_bridge_task = _racing_enqueue  # type: ignore[assignment]
 

--- a/scripts/smoke/rooms-p4-3-room-talk-helper.py
+++ b/scripts/smoke/rooms-p4-3-room-talk-helper.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""Helper for the rooms-p4-3-room-talk smoke (A2A Rooms P4.3).
+
+File-as-argv sidecar (never a heredoc-stdin — footgun #11). Imports the REAL
+rooms / a2a / handoffd modules from the repo root so the smoke exercises the
+canonical sender (`agb room talk` — OS-actor-anchored, cached-epoch stamp,
+room-scoped enqueue over the node-link), the canonical receiver (`do_POST`
+enqueue path → the fail-closed `room_scoped_check` leader-MAC roster-cache gate
+→ the dedupe ledger), and the canonical schema — WITHOUT a live socket or
+Tailscale.
+
+The transport is stubbed two ways (mirrors the P4.1/P4.2 helpers):
+  - SENDER side (`room talk`): the cross-node enqueue POST is captured by the
+    paired-flag test hook (BRIDGE_ROOMS_TEST_POST_HOOK → this script's
+    `post-hook`), which writes the fully-signed request to $CAPTURE_FILE.
+  - RECEIVER side: `deliver-talk-to-receiver` reconstructs a minimal fake HTTP
+    request from that captured file and drives the REAL `do_POST` handler, so
+    the actual auth preamble (protocol/peer/remote_addr/HMAC/skew/dedupe) + the
+    envelope parse + the room-scoped membership gate + the enqueue boundary all
+    run end to end. `enqueue_via_bridge_task` is monkeypatched to CAPTURE the
+    delivery (and avoid shelling out to bridge-task.sh / touching a live queue),
+    so a tooth can assert "delivered" vs "gated, never delivered".
+
+Subcommands (argv[1]):
+  post-hook <json>                 (BRIDGE_ROOMS_TEST_POST_HOOK target) — write
+                                   the signed request JSON to $CAPTURE_FILE and
+                                   echo a stub "{}" response.
+  captured-field <file> <key>      print headers[X-AGB-*] or body.<key>.
+  make-config <out> <this_node> <peer_node> <secret> <addr> [allowlist_csv]
+                                   write a minimal handoff config the receiver
+                                   loads (member node trusts the peer + allows
+                                   the talk targets).
+  seed-cache <db> <room_id> <epoch> <from_node> <members_csv>
+                                   write a leader-MAC roster cache row directly
+                                   (members_csv = agent@node[:role],... ).
+  deliver-talk-to-receiver <repo_root> <cfg_json> <captured_file> [overrides]
+                                   replay the captured room-scoped enqueue
+                                   through the REAL do_POST handler; print
+                                   "status=<n> delivered=<bool> body=<json>".
+  membership-unit <db>             unit-drive roster_cache_membership_check
+                                   across every tooth (member/non-member/epoch/
+                                   no-cache/target).
+  mutate-body <captured> <op> [arg]  print the captured envelope body JSON with
+                                   one mutation applied (drop-room-id /
+                                   drop-room-epoch / drop-both / set-sender-agent
+                                   <a> / set-body <text>); used to drive teeth
+                                   WITHOUT inline heredocs (heredoc-ban hygiene).
+  json-quote <text>                print <text> as a JSON string literal (for
+                                   embedding a mutated body into an overrides
+                                   JSON without a shell heredoc).
+  dedupe-isolation-unit <inbox_db> prove the inbox_dedupe ledger is scoped to
+                                   the authenticated peer (a second peer reusing
+                                   another peer's message_id does NOT collide).
+  migration-failclosed-unit <db>   prove open_inbox FAILS CLOSED (raises) if the
+                                   legacy->composite-PK migration did not take.
+  staged-race-unit <repo> <cfgA> <cfgB>  prove the staged body file is
+                                   peer-scoped: a competing same-message_id peer
+                                   cannot clobber the staged body the bridge-task
+                                   --body-file read returns.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import bridge_a2a_common as a2a  # noqa: E402
+import bridge_rooms_common as rooms  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# sender-side capture hook (invoked as BRIDGE_ROOMS_TEST_POST_HOOK)
+# ---------------------------------------------------------------------------
+def cmd_post_hook(payload_json: str) -> int:
+    """Write the captured signed request to $CAPTURE_FILE; stub a 200 body."""
+    capture = os.environ.get("CAPTURE_FILE")  # noqa: iso-helper-boundary - env var, not a .env file
+    if not capture:
+        print("CAPTURE_FILE unset", file=sys.stderr)
+        return 1
+    Path(capture).write_text(payload_json, encoding="utf-8")
+    override = os.environ.get("POST_HOOK_ACK")  # noqa: iso-helper-boundary - env var, not a .env file
+    if override is not None:
+        print(override)
+        return 0
+    print(json.dumps({"ok": True, "task_id": "stub"}))
+    return 0
+
+
+def cmd_captured_field(path: str, key: str) -> int:
+    doc = json.loads(Path(path).read_text(encoding="utf-8"))
+    if key.startswith("header:"):
+        val = doc.get("headers", {}).get(key[len("header:"):], "")
+    elif key.startswith("body:"):
+        body = json.loads(doc.get("body", "{}"))
+        val = body.get(key[len("body:"):], "")
+    elif key == "path":
+        val = doc.get("path", "")
+    else:
+        print(f"unknown captured key: {key}", file=sys.stderr)
+        return 1
+    if isinstance(val, (list, dict)):
+        print(json.dumps(val, separators=(",", ":")))
+    else:
+        print(val)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# config + cache helpers
+# ---------------------------------------------------------------------------
+def cmd_make_config(out_path: str, this_node: str, peer_node: str,
+                    peer_secret: str, address: str,
+                    allowlist_csv: str = "") -> int:
+    allowlist = [a for a in allowlist_csv.split(",") if a] if allowlist_csv else []
+    cfg = {
+        "bridge_id": this_node,
+        "listen": {"host": "127.0.0.1", "port": 8787,
+                   "enqueue_path": "/enqueue"},
+        "timestamp_skew_seconds": 300,
+        "timestamp_skew_grace_seconds": 3600,
+        "peers": [
+            {
+                "id": peer_node,
+                "address": address,
+                "secret": peer_secret,
+                "inbound_allowlist": allowlist,
+            }
+        ],
+    }
+    Path(out_path).write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    try:
+        os.chmod(out_path, 0o600)
+    except OSError:
+        pass
+    return 0
+
+
+def _parse_members_csv(members_csv: str) -> list:
+    members: list = []
+    for entry in members_csv.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        role = "member"
+        if ":" in entry:
+            entry, role = entry.rsplit(":", 1)
+        agent, _, node = entry.partition("@")
+        members.append({"agent": agent.strip(), "node": node.strip(),
+                        "role": role.strip() or "member"})
+    members.sort(key=lambda m: (m["agent"], m["node"]))
+    return members
+
+
+def cmd_seed_cache(db: str, room_id: str, epoch: str, from_node: str,
+                   members_csv: str) -> int:
+    """Seed a leader-MAC roster cache row directly (the P4.2 outcome).
+
+    Lets a P4.3 tooth set up the member-local cache the receiver gate reads,
+    WITHOUT re-running the whole P4.2 broadcast (covered by its own smoke)."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    members = _parse_members_csv(members_csv)
+    members_json = json.dumps(members, separators=(",", ":"))
+    conn = rooms.open_rooms()
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO room_roster_cache (room_id, epoch, "
+            "members_json, from_node, mac, fetched_ts) VALUES (?, ?, ?, ?, ?, ?)",
+            (room_id, int(epoch), members_json, from_node, "leader-mac",
+             rooms.now_ts()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    print(f"seeded cache room={room_id} epoch={epoch} members={len(members)}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# receiver-side replay against the REAL do_POST handler
+# ---------------------------------------------------------------------------
+def _load_handoffd(repo_root: str):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "bridge_handoffd", os.path.join(repo_root, "bridge-handoffd.py"))
+    hd = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(hd)
+    return hd
+
+
+class _FakeHeaders:
+    def __init__(self, headers: dict):
+        self._h = headers
+
+    def get(self, key, default=None):
+        return self._h.get(key, default)
+
+
+class _FakeRFile:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0 or n >= len(self._data):
+            out, self._data = self._data, b""
+            return out
+        out, self._data = self._data[:n], self._data[n:]
+        return out
+
+
+class _FakeServer:
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self.config_path = ""
+
+
+def cmd_deliver_talk_to_receiver(repo_root: str, cfg_json: str, captured: str,
+                                 overrides_json: str = "{}") -> int:
+    """Replay a captured room-scoped enqueue through the REAL do_POST handler.
+
+    `overrides_json` mutates the captured request (mirrors the P4.2 helper):
+      {"client_ip": "...", "headers": {...}, "body": "<json>",
+       "recompute_hash": true, "resign": true}
+    `resign` recomputes the body hash AND a VALID HMAC for the (mutated) body
+    using the peer's configured secret — to drive a path DOWNSTREAM of the HMAC
+    gate (e.g. the membership gate) with a legitimately-signed mutated body.
+    """
+    hd = _load_handoffd(repo_root)
+    cfg = json.loads(cfg_json)
+    doc = json.loads(Path(captured).read_text(encoding="utf-8"))
+    overrides = json.loads(overrides_json) if overrides_json else {}
+
+    path = doc.get("path", "/enqueue")
+    headers = dict(doc.get("headers", {}))
+    body = doc.get("body", "{}")
+
+    if "headers" in overrides:
+        headers.update(overrides["headers"])
+    if "body" in overrides:
+        body = overrides["body"]
+    body_bytes = body.encode("utf-8") if isinstance(body, str) else bytes(body)
+    if overrides.get("recompute_hash"):
+        headers["X-AGB-Body-SHA256"] = a2a.body_sha256(body_bytes)
+    if overrides.get("resign"):
+        peer_secret = ""
+        for p in cfg.get("peers", []):
+            if p.get("id") == headers.get("X-AGB-Peer", ""):
+                peer_secret = p.get("secret", "")
+                break
+        body_hash = a2a.body_sha256(body_bytes)
+        headers["X-AGB-Body-SHA256"] = body_hash
+        canonical = a2a.canonical_string(
+            "POST", path, headers.get("X-AGB-Peer", ""),
+            headers.get("X-AGB-Message-Id", ""),
+            headers.get("X-AGB-Timestamp", ""), body_hash)
+        headers["X-AGB-Signature"] = a2a.sign(peer_secret, canonical)
+    headers["Content-Length"] = str(len(body_bytes))
+
+    peer_id = headers.get("X-AGB-Peer", "")
+    peer_addr = ""
+    for p in cfg.get("peers", []):
+        if p.get("id") == peer_id:
+            peer_addr = p.get("address", "")
+            break
+    client_ip = overrides.get("client_ip", peer_addr or "127.0.0.1")
+
+    # Monkeypatch the enqueue boundary so a DELIVERED room message is captured
+    # in-process (no bridge-task.sh shell-out / live queue). The gate runs
+    # BEFORE this, so a gated message never reaches it (delivered stays False).
+    delivery: dict = {}
+
+    def _fake_enqueue(*, target, sender_bridge, sender_agent, priority, title,
+                      body_file):
+        delivery.update({
+            "target": target, "sender_bridge": sender_bridge,
+            "sender_agent": sender_agent, "priority": priority, "title": title,
+        })
+        return True, "9999", "created task #9999"
+
+    hd.enqueue_via_bridge_task = _fake_enqueue  # type: ignore[assignment]
+
+    handler = hd.HandoffHandler.__new__(hd.HandoffHandler)
+    handler.path = path
+    handler.headers = _FakeHeaders(headers)
+    handler.rfile = _FakeRFile(body_bytes)
+    handler.client_address = (client_ip, 0)
+    handler.server = _FakeServer(cfg)
+
+    captured_reply: dict = {}
+
+    def _capture_reply(status, payload, extra_headers=None):
+        captured_reply["status"] = status
+        captured_reply["payload"] = payload
+
+    handler._reply = _capture_reply  # type: ignore[assignment]
+    handler.do_POST()
+
+    status = captured_reply.get("status", 0)
+    payload = captured_reply.get("payload", {})
+    delivered = bool(delivery)
+    print(f"status={status} delivered={delivered} "
+          f"body={json.dumps(payload)} delivery={json.dumps(delivery)}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# unit-drive the membership gate directly (no HTTP at all)
+# ---------------------------------------------------------------------------
+def cmd_membership_unit(db: str) -> int:
+    """Drive roster_cache_membership_check across every P4.3 tooth."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    room = "room-unit"
+    members = [
+        {"agent": "alice", "node": "nodeA", "role": "leader"},
+        {"agent": "bob", "node": "nodeB", "role": "member"},
+    ]
+    conn.execute(
+        "INSERT OR REPLACE INTO room_roster_cache (room_id, epoch, members_json, "
+        "from_node, mac, fetched_ts) VALUES (?, ?, ?, ?, ?, ?)",
+        (room, 3, json.dumps(members, separators=(",", ":")), "nodeA",
+         "mac", rooms.now_ts()),
+    )
+    conn.commit()
+
+    def chk(**kw):
+        return rooms.roster_cache_membership_check(conn, room_id=kw["room"],
+            room_epoch=kw["epoch"], sender_agent=kw["sa"], sender_node=kw["sn"],
+            target_agent=kw["ta"], target_node=kw["tn"])
+
+    try:
+        # member sender + member target + matching epoch → OK
+        print(f"member_ok={chk(room=room, epoch=3, sa='bob', sn='nodeB', ta='alice', tn='nodeA')}")
+        # non-member sender → rejected
+        print(f"nonmember_sender={chk(room=room, epoch=3, sa='mallory', sn='nodeB', ta='alice', tn='nodeA')}")
+        # member agent on the WRONG (un-authenticated) node → rejected
+        print(f"member_wrong_node={chk(room=room, epoch=3, sa='bob', sn='nodeZ', ta='alice', tn='nodeA')}")
+        # target not a cached member → rejected
+        print(f"target_not_member={chk(room=room, epoch=3, sa='bob', sn='nodeB', ta='ghost', tn='nodeA')}")
+        # epoch BEHIND the cache → rejected fail-closed
+        print(f"epoch_stale={chk(room=room, epoch=2, sa='bob', sn='nodeB', ta='alice', tn='nodeA')}")
+        # epoch AHEAD of the cache → rejected fail-closed
+        print(f"epoch_ahead={chk(room=room, epoch=4, sa='bob', sn='nodeB', ta='alice', tn='nodeA')}")
+        # unknown room (no cache) → rejected fail-closed
+        print(f"no_cache={chk(room='room-unknown', epoch=3, sa='bob', sn='nodeB', ta='alice', tn='nodeA')}")
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_mutate_body(captured: str, op: str, arg: str = "") -> int:
+    """Print the captured envelope body JSON with one mutation applied.
+
+    Lets the smoke drive its teeth without inline shell heredocs (so the
+    heredoc-ban broad-match never trips on the .sh). The output is the mutated
+    envelope body as a JSON string on stdout."""
+    doc = json.loads(Path(captured).read_text(encoding="utf-8"))
+    env = json.loads(doc.get("body", "{}"))
+    if op == "drop-room-id":
+        env.pop("room_id", None)
+    elif op == "drop-room-epoch":
+        env.pop("room_epoch", None)
+    elif op == "drop-both":
+        env.pop("room_id", None)
+        env.pop("room_epoch", None)
+    elif op == "set-sender-agent":
+        env.setdefault("sender", {})["agent"] = arg
+    elif op == "set-body":
+        env["body"] = arg
+    else:
+        print(f"unknown mutate op: {op}", file=sys.stderr)
+        return 2
+    print(json.dumps(env, ensure_ascii=False))
+    return 0
+
+
+def cmd_json_quote(text: str) -> int:
+    print(json.dumps(text))
+    return 0
+
+
+def cmd_dedupe_isolation_unit(inbox_db: str) -> int:
+    """Prove the inbox_dedupe ledger is scoped to the AUTHENTICATED peer.
+
+    A2A Rooms P4.3 (codex review, contract 6): a second authenticated peer
+    reusing ANOTHER peer's sender-chosen message_id must NOT collide — it gets a
+    FRESH dedupe namespace, never a spurious duplicate/conflict against the first
+    peer's row. Drives the REAL `a2a.open_inbox()` (so the composite-PK schema +
+    migration are exercised) and the canonical dedupe semantics."""
+    os.environ["BRIDGE_A2A_INBOX_DB"] = inbox_db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = a2a.open_inbox()
+    mid = "nodeA:shared-id"
+    now = a2a.now_ts()
+    try:
+        # peerA reserves the id with body hash hA.
+        conn.execute(
+            "INSERT INTO inbox_dedupe (message_id, peer, body_sha256, "
+            "created_task_id, first_seen_ts, last_seen_ts, delivery_count) "
+            "VALUES (?, ?, ?, ?, ?, ?, 1)",
+            (mid, "nodeA", "hA", "task-A", now, now),
+        )
+        conn.commit()
+        # peerC reuses the SAME message_id with a DIFFERENT body hash hC.
+        # Under a global PK this INSERT would raise IntegrityError; under the
+        # composite (peer, message_id) PK it is a FRESH, independent row.
+        try:
+            conn.execute(
+                "INSERT INTO inbox_dedupe (message_id, peer, body_sha256, "
+                "created_task_id, first_seen_ts, last_seen_ts, delivery_count) "
+                "VALUES (?, ?, ?, ?, ?, ?, 1)",
+                (mid, "nodeC", "hC", "task-C", now, now),
+            )
+            conn.commit()
+            inserted = True
+        except sqlite3.IntegrityError:
+            inserted = False
+        # peerC's lookup must see ITS OWN row (hC), not peerA's (hA).
+        c_row = conn.execute(
+            "SELECT body_sha256 FROM inbox_dedupe WHERE peer=? AND message_id=?",
+            ("nodeC", mid)).fetchone()
+        a_row = conn.execute(
+            "SELECT body_sha256 FROM inbox_dedupe WHERE peer=? AND message_id=?",
+            ("nodeA", mid)).fetchone()
+        print(f"peerC_insert_ok={inserted}")
+        print(f"peerC_sees={c_row['body_sha256'] if c_row else None}")
+        print(f"peerA_sees={a_row['body_sha256'] if a_row else None}")
+    finally:
+        conn.close()
+    return 0
+
+
+def _build_signed_enqueue(cfg: dict, peer_id: str, secret: str, *,
+                          message_id: str, target: str, sender_agent: str,
+                          title: str, body: str) -> tuple:
+    """Build a fully-signed plain A2A enqueue request (headers + body bytes) for
+    `peer_id`. Returns (path, headers, body_bytes)."""
+    env = a2a.build_envelope(
+        message_id=message_id, sender_bridge=peer_id, sender_agent=sender_agent,
+        target_agent=target, priority="normal", title=title, body=body,
+    )
+    body_bytes = json.dumps(env, ensure_ascii=False).encode("utf-8")
+    path = cfg.get("listen", {}).get("enqueue_path", "/enqueue")
+    ts = str(a2a.now_ts())
+    bh = a2a.body_sha256(body_bytes)
+    canonical = a2a.canonical_string("POST", path, peer_id, message_id, ts, bh)
+    headers = {
+        "X-AGB-Protocol": a2a.PROTOCOL_VERSION,
+        "X-AGB-Peer": peer_id,
+        "X-AGB-Message-Id": message_id,
+        "X-AGB-Timestamp": ts,
+        "X-AGB-Body-SHA256": bh,
+        "X-AGB-Signature": a2a.sign(secret, canonical),
+        "Content-Length": str(len(body_bytes)),
+    }
+    return path, headers, body_bytes
+
+
+def cmd_staged_race_unit(repo_root: str, cfg_a_json: str, cfg_b_json: str) -> int:
+    """Prove the staged body file is PEER-SCOPED + collision-proof (codex P4.3
+    r2): two peers reusing ONE message_id must NOT share/overwrite the staged
+    file between stage-time and the bridge-task --body-file READ.
+
+    Drives peer A's REAL do_POST. The fake enqueue ACTUALLY READS `body_file`,
+    but FIRST — while peer A's body is staged and BEFORE peer A's read — it stages
+    peer B's body under the SAME message_id (the competing concurrent peer). If
+    the staged path were message_id-keyed, peer B's stage would overwrite peer
+    A's file and peer A's read would return peer B's bytes. With peer-scoped O_EXCL
+    staging the paths are distinct, so peer A reads its OWN body/provenance."""
+    hd = _load_handoffd(repo_root)
+    cfg_a = json.loads(cfg_a_json)
+    cfg_b = json.loads(cfg_b_json)
+    secret_a = next((p.get("secret", "") for p in cfg_a.get("peers", [])
+                     if p.get("id") == "nodeA"), "")
+    secret_b = next((p.get("secret", "") for p in cfg_b.get("peers", [])
+                     if p.get("id") == "nodeB"), "")
+    addr_a = next((p.get("address", "") for p in cfg_a.get("peers", [])
+                   if p.get("id") == "nodeA"), "127.0.0.1")
+    shared_id = "shared:race-id"
+
+    # Build BOTH peers' signed enqueue requests carrying the SAME message_id but
+    # DIFFERENT bodies/agents.
+    path_a, headers_a, body_a = _build_signed_enqueue(
+        cfg_a, "nodeA", secret_a, message_id=shared_id, target="bob",
+        sender_agent="alice", title="from-A", body="PEER-A-BODY")
+    path_b, headers_b, body_b = _build_signed_enqueue(
+        cfg_b, "nodeB", secret_b, message_id=shared_id, target="bob",
+        sender_agent="carol", title="from-B", body="PEER-B-BODY")
+
+    captured: dict = {}
+
+    def _racing_enqueue(*, target, sender_bridge, sender_agent, priority, title,
+                        body_file):
+        # The COMPETING peer B stages its body under the SAME message_id NOW —
+        # after peer A staged, before peer A's read. Peer-scoped staging means
+        # this writes a DIFFERENT file and cannot clobber peer A's.
+        hd.stage_inbound_body("nodeB", shared_id,
+                              hd.staged_body_text(json.loads(
+                                  body_b.decode("utf-8"))))
+        # NOW read what peer A's enqueue was handed.
+        with open(body_file, encoding="utf-8") as fh:
+            captured["read"] = fh.read()
+        captured["sender_bridge"] = sender_bridge
+        captured["sender_agent"] = sender_agent
+        captured["body_file"] = str(body_file)
+        return True, "9999", "created task #9999"
+
+    hd.enqueue_via_bridge_task = _racing_enqueue  # type: ignore[assignment]
+
+    handler = hd.HandoffHandler.__new__(hd.HandoffHandler)
+    handler.path = path_a
+    handler.headers = _FakeHeaders(headers_a)
+    handler.rfile = _FakeRFile(body_a)
+    handler.client_address = (addr_a, 0)
+    handler.server = _FakeServer(cfg_a)
+    reply: dict = {}
+    handler._reply = lambda s, p, extra_headers=None: reply.update(  # type: ignore[assignment]
+        {"status": s, "payload": p})
+    handler.do_POST()
+
+    read = captured.get("read", "")
+    saw_a_body = "PEER-A-BODY" in read
+    saw_b_body = "PEER-B-BODY" in read
+    saw_a_prov = "remote agent : alice" in read
+    print(f"status={reply.get('status')}")
+    print(f"peerA_read_own_body={saw_a_body}")
+    print(f"peerA_read_B_body={saw_b_body}")
+    print(f"peerA_read_own_provenance={saw_a_prov}")
+    print(f"sender_bridge={captured.get('sender_bridge')}")
+    return 0
+
+
+def cmd_migration_failclosed_unit(inbox_db: str) -> int:
+    """Prove open_inbox FAILS CLOSED if the legacy->composite migration did not
+    take (codex P4.3 r2). Seeds a legacy single-PK inbox.db, neutralizes the
+    migration (simulating a rollback that left the legacy table intact), and
+    asserts open_inbox raises rather than serving peer-scoped dedupe on a
+    global-PK ledger."""
+    # 1) a legacy single-column-PK inbox.db.
+    conn = sqlite3.connect(inbox_db)
+    conn.executescript(
+        "CREATE TABLE inbox_dedupe (message_id TEXT PRIMARY KEY, peer TEXT NOT "
+        "NULL, body_sha256 TEXT NOT NULL, created_task_id TEXT, first_seen_ts "
+        "INTEGER NOT NULL, last_seen_ts INTEGER NOT NULL, delivery_count INTEGER "
+        "NOT NULL DEFAULT 1);")
+    conn.commit()
+    conn.close()
+    os.environ["BRIDGE_A2A_INBOX_DB"] = inbox_db  # noqa: iso-helper-boundary - env var, not a .env file
+    # 2) neutralize the migration → legacy table persists after open.
+    a2a._migrate_inbox_schema = lambda c: None  # type: ignore[assignment]
+    try:
+        a2a.open_inbox()
+        print("failclosed=no:open_inbox returned a legacy-PK connection")
+        return 0
+    except a2a.A2AError as exc:
+        print(f"failclosed=yes:{getattr(exc, 'code', '')}")
+        return 0
+
+
+def main(argv: list) -> int:
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    cmd = argv[1]
+    if cmd == "post-hook":
+        return cmd_post_hook(argv[2])
+    if cmd == "captured-field":
+        return cmd_captured_field(argv[2], argv[3])
+    if cmd == "make-config":
+        return cmd_make_config(*argv[2:])
+    if cmd == "seed-cache":
+        return cmd_seed_cache(argv[2], argv[3], argv[4], argv[5], argv[6])
+    if cmd == "deliver-talk-to-receiver":
+        return cmd_deliver_talk_to_receiver(*argv[2:])
+    if cmd == "membership-unit":
+        return cmd_membership_unit(argv[2])
+    if cmd == "mutate-body":
+        return cmd_mutate_body(argv[2], argv[3], argv[4] if len(argv) > 4 else "")
+    if cmd == "json-quote":
+        return cmd_json_quote(argv[2])
+    if cmd == "dedupe-isolation-unit":
+        return cmd_dedupe_isolation_unit(argv[2])
+    if cmd == "migration-failclosed-unit":
+        return cmd_migration_failclosed_unit(argv[2])
+    if cmd == "staged-race-unit":
+        return cmd_staged_race_unit(argv[2], argv[3], argv[4])
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/smoke/rooms-p4-3-room-talk.sh
+++ b/scripts/smoke/rooms-p4-3-room-talk.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-3-room-talk.sh — A2A Rooms P4.3 room-scoped TALK
+# (cross-node member messaging).
+#
+# Exercises the THIRD cross-node rooms phase (design docs/design/
+# a2a-rooms-design.md §11): once a member node holds a leader-MAC'd roster in
+# room_roster_cache (from P4.2), members on DIFFERENT nodes exchange room-scoped
+# messages WITHOUT the leader online — each member validates membership against
+# its OWN local cache + the envelope's room_epoch, fail-closed. The transport is
+# STUBBED end-to-end (no real Tailscale / live socket): the sender's `room talk`
+# enqueue POST is captured by the paired-flag test hook, then replayed through
+# the REAL receiver `do_POST` handler (the enqueue boundary is monkeypatched in
+# the helper to capture delivery, so no bridge-task.sh shell-out / live queue).
+#
+# THE 9 REQUIRED TEETH (each proven below):
+#   T1  A room message from a roster MEMBER (correct room_id + matching epoch) IS
+#       delivered.
+#   T2  A room message from a NON-member (sender not in the local roster cache)
+#       is REJECTED, no delivery.
+#   T3  A room message with a MISMATCHED room_epoch (both stale AND ahead) is
+#       REJECTED fail-closed.
+#   T4  A room message for an UNKNOWN room_id (no local roster cache) is REJECTED
+#       fail-closed.
+#   T5  A room message MISSING room_id or room_epoch -> 422 (no delivery).
+#   T6  A PLAIN non-room message is NOT treated as room talk (doesn't hit the
+#       room gate, IS delivered as a normal message) AND does not grant
+#       membership.
+#   T7  A hostile --from/env cannot impersonate another member (OS-actor/node
+#       anchoring holds; a wire sender_agent that is not a cached member fails).
+#   T8  A replayed room message (same peer+message_id) is deduped/idempotent;
+#       same-id/diff-body is NOT double-delivered (409).
+#   T9  Auth-preamble parity: the room-talk delivery is unreachable pre-auth (bad
+#       HMAC / remote_addr / allowlist -> 401/403 BEFORE any room logic).
+#   T10 (codex review) inbox_dedupe is scoped to the authenticated peer (composite
+#       PK): a second peer reusing another peer's message_id does NOT collide, so
+#       room talk's replay protection (which rides this dedupe) is peer-isolated.
+#   T11 (codex r2) open_inbox FAILS CLOSED if the legacy->composite-PK migration
+#       did not take (no global-PK dedupe ever served).
+#   T12 (codex r2) the staged body file is PEER-SCOPED + O_EXCL collision-proof: a
+#       competing same-message_id peer cannot clobber the staged body the later
+#       bridge-task --body-file read returns.
+
+set -euo pipefail
+
+SMOKE_NAME="rooms-p4-3-room-talk"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+HELPER="$SCRIPT_DIR/rooms-p4-3-room-talk-helper.py"
+POST_HOOK="$SCRIPT_DIR/rooms-p4-3-post-hook.sh"
+ROOMS_CLI="$SMOKE_REPO_ROOT/bridge-rooms.py"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+export BRIDGE_A2A_ROOMS_DB="$BRIDGE_STATE_DIR/handoff/rooms.db"
+mkdir -p "$BRIDGE_STATE_DIR/handoff"
+
+NODE_A="nodeA"   # the SENDER's node (alice talks)
+NODE_B="nodeB"   # the RECEIVER / member node (bob receives)
+SECRET="test-pair-secret-aaaaaaaaaaaaaaaaaaaa"
+ADDR="127.0.0.1"
+ROOM="room-talk-001"
+EPOCH=4
+
+# The canonical cached roster the receiver gate reads (alice@nodeA leader +
+# bob@nodeB member). Same bytes seeded on BOTH nodes (mirrors a leader broadcast
+# already applied on each via P4.2).
+MEMBERS_CSV="alice@${NODE_A}:leader,bob@${NODE_B}:member"
+
+# Node-A (sender) config: bridge_id=nodeA, peer nodeB (the delivery target).
+CFG_A="$SMOKE_TMP_ROOT/handoff-A.json"
+python3 "$HELPER" make-config "$CFG_A" "$NODE_A" "$NODE_B" "$SECRET" "$ADDR" "bob" >/dev/null
+# Sender-side rooms.db (node A) — alice's own cache, so `room talk` can resolve
+# the epoch + confirm alice is a member before sending.
+SENDER_DB="$SMOKE_TMP_ROOT/sender-rooms.db"
+python3 "$HELPER" seed-cache "$SENDER_DB" "$ROOM" "$EPOCH" "$NODE_A" "$MEMBERS_CSV" >/dev/null
+
+# Node-B (receiver) config: bridge_id=nodeB, peer nodeA (the authenticated
+# sender). The inbound allowlist permits delivery to bob (the room talk target).
+CFG_B="$SMOKE_TMP_ROOT/handoff-B.json"
+python3 "$HELPER" make-config "$CFG_B" "$NODE_B" "$NODE_A" "$SECRET" "$ADDR" "bob" >/dev/null
+CFG_B_JSON="$(cat "$CFG_B")"
+
+# Member-local receiver rooms.db (node B) — the leader-MAC cache the gate reads.
+MEMBER_DB="$SMOKE_TMP_ROOT/member-rooms.db"
+python3 "$HELPER" seed-cache "$MEMBER_DB" "$ROOM" "$EPOCH" "$NODE_A" "$MEMBERS_CSV" >/dev/null
+
+CAPTURE="$SMOKE_TMP_ROOT/captured-talk.json"
+
+TEST_FLAGS=("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1" "BRIDGE_A2A_ALLOW_TEST_BIND=1")
+
+# talk_as <agent> <sender_db> [extra room-talk args...] — run `room talk` as
+# iso-user agent-bridge-<agent> on node A, capturing the signed enqueue POST to
+# $CAPTURE. Echoes the CLI JSON.
+talk_as() {
+  local who="$1" sdb="$2"; shift 2
+  : >"$CAPTURE" || true
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+      "BRIDGE_A2A_ROOMS_DB=$sdb" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$POST_HOOK" \
+      "CAPTURE_FILE=$CAPTURE" \
+    python3 "$ROOMS_CLI" talk "$ROOM" "$@" --json 2>/dev/null
+}
+
+# deliver_talk <cfg_json> [overrides_json] [member_db] — replay $CAPTURE through
+# the REAL receiver do_POST handler against <member_db> (default $MEMBER_DB).
+deliver_talk() {
+  local cfg_json="$1" overrides="${2:-}" mdb="${3:-$MEMBER_DB}"
+  [[ -n "$overrides" ]] || overrides='{}'
+  env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-talk-to-receiver "$SMOKE_REPO_ROOT" \
+      "$cfg_json" "$CAPTURE" "$overrides"
+}
+
+# ---------------------------------------------------------------------------
+# setup + T1: a member sends; the receiver delivers (matching epoch + roster).
+# ---------------------------------------------------------------------------
+test_T1_member_talk_delivered() {
+  local out
+  out="$(talk_as alice "$SENDER_DB" --title "hello room" --body "from alice")"
+  smoke_assert_contains "$out" "\"epoch\": $EPOCH" "T1: sender stamped its locally-cached epoch"
+  smoke_assert_contains "$out" "\"from\": \"alice@$NODE_A\"" "T1: sender identity is OS-actor anchored (alice@nodeA)"
+  smoke_assert_file_exists "$CAPTURE" "T1: the signed room-talk enqueue was captured"
+
+  # The captured POST carries the room scope + targets bob over the enqueue path.
+  local proto room_in_body epoch_in_body target_in_body path_in
+  proto="$(python3 "$HELPER" captured-field "$CAPTURE" "header:X-AGB-Protocol")"
+  smoke_assert_eq "a2a-enqueue-v1" "$proto" "T1: room talk routes over the normal enqueue protocol"
+  path_in="$(python3 "$HELPER" captured-field "$CAPTURE" "path")"
+  smoke_assert_eq "/enqueue" "$path_in" "T1: room talk posts to the enqueue path (not a new endpoint)"
+  room_in_body="$(python3 "$HELPER" captured-field "$CAPTURE" "body:room_id")"
+  smoke_assert_eq "$ROOM" "$room_in_body" "T1: the envelope carries the room id"
+  epoch_in_body="$(python3 "$HELPER" captured-field "$CAPTURE" "body:room_epoch")"
+  smoke_assert_eq "$EPOCH" "$epoch_in_body" "T1: the envelope carries the cached room epoch"
+  target_in_body="$(python3 "$HELPER" captured-field "$CAPTURE" "body:target_agent")"
+  smoke_assert_eq "bob" "$target_in_body" "T1: the envelope targets the other-node member bob"
+
+  # The receiver delivers it (member sender + member target + matching epoch).
+  local res
+  res="$(deliver_talk "$CFG_B_JSON")"
+  smoke_assert_contains "$res" "status=200" "T1: a member room message is accepted (200)"
+  smoke_assert_contains "$res" "delivered=True" "T1: the room message is DELIVERED into the queue"
+  smoke_assert_contains "$res" "\"task_id\": \"9999\"" "T1: delivery created a task"
+}
+
+# ---------------------------------------------------------------------------
+# T2: a NON-member sender (not in the local roster cache) is rejected.
+# A member db that does NOT list the sender's agent → the gate denies. We mutate
+# the captured envelope's sender.agent to a non-member, re-signing so it passes
+# the HMAC gate and reaches the membership gate.
+# ---------------------------------------------------------------------------
+# deliver_mutated <cfg_json> <mutate_op> [mutate_arg] [member_db] — replay the
+# captured talk through the receiver with the envelope body mutated by the
+# helper (no inline heredocs — heredoc-ban hygiene), re-signed so it passes HMAC.
+deliver_mutated() {
+  local cfg_json="$1" op="$2" arg="${3:-}" mdb="${4:-$MEMBER_DB}"
+  local mutated quoted overrides
+  mutated="$(python3 "$HELPER" mutate-body "$CAPTURE" "$op" "$arg")"
+  quoted="$(python3 "$HELPER" json-quote "$mutated")"
+  overrides="{\"body\":$quoted,\"resign\":true}"
+  deliver_talk "$cfg_json" "$overrides" "$mdb"
+}
+
+test_T2_non_member_sender_rejected() {
+  talk_as alice "$SENDER_DB" --title "t" --body "b" >/dev/null
+  # Rewrite sender.agent → "mallory" (not in the cached roster). Node stays nodeA
+  # (the authenticated peer), so this is the pure "agent not a member" case.
+  local res
+  res="$(deliver_mutated "$CFG_B_JSON" set-sender-agent mallory)"
+  smoke_assert_contains "$res" "status=403" "T2: a non-member sender is 403"
+  smoke_assert_contains "$res" "sender_not_member" "T2: refusal reason is sender_not_member"
+  smoke_assert_contains "$res" "delivered=False" "T2: a non-member message is NEVER delivered"
+}
+
+# ---------------------------------------------------------------------------
+# T3: a MISMATCHED room_epoch (both stale AND ahead) is rejected fail-closed.
+# ---------------------------------------------------------------------------
+test_T3_epoch_mismatch_rejected() {
+  talk_as alice "$SENDER_DB" --title "t" --body "b" >/dev/null
+  # stale: deliver against a member cache pinned at a HIGHER epoch.
+  local mdb_ahead="$SMOKE_TMP_ROOT/member-epoch-ahead.db"
+  python3 "$HELPER" seed-cache "$mdb_ahead" "$ROOM" $((EPOCH+1)) "$NODE_A" "$MEMBERS_CSV" >/dev/null
+  local res_stale
+  res_stale="$(deliver_talk "$CFG_B_JSON" '{}' "$mdb_ahead")"
+  smoke_assert_contains "$res_stale" "status=403" "T3: a STALE epoch (cache ahead) is 403"
+  smoke_assert_contains "$res_stale" "epoch_mismatch" "T3: stale refusal reason is epoch_mismatch"
+  smoke_assert_contains "$res_stale" "delivered=False" "T3: a stale-epoch message is not delivered"
+  # ahead: deliver against a member cache pinned at a LOWER epoch.
+  local mdb_behind="$SMOKE_TMP_ROOT/member-epoch-behind.db"
+  python3 "$HELPER" seed-cache "$mdb_behind" "$ROOM" $((EPOCH-1)) "$NODE_A" "$MEMBERS_CSV" >/dev/null
+  local res_ahead
+  res_ahead="$(deliver_talk "$CFG_B_JSON" '{}' "$mdb_behind")"
+  smoke_assert_contains "$res_ahead" "status=403" "T3: an AHEAD epoch (cache behind) is 403"
+  smoke_assert_contains "$res_ahead" "epoch_mismatch" "T3: ahead refusal reason is epoch_mismatch"
+  smoke_assert_contains "$res_ahead" "delivered=False" "T3: an ahead-epoch message is not delivered"
+}
+
+# ---------------------------------------------------------------------------
+# T4: an UNKNOWN room_id (no local roster cache) is rejected fail-closed.
+# ---------------------------------------------------------------------------
+test_T4_unknown_room_rejected() {
+  talk_as alice "$SENDER_DB" --title "t" --body "b" >/dev/null
+  # A member db with a cache for a DIFFERENT room only → the talk's room has no
+  # cache here → no_roster_cache fail-closed.
+  local mdb_other="$SMOKE_TMP_ROOT/member-otherroom.db"
+  python3 "$HELPER" seed-cache "$mdb_other" "room-different" "$EPOCH" "$NODE_A" "$MEMBERS_CSV" >/dev/null
+  local res
+  res="$(deliver_talk "$CFG_B_JSON" '{}' "$mdb_other")"
+  smoke_assert_contains "$res" "status=403" "T4: an unknown room (no cache) is 403"
+  smoke_assert_contains "$res" "no_roster_cache" "T4: refusal reason is no_roster_cache"
+  smoke_assert_contains "$res" "delivered=False" "T4: an unknown-room message is not delivered"
+}
+
+# ---------------------------------------------------------------------------
+# T5: a room message MISSING room_id or room_epoch -> 422 (no delivery).
+# parse_envelope rejects a half-room envelope at the wire boundary.
+# ---------------------------------------------------------------------------
+test_T5_missing_room_fields_422() {
+  talk_as alice "$SENDER_DB" --title "t" --body "b" >/dev/null
+  # Drop room_epoch but keep room_id → a malformed room-scoped envelope.
+  local res_no_epoch
+  res_no_epoch="$(deliver_mutated "$CFG_B_JSON" drop-room-epoch)"
+  smoke_assert_contains "$res_no_epoch" "status=422" "T5: room_id present without room_epoch is 422"
+  smoke_assert_contains "$res_no_epoch" "delivered=False" "T5: a 422 half-room envelope is not delivered"
+  # Drop room_id but keep room_epoch → also malformed.
+  local res_no_id
+  res_no_id="$(deliver_mutated "$CFG_B_JSON" drop-room-id)"
+  smoke_assert_contains "$res_no_id" "status=422" "T5: room_epoch present without room_id is 422"
+  smoke_assert_contains "$res_no_id" "delivered=False" "T5: a 422 half-room envelope is not delivered"
+}
+
+# ---------------------------------------------------------------------------
+# T6: a PLAIN non-room message is NOT treated as room talk — it IS delivered via
+# the normal path and does NOT touch the room gate or grant membership.
+# ---------------------------------------------------------------------------
+test_T6_plain_send_not_room_talk() {
+  talk_as alice "$SENDER_DB" --title "t" --body "b" >/dev/null
+  # Strip BOTH room fields → a plain v1 envelope. It must deliver (allowlist has
+  # bob) WITHOUT the room gate (no room_id), and must not depend on/seed any
+  # cache. Deliver against a member db that has NO cache for the talk's room to
+  # prove the plain path is independent of room state.
+  local mdb_empty="$SMOKE_TMP_ROOT/member-nocache.db"
+  python3 "$HELPER" seed-cache "$mdb_empty" "room-unrelated" 1 "$NODE_A" "alice@$NODE_A" >/dev/null
+  local res
+  res="$(deliver_mutated "$CFG_B_JSON" drop-both "" "$mdb_empty")"
+  smoke_assert_contains "$res" "status=200" "T6: a plain non-room message is accepted via the normal path"
+  smoke_assert_contains "$res" "delivered=True" "T6: a plain message IS delivered (not gated by room membership)"
+  smoke_assert_not_contains "$res" "room-scoped enqueue denied" "T6: a plain message never hits the room gate"
+}
+
+# ---------------------------------------------------------------------------
+# T7: a hostile --from/env cannot impersonate another member. The recorded
+# sender is the OS-actor (BRIDGE_ROOMS_TEST_ISO_USER), so --as/--from is ignored;
+# and a wire sender_agent that is not a cached member fails the gate (T2 proves
+# the latter). Here we prove the SENDER side: `room talk --as <other-member>`
+# from carl's iso uid still sends as carl (OS-anchored), and since carl is not a
+# member, the CLI refuses to send at all.
+# ---------------------------------------------------------------------------
+test_T7_hostile_from_cannot_impersonate() {
+  # carl is NOT in the room. Even passing --as alice (a real member) the OS actor
+  # resolves to carl → the CLI refuses (carl not a cached member). A hostile
+  # --as/--from cannot make carl's send go out as alice.
+  local out rc
+  set +e
+  out="$(env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-carl" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+      "BRIDGE_A2A_ROOMS_DB=$SENDER_DB" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$POST_HOOK" \
+      "CAPTURE_FILE=$CAPTURE" \
+    python3 "$ROOMS_CLI" talk "$ROOM" --as alice --title hi --body x --json 2>&1)"
+  rc=$?
+  set -e
+  [[ $rc -ne 0 ]] || smoke_fail "T7: carl (non-member) impersonating alice must FAIL to send"
+  smoke_assert_contains "$out" "is not a member" "T7: the OS actor carl is not a member; --as alice is ignored (no impersonation)"
+}
+
+# ---------------------------------------------------------------------------
+# T8: a replayed room message (same peer+message_id) is deduped/idempotent;
+# same-id/diff-body is NOT double-delivered (409).
+# ---------------------------------------------------------------------------
+test_T8_replay_dedupe() {
+  talk_as alice "$SENDER_DB" --title "t" --body "b" >/dev/null
+  local mdb="$SMOKE_TMP_ROOT/member-dedupe.db"
+  python3 "$HELPER" seed-cache "$mdb" "$ROOM" "$EPOCH" "$NODE_A" "$MEMBERS_CSV" >/dev/null
+  # first delivery → 200 delivered.
+  local first
+  first="$(deliver_talk "$CFG_B_JSON" '{}' "$mdb")"
+  smoke_assert_contains "$first" "status=200" "T8: first room message is delivered (200)"
+  smoke_assert_contains "$first" "delivered=True" "T8: first delivery enqueues a task"
+  # byte-identical replay (same id + same body) → idempotent 200, NOT re-delivered.
+  local replay
+  replay="$(deliver_talk "$CFG_B_JSON" '{}' "$mdb")"
+  smoke_assert_contains "$replay" "status=200" "T8: a byte-identical replay is an idempotent 200"
+  smoke_assert_contains "$replay" "\"duplicate\": true" "T8: the replay is flagged duplicate"
+  smoke_assert_contains "$replay" "delivered=False" "T8: a replay does NOT enqueue a second task"
+  # same id + DIFFERENT body → 409 conflict, not delivered.
+  local conflict
+  conflict="$(deliver_mutated "$CFG_B_JSON" set-body "a different body for the same message id" "$mdb")"
+  smoke_assert_contains "$conflict" "status=409" "T8: same-id/different-body is a 409 conflict"
+  smoke_assert_contains "$conflict" "delivered=False" "T8: a conflicting replay is not double-delivered"
+}
+
+# ---------------------------------------------------------------------------
+# T9: auth-preamble parity — the room-talk delivery is unreachable pre-auth.
+# Bad HMAC / remote_addr / allowlist all reject BEFORE any room logic runs.
+# ---------------------------------------------------------------------------
+test_T9_auth_preamble_unweakened() {
+  talk_as alice "$SENDER_DB" --title "t" --body "b" >/dev/null
+  # bad HMAC → 401 (auth gate), room gate never reached.
+  local res_hmac
+  res_hmac="$(deliver_talk "$CFG_B_JSON" '{"headers":{"X-AGB-Signature":"v1=deadbeefdeadbeef"}}')"
+  smoke_assert_contains "$res_hmac" "status=401" "T9: a bad pairwise HMAC is 401 (auth gate intact)"
+  smoke_assert_contains "$res_hmac" "delivered=False" "T9: an HMAC-rejected room message is never delivered"
+  # remote_addr mismatch → 403 before the body/room logic.
+  local res_addr
+  res_addr="$(deliver_talk "$CFG_B_JSON" '{"client_ip":"10.9.9.9"}')"
+  smoke_assert_contains "$res_addr" "status=403" "T9: a source-address mismatch is 403"
+  smoke_assert_contains "$res_addr" "delivered=False" "T9: an addr-rejected room message is never delivered"
+  # unknown peer → 403.
+  local res_peer
+  res_peer="$(deliver_talk "$CFG_B_JSON" '{"headers":{"X-AGB-Peer":"nodeZ"}}')"
+  smoke_assert_contains "$res_peer" "status=403" "T9: an unknown peer is 403"
+  smoke_assert_contains "$res_peer" "delivered=False" "T9: an unknown-peer room message is never delivered"
+  # allowlist miss → a room message targeting an agent NOT in the inbound
+  # allowlist is 403 (the existing allowlist gate runs BEFORE the room gate).
+  local cfg_noallow res_allow
+  cfg_noallow="$SMOKE_TMP_ROOT/handoff-B-noallow.json"
+  python3 "$HELPER" make-config "$cfg_noallow" "$NODE_B" "$NODE_A" "$SECRET" "$ADDR" "" >/dev/null
+  res_allow="$(deliver_talk "$(cat "$cfg_noallow")")"
+  smoke_assert_contains "$res_allow" "status=403" "T9: a target not in the inbound allowlist is 403"
+  smoke_assert_contains "$res_allow" "delivered=False" "T9: an allowlist-rejected room message is never delivered"
+}
+
+# ---------------------------------------------------------------------------
+# unit: the membership gate decision surface (deterministic, no HTTP).
+# ---------------------------------------------------------------------------
+test_membership_gate_unit() {
+  local udb="$SMOKE_TMP_ROOT/membership-unit.db"
+  local out
+  out="$(python3 "$HELPER" membership-unit "$udb" 2>&1)" \
+    || smoke_fail "membership-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "member_ok=members_ok" "unit: a member sender+target at the matching epoch passes"
+  smoke_assert_contains "$out" "nonmember_sender=sender_not_member" "unit: a non-member sender is rejected"
+  smoke_assert_contains "$out" "member_wrong_node=sender_not_member" "unit: a member on the wrong (unauth) node is rejected"
+  smoke_assert_contains "$out" "target_not_member=target_not_member" "unit: a non-member target is rejected"
+  smoke_assert_contains "$out" "epoch_stale=epoch_mismatch" "unit: a stale epoch is rejected fail-closed"
+  smoke_assert_contains "$out" "epoch_ahead=epoch_mismatch" "unit: an ahead epoch is rejected fail-closed"
+  smoke_assert_contains "$out" "no_cache=no_roster_cache" "unit: an unknown room (no cache) is rejected fail-closed"
+}
+
+# ---------------------------------------------------------------------------
+# T10 (codex review): the inbox_dedupe ledger is scoped to the AUTHENTICATED
+# peer (composite PK). A second peer reusing another peer's sender-chosen
+# message_id does NOT collide — room talk rides this dedupe, so contract 6's
+# peer-scoped replay protection holds for room messages too.
+# ---------------------------------------------------------------------------
+test_T10_cross_peer_dedupe_isolation() {
+  local idb="$SMOKE_TMP_ROOT/inbox-isolation.db"
+  local out
+  out="$(python3 "$HELPER" dedupe-isolation-unit "$idb" 2>&1)" \
+    || smoke_fail "dedupe-isolation-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "peerC_insert_ok=True" \
+    "T10: a second peer reusing another peer's message_id is a FRESH row (no PK collision)"
+  smoke_assert_contains "$out" "peerC_sees=hC" \
+    "T10: the second peer's dedupe lookup sees ITS OWN body, not the first peer's"
+  smoke_assert_contains "$out" "peerA_sees=hA" \
+    "T10: the first peer's row is untouched by the second peer's reuse"
+}
+
+# ---------------------------------------------------------------------------
+# T11 (codex r2): open_inbox FAILS CLOSED if the legacy->composite-PK migration
+# did not take — it must NOT hand back a global-PK ledger on which a cross-peer
+# same-id message could pass the peer-scoped lookup yet collide at enqueue.
+# ---------------------------------------------------------------------------
+test_T11_migration_fail_closed() {
+  local idb="$SMOKE_TMP_ROOT/inbox-failclosed.db"
+  local out
+  out="$(python3 "$HELPER" migration-failclosed-unit "$idb" 2>&1)" \
+    || smoke_fail "migration-failclosed-unit helper must not raise itself: $out"
+  smoke_assert_contains "$out" "failclosed=yes:inbox_dedupe_legacy_pk" \
+    "T11: a failed inbox migration makes open_inbox fail closed (no global-PK dedupe served)"
+}
+
+# ---------------------------------------------------------------------------
+# T12 (codex r2 BLOCKER): the staged body file is PEER-SCOPED + collision-proof.
+# Drives peer A's REAL do_POST through to the enqueue --body-file READ, while a
+# competing peer B stages its body under the SAME message_id between stage and
+# read. With message_id-only staging peer A would read peer B's body; with the
+# peer-scoped O_EXCL fix peer A reads its OWN body + provenance.
+# ---------------------------------------------------------------------------
+test_T12_staged_body_peer_scoped() {
+  local idb="$SMOKE_TMP_ROOT/inbox-staged-race.db"
+  local out
+  # cfg_a = the receiver config that trusts nodeA as an inbound peer (CFG_B);
+  # cfg_b = a config carrying nodeB's secret (CFG_A). The inbox dedupe + incoming
+  # staging dir live under this isolated BRIDGE_STATE_DIR.
+  out="$(env "BRIDGE_A2A_INBOX_DB=$idb" \
+    python3 "$HELPER" staged-race-unit "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$(cat "$CFG_A")" 2>&1)" \
+    || smoke_fail "staged-race-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "status=200" "T12: peer A's plain enqueue is accepted (200)"
+  smoke_assert_contains "$out" "peerA_read_own_body=True" \
+    "T12: peer A's bridge-task --body-file read returns peer A's OWN body (not peer B's)"
+  smoke_assert_contains "$out" "peerA_read_B_body=False" \
+    "T12: a competing same-message_id peer B did NOT clobber peer A's staged body"
+  smoke_assert_contains "$out" "peerA_read_own_provenance=True" \
+    "T12: peer A's staged provenance is peer A's (remote agent alice), not peer B's"
+  smoke_assert_contains "$out" "sender_bridge=nodeA" \
+    "T12: the enqueued task is attributed to peer A"
+}
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+smoke_run "T1: a member room message (matching epoch) IS delivered" test_T1_member_talk_delivered
+smoke_run "T2: a NON-member sender room message is REJECTED, no delivery" test_T2_non_member_sender_rejected
+smoke_run "T3: a MISMATCHED room_epoch (stale AND ahead) is REJECTED fail-closed" test_T3_epoch_mismatch_rejected
+smoke_run "T4: an UNKNOWN room_id (no local cache) is REJECTED fail-closed" test_T4_unknown_room_rejected
+smoke_run "T5: a room message MISSING room_id or room_epoch -> 422" test_T5_missing_room_fields_422
+smoke_run "T6: a PLAIN non-room message is NOT room talk (delivered, no gate, no membership)" test_T6_plain_send_not_room_talk
+smoke_run "T7: a hostile --from/env cannot impersonate another member" test_T7_hostile_from_cannot_impersonate
+smoke_run "T8: a replayed room message is deduped/idempotent; same-id/diff-body 409" test_T8_replay_dedupe
+smoke_run "T9: auth-preamble parity — room talk is unreachable pre-auth" test_T9_auth_preamble_unweakened
+smoke_run "T10: inbox dedupe is peer-scoped — cross-peer message_id reuse does not collide" test_T10_cross_peer_dedupe_isolation
+smoke_run "T11: open_inbox fails closed if the dedupe-PK migration did not take" test_T11_migration_fail_closed
+smoke_run "T12: the staged body file is peer-scoped — no cross-peer same-id clobber" test_T12_staged_body_peer_scoped
+smoke_run "unit: the roster-cache membership gate decision surface" test_membership_gate_unit
+
+smoke_log "passed"

--- a/scripts/smoke/rooms-p4-5-helper.py
+++ b/scripts/smoke/rooms-p4-5-helper.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Helper for the rooms-p4-5-polish smoke (A2A Rooms P4.5).
+
+File-as-argv sidecar (never a heredoc-stdin — footgun #11). Imports the REAL
+`bridge_rooms_common` so the member-side roster cache the smoke seeds uses the
+canonical schema + the canonical insert the P4.2 broadcast would have written.
+
+Subcommands (argv[1]):
+  seed-cache <db> <room_id> <epoch> <from_node> <members_csv>
+        write a leader-MAC roster cache row directly (the applied P4.2 outcome),
+        WITHOUT a matching `rooms` row — i.e. the exact state of a NON-leader
+        node that joined + was approved into a room. members_csv entries are
+        `agent@node[:role]`, comma-separated.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import bridge_rooms_common as rooms  # noqa: E402
+
+
+def _parse_members_csv(members_csv: str) -> list:
+    members: list = []
+    for entry in members_csv.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        role = "member"
+        if ":" in entry:
+            entry, role = entry.rsplit(":", 1)
+        agent, _, node = entry.partition("@")
+        members.append({"agent": agent.strip(), "node": node.strip(),
+                        "role": role.strip() or "member"})
+    members.sort(key=lambda m: (m["agent"], m["node"]))
+    return members
+
+
+def cmd_seed_cache(db: str, room_id: str, epoch: str, from_node: str,
+                   members_csv: str) -> int:
+    """Seed a member-side leader-MAC roster cache row (the P4.2 outcome).
+
+    No `rooms` row is written — this is exactly a NON-leader node's state, so
+    `cmd_show`/`cmd_list` must consult `room_roster_cache` to see the room.
+    """
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    members = _parse_members_csv(members_csv)
+    members_json = json.dumps(members, separators=(",", ":"))
+    conn = rooms.open_rooms()
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO room_roster_cache (room_id, epoch, "
+            "members_json, from_node, mac, fetched_ts) VALUES (?, ?, ?, ?, ?, ?)",
+            (room_id, int(epoch), members_json, from_node, "leader-mac",
+             rooms.now_ts()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    print(f"seeded cache room={room_id} epoch={epoch} members={len(members)}")
+    return 0
+
+
+def main(argv: list) -> int:
+    if len(argv) < 2:
+        print("usage: rooms-p4-5-helper.py <subcommand> ...", file=sys.stderr)
+        return 2
+    cmd = argv[1]
+    if cmd == "seed-cache":
+        return cmd_seed_cache(argv[2], argv[3], argv[4], argv[5], argv[6])
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/smoke/rooms-p4-5-polish.sh
+++ b/scripts/smoke/rooms-p4-5-polish.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-5-polish.sh — A2A Rooms P4.5 polish (two follow-ups
+# from the P4.4 two-VM acceptance, design docs/design/a2a-rooms-design.md §11).
+#
+# FIX 1 (UX completeness): on a NON-leader node that has JOINED + been approved
+#   into a room, `agb room show <id>` / `room list` must surface the room from
+#   the member-side `room_roster_cache` (the same cache `room talk` reads),
+#   instead of "room not found" / omitting it. A leader-led room must still show
+#   exactly as before (additive role/source fields only). A room with NEITHER a
+#   local `rooms` row NOR a cache row is still "not found".
+#
+# FIX 2 (info-hygiene, peer-facing): a cross-node enqueue to a target that
+#   passes the inbound allowlist but is NOT in the local roster fails at the
+#   `bridge-task.sh create` boundary, which prints the FULL `agb list` roster
+#   dump (agent names/engines/workdirs/sources) on stderr. The receiver MUST
+#   return a TERSE 422 detail ("unknown target '<agent>'") to the remote peer —
+#   the roster dump goes to the LOCAL audit/log ONLY, never the HTTP response.
+#   The rejection status + the local audit detail are unchanged.
+#
+# TEETH (each proven below):
+#   F1a  member-side `room show <id>` surfaces cached members/epoch/leader
+#        (not "not found").
+#   F1b  member-side `room list` includes the joined-but-not-led room, marked
+#        role=member.
+#   F1c  a leader-led room still shows/lists as before (no regression).
+#   F1d  a room with no `rooms` row AND no cache row -> still "not found".
+#   F2a  an unknown-but-allowlisted enqueue target -> 422 (still rejected).
+#   F2b  the 422 HTTP body does NOT contain the `agb list` workdir/engine/source
+#        columns (the roster dump is absent from the peer-facing response).
+#   F2c  the 422 HTTP body carries the terse "unknown target '<agent>'" detail.
+#   F2d  the LOCAL audit/log still records the full reason (roster dump present
+#        in the local enqueue_permanent_fail audit line).
+#   F2e  a VALID (rostered + allowlisted) target still enqueues normally (200).
+
+set -euo pipefail
+
+SMOKE_NAME="rooms-p4-5-polish"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+ROOMS_CLI="$SMOKE_REPO_ROOT/bridge-rooms.py"
+ROOMS_COMMON="$SMOKE_REPO_ROOT/bridge_rooms_common.py"
+XBRIDGE_HELPER="$SCRIPT_DIR/a2a-cross-bridge-helper.py"
+
+HANDOFFD_PID=""
+
+cleanup() {
+  if [[ -n "$HANDOFFD_PID" ]]; then
+    kill "$HANDOFFD_PID" >/dev/null 2>&1 || true
+    wait "$HANDOFFD_PID" >/dev/null 2>&1 || true
+  fi
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+# ===========================================================================
+# FIX 1 — member-node room show/list reads room_roster_cache
+# ===========================================================================
+MEMBER_DB="$SMOKE_TMP_ROOT/member-rooms.db"
+JOINED_ROOM="room-joined-001"
+JOINED_EPOCH=7
+
+# Seed a member-side roster cache row (the applied leader-MAC roster from P4.2)
+# directly, with NO matching `rooms` row — exactly the non-leader node state.
+seed_member_cache() {
+  env "BRIDGE_A2A_ROOMS_DB=$MEMBER_DB" python3 "$SCRIPT_DIR/rooms-p4-5-helper.py" \
+    seed-cache "$MEMBER_DB" "$JOINED_ROOM" "$JOINED_EPOCH" "nodeLeader" \
+    "alice@nodeLeader:leader,bob@nodeMember:member"
+}
+
+room_cli_member() {
+  env "BRIDGE_A2A_ROOMS_DB=$MEMBER_DB" python3 "$ROOMS_CLI" "$@"
+}
+
+test_F1a_member_show_from_cache() {
+  local out
+  out="$(room_cli_member show "$JOINED_ROOM" --json)"
+  smoke_assert_contains "$out" "\"room_id\": \"$JOINED_ROOM\"" \
+    "F1a: member-side show returns the joined room (not 'not found')"
+  smoke_assert_contains "$out" "\"epoch\": $JOINED_EPOCH" \
+    "F1a: the cached epoch is surfaced"
+  smoke_assert_contains "$out" "\"leader\": \"alice@nodeLeader\"" \
+    "F1a: the cached leader is surfaced"
+  smoke_assert_contains "$out" "\"source\": \"roster-cache\"" \
+    "F1a: the view is marked as a member-side cached view"
+  smoke_assert_contains "$out" "\"role\": \"member\"" \
+    "F1a: the view is marked role=member"
+  smoke_assert_contains "$out" "\"agent\": \"bob\"" \
+    "F1a: the cached members list is surfaced"
+}
+
+test_F1b_member_list_includes_joined() {
+  local out
+  out="$(room_cli_member list --json)"
+  smoke_assert_contains "$out" "\"room_id\": \"$JOINED_ROOM\"" \
+    "F1b: member-side list includes the joined-but-not-led room"
+  smoke_assert_contains "$out" "\"source\": \"roster-cache\"" \
+    "F1b: the joined room is marked as a cached/member entry"
+  # Human-readable form marks it as a cached member room.
+  local hout
+  hout="$(room_cli_member list)"
+  smoke_assert_contains "$hout" "role=member (cached)" \
+    "F1b: the human list marks the joined room role=member (cached)"
+}
+
+# F1c/F1d run against a SEPARATE leader db (a node that LEADS a room).
+LEADER_DB="$SMOKE_TMP_ROOT/leader-rooms.db"
+LED_ROOM=""
+
+room_cli_leader() {
+  env "BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-carol" \
+      "BRIDGE_A2A_ROOMS_DB=$LEADER_DB" \
+    python3 "$ROOMS_CLI" "$@"
+}
+
+test_F1c_leader_room_unchanged() {
+  local created
+  created="$(room_cli_leader create --name "led-room" --json)"
+  LED_ROOM="$(printf '%s\n' "$created" | sed -n 's/.*"room_id": "\([^"]*\)".*/\1/p' | head -n 1)"
+  smoke_assert_match "$LED_ROOM" '^room-' "F1c: a led room was created"
+
+  local sout
+  sout="$(room_cli_leader show "$LED_ROOM" --json)"
+  # The full leader payload is preserved (name/status/pending + role=leader).
+  smoke_assert_contains "$sout" "\"name\": \"led-room\"" \
+    "F1c: a led room still shows its name (leader-only field preserved)"
+  smoke_assert_contains "$sout" "\"status\":" \
+    "F1c: a led room still shows its status"
+  smoke_assert_contains "$sout" "\"pending_join_requests\":" \
+    "F1c: a led room still shows its pending-join queue"
+  smoke_assert_contains "$sout" "\"source\": \"rooms\"" \
+    "F1c: a led room is sourced from the local rooms table, not the cache"
+  smoke_assert_contains "$sout" "\"role\": \"leader\"" \
+    "F1c: a led room is marked role=leader"
+
+  local lout
+  lout="$(room_cli_leader list)"
+  smoke_assert_contains "$lout" "$LED_ROOM" \
+    "F1c: a led room still appears in list"
+  smoke_assert_contains "$lout" "name='led-room'" \
+    "F1c: the led-room list row is unchanged (name + status columns)"
+}
+
+test_F1d_no_room_no_cache_not_found() {
+  local out rc
+  set +e
+  out="$(room_cli_leader show "room-does-not-exist" --json 2>&1)"
+  rc=$?
+  set -e
+  [[ $rc -ne 0 ]] || smoke_fail "F1d: an unknown room (no rooms row, no cache) must exit non-zero"
+  smoke_assert_contains "$out" "room not found" \
+    "F1d: an unknown room with neither a rooms row nor a cache row is still 'not found'"
+}
+
+# ===========================================================================
+# FIX 2 — peer-facing enqueue 422 detail is terse (no roster leak)
+# ===========================================================================
+A2A_PORT=""
+A2A_SECRET="smoke-shared-secret-do-not-use-in-prod-0123456789"
+UNKNOWN_TARGET="ghost-agent"
+VALID_TARGET="reviewer"
+REVIEWER_SESSION_NAME="a2a-p45-$$-${RANDOM}"
+
+helper() { python3 "$XBRIDGE_HELPER" "$@"; }
+base_url() { printf 'http://127.0.0.1:%s' "$A2A_PORT"; }
+
+# A roster that has 'reviewer' (a real, rostered agent) but NOT 'ghost-agent'.
+# The roster intentionally carries the leaky columns (engine/workdir/source) so
+# a roster dump would be obvious if it leaked.
+write_a2a_roster() {
+  local workdir="$BRIDGE_AGENT_HOME_ROOT/reviewer"
+  mkdir -p "$workdir"
+  # printf (not a heredoc) per the repo's heredoc-stdin ban (footgun #11 /
+  # KNOWN_ISSUES §26). Each roster line is a separate printf arg; the
+  # session/workdir values interpolate the same way an unquoted heredoc would.
+  printf '%s\n' \
+    'BRIDGE_ADMIN_AGENT_ID="reviewer"' \
+    'bridge_add_agent_id_if_missing "reviewer"' \
+    'BRIDGE_AGENT_DESC["reviewer"]="A2A P4.5 polish smoke reviewer"' \
+    'BRIDGE_AGENT_ENGINE["reviewer"]="shell"' \
+    "BRIDGE_AGENT_SESSION[\"reviewer\"]=\"$REVIEWER_SESSION_NAME\"" \
+    "BRIDGE_AGENT_WORKDIR[\"reviewer\"]=\"$workdir\"" \
+    "BRIDGE_AGENT_LAUNCH_CMD[\"reviewer\"]=\"bash -lc 'echo reviewer'\"" \
+    'BRIDGE_AGENT_LOOP["reviewer"]=0' \
+    'BRIDGE_AGENT_CONTINUE["reviewer"]=0' \
+    >"$BRIDGE_ROSTER_LOCAL_FILE"
+}
+
+# Both the unknown AND the valid target are in the inbound allowlist so the
+# allowlist preamble admits each — the unknown one then fails at bridge-task.sh
+# (the roster gate), the valid one enqueues.
+write_a2a_config() {
+  local port="$1"
+  # printf (not a heredoc) per the repo's heredoc-stdin ban (footgun #11 /
+  # KNOWN_ISSUES §26). One printf arg per JSON line; the port/secret/allowlist
+  # values interpolate the same way an unquoted heredoc would.
+  printf '%s\n' \
+    '{' \
+    '  "bridge_id": "bridge-b",' \
+    "  \"listen\": { \"address\": \"127.0.0.1\", \"port\": ${port}, \"enqueue_path\": \"/enqueue\" }," \
+    '  "timestamp_skew_seconds": 300,' \
+    '  "peers": [' \
+    '    {' \
+    '      "id": "bridge-a",' \
+    '      "address": "127.0.0.1",' \
+    "      \"port\": ${port}," \
+    "      \"secret\": \"${A2A_SECRET}\"," \
+    "      \"inbound_allowlist\": [\"${VALID_TARGET}\", \"${UNKNOWN_TARGET}\"]," \
+    '      "caps": { "max_body_bytes": 262144, "max_title_bytes": 1024 }' \
+    '    }' \
+    '  ]' \
+    '}' \
+    >"$BRIDGE_HOME/handoff.local.json"
+  chmod 0600 "$BRIDGE_HOME/handoff.local.json"
+}
+
+start_receiver() {
+  A2A_PORT="$(helper free-port)"
+  write_a2a_config "$A2A_PORT"
+  BRIDGE_A2A_ALLOW_TEST_BIND=1 \
+    python3 "$SMOKE_REPO_ROOT/bridge-handoffd.py" serve \
+      --config "$BRIDGE_HOME/handoff.local.json" \
+      >"$SMOKE_TMP_ROOT/handoffd.log" 2>&1 &
+  HANDOFFD_PID=$!
+  local waited=0
+  while (( waited < 50 )); do
+    if helper wait-port "$A2A_PORT" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  smoke_fail "receiver did not start; log: $(cat "$SMOKE_TMP_ROOT/handoffd.log")"
+}
+
+test_F2_unknown_target_terse_no_leak() {
+  local out
+  out="$(helper unknown-target "$(base_url)" bridge-a "$A2A_SECRET" "$UNKNOWN_TARGET")"
+  # F2a: still rejected with 422 (the rejection itself is unchanged).
+  smoke_assert_contains "$out" "STATUS=422" \
+    "F2a: an unknown-but-allowlisted target is still rejected (422)"
+  # F2b: the peer-facing body must NOT contain the agb-list roster columns.
+  smoke_assert_not_contains "$out" "engine=" \
+    "F2b: the 422 body does NOT leak the roster 'engine=' column"
+  smoke_assert_not_contains "$out" "workdir=" \
+    "F2b: the 422 body does NOT leak the roster 'workdir=' column"
+  smoke_assert_not_contains "$out" "source=" \
+    "F2b: the 422 body does NOT leak the roster 'source=' column"
+  smoke_assert_not_contains "$out" "$BRIDGE_AGENT_HOME_ROOT" \
+    "F2b: the 422 body does NOT leak agent workdir paths"
+  # F2c: the terse detail names only the target the peer already chose.
+  smoke_assert_contains "$out" "unknown target '$UNKNOWN_TARGET'" \
+    "F2c: the 422 body carries the terse 'unknown target' detail"
+}
+
+test_F2d_local_audit_has_full_reason() {
+  # The local audit log must still record the full reason (the roster dump) —
+  # redaction is peer-facing ONLY. The audit truncates to 200 chars (pre-existing
+  # behavior), so the roster dump's leading column marker is present locally.
+  local audit_log="$BRIDGE_HOME/logs/a2a-handoff.jsonl"
+  smoke_assert_file_exists "$audit_log" \
+    "F2d: the local a2a audit log exists"
+  local perm_lines
+  perm_lines="$(grep "enqueue_permanent_fail" "$audit_log" || true)"
+  smoke_assert_contains "$perm_lines" "enqueue_permanent_fail" \
+    "F2d: the rejection is recorded as a permanent-fail audit event locally"
+  # The roster-dump fingerprint (engine= ... column) must be present LOCALLY in
+  # the audit detail even though it is redacted from the peer response.
+  smoke_assert_contains "$perm_lines" "engine=" \
+    "F2d: the local audit detail still records the full reason (roster dump kept locally)"
+}
+
+test_F2e_valid_target_still_enqueues() {
+  local out task_id inbox_out
+  out="$(helper ok "$(base_url)" bridge-a "$A2A_SECRET")"
+  smoke_assert_contains "$out" "STATUS=200" \
+    "F2e: a valid, rostered + allowlisted target still enqueues normally (200)"
+  task_id="$(printf '%s\n' "$out" | sed -n 's/.*"task_id"[^0-9]*\([0-9][0-9]*\).*/\1/p' | head -n 1)"
+  smoke_assert_match "$task_id" '^[0-9]+$' \
+    "F2e: the valid enqueue returned a local task id"
+  inbox_out="$("$SMOKE_REPO_ROOT/agent-bridge" inbox "$VALID_TARGET")"
+  smoke_assert_contains "$inbox_out" "a2a smoke ok" \
+    "F2e: the valid handoff is visible in the target's inbox"
+}
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+smoke_run "FIX1 setup: seed a member-side roster cache (joined, not led)" seed_member_cache
+smoke_run "F1a: member-side room show surfaces the joined room from the cache" test_F1a_member_show_from_cache
+smoke_run "F1b: member-side room list includes the joined-but-not-led room" test_F1b_member_list_includes_joined
+smoke_run "F1c: a leader-led room still shows/lists as before (no regression)" test_F1c_leader_room_unchanged
+smoke_run "F1d: a room with no rooms row and no cache row is still 'not found'" test_F1d_no_room_no_cache_not_found
+
+smoke_run "FIX2 setup: write roster (reviewer rostered, ghost-agent not)" write_a2a_roster
+smoke_run "FIX2 setup: start loopback receiver (test-bind)" start_receiver
+smoke_run "F2a-c: unknown target -> terse 422, no roster leak in the peer body" test_F2_unknown_target_terse_no_leak
+smoke_run "F2d: the local audit still records the full reason" test_F2d_local_audit_has_full_reason
+smoke_run "F2e: a valid target still enqueues normally" test_F2e_valid_target_still_enqueues
+
+smoke_log "passed"


### PR DESCRIPTION
# A2A Rooms P4 — cross-node rooms (join / approve / roster / talk)

Lands the **cross-node** A2A Rooms feature (design `docs/design/a2a-rooms-design.md` §11 phase P4) onto main: agents on **different machines** form a room — one becomes the **leader**, others **join** via a link-invite, the leader **approves** and broadcasts a **signed roster**, and members then exchange **room-scoped messages** that each receiver validates fail-closed against its own cached leader-signed roster (no live leader call). Built on the merged single-node Rooms (P1) + the existing A2A node-link transport.

Integration branch `feat/rooms-p4`; each phase landed as its own codex-pair-reviewed PR, then VM-accepted on two real Linux nodes, then a polish pass. This PR merges the whole feature to main.

## Phases (all codex-pair-reviewed)
- **P4.1 cross-node JOIN** (#1545) — pending-only, OS-actor-anchored joiner identity, token TTL + revocation, peer-scoped `(peer, message_id)` dedupe.
- **P4.2 leader approve + roster broadcast** (#1546) — leader-only roster accept (`peer_id==leader_node`), pairwise-HMAC over the canonical roster, monotonic epoch, atomic roster cache, first-roster binds to local pending state (no rogue-leader minting).
- **P4.3 room-scoped talk** (#1548) — mandatory `room_id`+`room_epoch`, receiver delivers ONLY if sender ∈ local leader-MAC roster cache AND epoch matches (fail-closed); plain sends are a separate, non-membership path. Includes the inbox_dedupe composite-PK migration (peer-scoped).
- **P4.5 polish** (#1550) — member-node `room show`/`list` falls back to the roster cache; terse peer-facing enqueue error (no roster dump leaked to peers).

## Security holes caught by the codex pair gate BEFORE shipping (all closed + teethed)
1. Cross-peer JOIN dedupe — one authenticated peer could consume/block another peer's join id (composite PK fix).
2. Roster-broadcast TOCTOU — same-id/different-body roster could land in cache before the dedupe conflict was detected (atomic reserve+write).
3. Roster dedupe-completeness — the byte-identical-duplicate branch didn't burn the id, letting a later different-body reuse slip through (reserve-in-duplicate-branch).
4. Staged-body cross-peer overwrite — the composite-PK change let a concurrent same-id peer overwrite another peer's staged enqueue body before the bridge-task read (O_EXCL peer-scoped staging).
5. inbox_dedupe cross-peer hole — global PK let one peer's id collide another's (composite `(peer, message_id)` + fail-closed migration).

## VM acceptance (P4.4) — GREEN on two real Linux nodes
Deployed `feat/rooms-p4` to two separate OrbStack Linux VMs over a real LAN (every security gate real — node-link HMAC, remote_addr allowlist, dedupe, membership/epoch; only the tailnet-bind *proof* was shimmed for the no-Tailscale LAN test). End-to-end:
- create (leader) → cross-node join (pending) → approve (epoch 0→1, roster broadcast) → member roster cache applied (leader-MAC, 2 members) → **a→b talk received AND b→a talk received** (bidirectional, the headline requirement).
- Negative teeth all PASS on real signed envelopes: non-member→403, epoch-mismatch→403 (both directions), unknown-room→403, plain≠room (no membership granted).

## Receiver security
The A2A receiver auth preamble (fail-closed tailnet bind + node-link HMAC + remote_addr + allowlist + dedupe + skew) is unchanged; `--skip-companion-validate` is never reachable for a remote peer. All new room handlers sit after the auth preamble.

## CI
Full unit/static + integration + lint + lint-heredoc-ban + oss-preflight green on `feat/rooms-p4` (rebased past the #1549 1520c CI fix). New smokes: rooms-p4-1-cross-node-join, rooms-p4-2-roster-broadcast, rooms-p4-3-room-talk, rooms-p4-5-polish — all registered in ci-select.
