### PR TITLE
reaper: surgical per-session codex app-server subtree reap on teardown (#9770 Track 2)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -10094,8 +10094,30 @@ reap_idle_orphan_sessions() {
     [[ "$idle" =~ ^[0-9]+$ ]] || idle=0
     (( idle >= threshold )) || continue
 
+    # Incident #9770 Track 2: capture the session's codex app-server + Pencil
+    # MCP subtree BEFORE the external kill, while the pane PID still resolves.
+    # The pane's own EXIT trap does not run under an external `tmux
+    # kill-session`, so this is the only path that catches the leak on idle
+    # reap. Scoped to the pane subtree — never a live roster codex elsewhere.
+    local codex_subtree_root_pid=""
+    local codex_subtree_capture=""
+    if command -v bridge_codex_subtree_capture >/dev/null 2>&1; then
+      codex_subtree_root_pid="$(bridge_codex_subtree_pane_pid "$session" 2>/dev/null || true)"
+      codex_subtree_capture="$(bridge_codex_subtree_capture "$session" 2>/dev/null || true)"
+    fi
+
     if bridge_tmux_kill_session "$session" >/dev/null 2>&1; then
       sleep 0.2
+      if command -v bridge_codex_subtree_reap_captured >/dev/null 2>&1; then
+        if [[ -n "$codex_subtree_root_pid" ]]; then
+          bridge_codex_subtree_reap_captured "$session" "$codex_subtree_root_pid" \
+            "$codex_subtree_capture" "orphan-session:${session}" >/dev/null 2>&1 || true
+        else
+          bridge_audit_log daemon codex_subtree_reap_skipped_no_pane codex \
+            --detail "session=${session}" --detail "reason=pane-pid-unresolvable" \
+            >/dev/null 2>&1 || true
+        fi
+      fi
       if [[ "${BRIDGE_MCP_ORPHAN_CLEANUP_ENABLED:-1}" == "1" ]]; then
         bridge_mcp_orphan_cleanup "orphan-session:${session}" "${BRIDGE_MCP_ORPHAN_SESSION_STOP_MIN_AGE_SECONDS:-0}" 1 >/dev/null 2>&1 || true
       fi

--- a/bridge-mcp-cleanup.py
+++ b/bridge-mcp-cleanup.py
@@ -74,6 +74,33 @@ DEFAULT_PATTERNS = [
 ]
 
 
+# Incident #9770 Track 2 — codex app-server / Pencil MCP teardown leak.
+#
+# These patterns are used ONLY by the `subtree` subcommand (surgical
+# per-session reap rooted at a known tmux pane PID). They are deliberately
+# NOT part of DEFAULT_PATTERNS: the global orphan path (scan/cleanup) must
+# stay PPID-orphan + DEFAULT_PATTERNS only, so a live roster `codex resume`
+# (a descendant of its OWN live pane) is never a global-cleanup candidate.
+#
+# In `subtree` mode the allowlist is a WITHIN-SUBTREE filter, never a global
+# match: the candidate set is already constrained to descendants of the
+# torn-down session's pane PID, so matching `codex` here can only ever reach
+# the codex the torn-down session itself spawned. A second live roster codex,
+# the operator's interactive codex, and a non-codex child the user opened in
+# the same pane are all excluded by construction (different pane subtree) or
+# by name (the same-pane non-codex child).
+#
+# Provenance (live ps -axo command= on the Darwin leak host):
+#   - `codex` / `codex resume <hash>` / `codex exec ...`  (the CLI itself)
+#   - `codex app-server`                                  (the leaked child)
+#   - `.../Pencil.app/.../mcp-server-darwin-arm64 ...`    (Pencil MCP grandchild)
+SUBTREE_ALLOWLIST_PATTERNS = [
+    r"(?:^|/)codex(?:\s|$)",
+    r"(?:^|/)codex\s+app-server\b",
+    r"\bmcp-server-darwin-arm64\b",
+]
+
+
 @dataclass(frozen=True)
 class Proc:
     pid: int
@@ -310,6 +337,315 @@ def kill_pid(
     return True, "killed"
 
 
+def still_killable_subtree(
+    pid: int,
+    expected_command: str,
+    expected_pattern: re.Pattern[str],
+    min_observed_age: int,
+) -> bool:
+    """PID-reuse guard for the SUBTREE reap path (#9770 Track 2).
+
+    Identical to `still_killable` EXCEPT it deliberately drops the parent-PID
+    constraint. On the daemon idle-kill path we capture the codex/app-server/MCP
+    descendants of a pane PID and reap them AFTER `tmux kill-session` — which
+    tears the pane down, so the captured codex REPARENTS to init/launchd. That
+    reparent is the expected, benign signal of the teardown we initiated, not a
+    PID-reuse event, so a ppid check would wrongly refuse to reap the very leak
+    we are trying to close. PID reuse is still defended by the triple (a) the
+    pid still exists, (b) it still matches the within-subtree allowlist, (c) its
+    command string is byte-identical to the captured command, and (d) it is no
+    younger than when captured (a recycled pid is a fresh, younger process).
+    """
+    identity = read_proc_identity(pid)
+    if identity is None:
+        return False
+    command, _ppid, age = identity
+    if not expected_pattern.search(command):
+        return False
+    if command != expected_command:
+        return False
+    if age < min_observed_age:
+        return False
+    return True
+
+
+def kill_pid_subtree(
+    pid: int,
+    grace_seconds: float,
+    expected_command: str,
+    expected_pattern: re.Pattern[str],
+    min_observed_age: int,
+) -> tuple[bool, str]:
+    """SIGTERM→grace→SIGKILL with ppid-agnostic PID-reuse revalidation before
+    every signal. Fail-soft + idempotent: ESRCH is success/no-op; a vanished or
+    identity-changed pid is skipped rather than signalled."""
+    # PID-reuse revalidation IMMEDIATELY before SIGTERM.
+    if not still_killable_subtree(pid, expected_command, expected_pattern, min_observed_age):
+        return True, "skipped-pid-reuse"
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True, "already-gone"
+    except PermissionError as exc:
+        return False, str(exc)
+
+    deadline = time.monotonic() + grace_seconds
+    while time.monotonic() < deadline:
+        if not alive(pid):
+            return True, "terminated"
+        time.sleep(0.05)
+
+    # Revalidate again before escalating to SIGKILL — the pid may have exited
+    # (and possibly been recycled) during the grace window. A process that has
+    # become a zombie (SIGTERM took effect, parent has not reaped it yet) no
+    # longer matches the captured command, so this correctly reports it as
+    # already-terminated rather than re-signalling a recycled pid.
+    if not still_killable_subtree(pid, expected_command, expected_pattern, min_observed_age):
+        return True, "terminated"
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return True, "terminated"
+    except PermissionError as exc:
+        return False, str(exc)
+    return True, "killed"
+
+
+def descendants_of(root_pid: int, processes: dict[int, Proc], max_nodes: int = 4096) -> list[Proc]:
+    """BFS the live process map for every descendant of `root_pid`.
+
+    The root itself is NOT included — we only ever reap the codex/app-server/
+    MCP children the pane spawned, never the pane's shell/login process. Bounded
+    by `max_nodes` so a pathological cycle (which `seen` already prevents) or a
+    huge process table can never spin. Built from a single ps snapshot so the
+    parent→child edges are internally consistent.
+    """
+    children: dict[int, list[int]] = {}
+    for proc in processes.values():
+        children.setdefault(proc.ppid, []).append(proc.pid)
+
+    out: list[Proc] = []
+    seen: set[int] = {root_pid}
+    queue: list[int] = list(children.get(root_pid, []))
+    while queue and len(seen) < max_nodes:
+        pid = queue.pop(0)
+        if pid in seen:
+            continue
+        seen.add(pid)
+        proc = processes.get(pid)
+        if proc is None:
+            continue
+        out.append(proc)
+        queue.extend(children.get(pid, []))
+    return out
+
+
+def _subtree_matched_pattern(proc: Proc, patterns: list[re.Pattern[str]]) -> str:
+    if proc.pid == os.getpid():
+        return ""
+    if "bridge-mcp-cleanup.py" in proc.command:
+        return ""
+    for pattern in patterns:
+        if pattern.search(proc.command):
+            return pattern.pattern
+    return ""
+
+
+def capture_subtree(root_pid: int, patterns: list[re.Pattern[str]]) -> list[dict[str, object]]:
+    """Resolve the codex/app-server/MCP descendants of `root_pid` (the torn-down
+    session's tmux pane PID), with per-PID metadata for later revalidation.
+
+    Returns a leaf-to-root–ordered list (highest pid first as a cheap proxy) of
+    {pid, ppid, age_seconds, rss_kb, pattern, command}. Only processes whose
+    command matches the within-subtree allowlist are captured — a non-codex
+    child the user opened in the same pane is intentionally left out.
+    """
+    processes = load_processes()
+    captured: list[dict[str, object]] = []
+    for proc in descendants_of(root_pid, processes):
+        pattern = _subtree_matched_pattern(proc, patterns)
+        if not pattern:
+            continue
+        captured.append(
+            {
+                "pid": proc.pid,
+                "ppid": proc.ppid,
+                "age_seconds": proc.age_seconds,
+                "rss_kb": proc.rss_kb,
+                "pattern": pattern,
+                "command": proc.command,
+            }
+        )
+    # Reap children before their parents: a parent that re-spawns a child
+    # mid-reap is defended by per-signal revalidation, but leaf-first keeps the
+    # common case clean. Highest pid first is a cheap, stable leaf-to-root proxy.
+    captured.sort(key=lambda item: int(item["pid"]), reverse=True)
+    return captured
+
+
+def reap_captured(
+    captured: list[dict[str, object]],
+    patterns: list[re.Pattern[str]],
+    grace_seconds: float,
+) -> dict[str, list[dict[str, object]]]:
+    """Reap a previously-captured subtree PID set, revalidating each PID against
+    its captured metadata immediately before EVERY signal (PID-reuse defense).
+
+    Fail-soft and idempotent: a vanished PID is success/no-op (ESRCH), a PID
+    whose identity changed since capture is skipped, and a permission failure is
+    recorded as an error without raising.
+    """
+    pattern_by_str = {pattern.pattern: pattern for pattern in patterns}
+    killed: list[dict[str, object]] = []
+    skipped: list[dict[str, object]] = []
+    errors: list[dict[str, object]] = []
+    self_pid = os.getpid()
+    parent_pid = os.getppid()
+    for item in captured:
+        try:
+            pid = int(item["pid"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        enriched = dict(item)
+        # Never signal self or our own parent — a captured set should never
+        # contain them, but this is the cheap structural guard the reviewer
+        # asked for ("PID is not self/parent").
+        if pid in (self_pid, parent_pid):
+            enriched["kill_status"] = "skipped-self-or-parent"
+            skipped.append(enriched)
+            continue
+        expected_pattern = pattern_by_str.get(str(item.get("pattern")))
+        if expected_pattern is None:
+            # Defensive: never signal a pid we cannot revalidate against a
+            # within-subtree allowlist pattern.
+            enriched["kill_status"] = "skipped-no-pattern"
+            skipped.append(enriched)
+            continue
+        # ppid-agnostic revalidation: the captured codex reparents to init when
+        # we tear its pane down on the daemon path, which is expected — see
+        # kill_pid_subtree / still_killable_subtree.
+        ok, status = kill_pid_subtree(
+            pid,
+            grace_seconds,
+            str(item.get("command", "")),
+            expected_pattern,
+            int(item.get("age_seconds", 0)),
+        )
+        enriched["kill_status"] = status
+        if status.startswith("skipped-"):
+            skipped.append(enriched)
+        elif ok:
+            killed.append(enriched)
+        else:
+            errors.append(enriched)
+    return {"killed": killed, "skipped": skipped, "errors": errors}
+
+
+def build_subtree_report(args: argparse.Namespace) -> dict[str, object]:
+    """`subtree` subcommand: surgical per-session reap of the codex/app-server/
+    MCP descendants of a known tmux pane PID.
+
+    Three shapes, all scoped to ONE torn-down session's pane subtree:
+      * --capture-only --root-pid N   → emit the captured PID+metadata set
+        (used on the daemon idle-kill path BEFORE `tmux kill-session`).
+      * --pids-json '[...]'           → reap a previously-captured set (used
+        AFTER the kill, so we never rediscover globally once the pane is gone).
+      * --root-pid N (no flags)       → capture-then-reap in one shot (the
+        clean-exit / kill-agent-session path, where the pane is still alive).
+    """
+    patterns = compile_patterns(args.pattern or SUBTREE_ALLOWLIST_PATTERNS)
+
+    if args.pids_json is not None:
+        try:
+            captured = json.loads(args.pids_json)
+        except (ValueError, TypeError):
+            captured = []
+        if not isinstance(captured, list):
+            captured = []
+        root_pid = int(args.root_pid) if args.root_pid is not None else -1
+    else:
+        if args.root_pid is None:
+            return {
+                "mode": "subtree",
+                "root_pid": None,
+                "captured_count": 0,
+                "captured": [],
+                "killed_count": 0,
+                "skipped_count": 0,
+                "killed": [],
+                "skipped": [],
+                "errors": [],
+                "error": "no-root-pid",
+            }
+        root_pid = int(args.root_pid)
+        captured = capture_subtree(root_pid, patterns)
+
+    if args.capture_only:
+        return {
+            "mode": "subtree-capture",
+            "root_pid": root_pid,
+            "captured_count": len(captured),
+            "captured": captured,
+        }
+
+    result = reap_captured(captured, patterns, args.grace_seconds)
+    killed_rss_kb = sum(int(item.get("rss_kb") or 0) for item in result["killed"])
+    return {
+        "mode": "subtree",
+        "trigger": args.trigger,
+        "root_pid": root_pid,
+        "captured_count": len(captured),
+        "killed_count": len(result["killed"]),
+        "skipped_count": len(result["skipped"]),
+        "error_count": len(result["errors"]),
+        "freed_mb_estimate": round(killed_rss_kb / 1024, 1),
+        "captured": captured,
+        "killed": result["killed"],
+        "skipped": result["skipped"],
+        "errors": result["errors"],
+    }
+
+
+def extract_captured_pids(report_text: str) -> str:
+    """Parse a `subtree --capture-only` JSON report and re-emit its `captured`
+    array as a compact JSON list (for `--pids-json`). Empty string on any
+    parse failure so the bash caller can no-op without hand-rolling JSON."""
+    try:
+        report = json.loads(report_text)
+    except (ValueError, TypeError):
+        return ""
+    if not isinstance(report, dict):
+        return ""
+    captured = report.get("captured")
+    if not isinstance(captured, list):
+        return ""
+    return json.dumps(captured, ensure_ascii=False)
+
+
+def subtree_audit_summary(report_text: str) -> str:
+    """Render a redacted one-line `key=value` summary of a subtree reap report
+    for the audit log. ONLY counts + the freed-MB estimate leave the process —
+    never the captured command strings (which can carry cwd/paths). Returns ''
+    when there was nothing worth recording (no captures and no skips/errors)."""
+    try:
+        report = json.loads(report_text)
+    except (ValueError, TypeError):
+        return ""
+    if not isinstance(report, dict):
+        return ""
+    captured = int(report.get("captured_count") or 0)
+    killed = int(report.get("killed_count") or 0)
+    skipped = int(report.get("skipped_count") or 0)
+    errors = int(report.get("error_count") or 0)
+    if captured == 0 and killed == 0 and skipped == 0 and errors == 0:
+        return ""
+    freed = report.get("freed_mb_estimate") or 0
+    return (
+        f"captured={captured} killed={killed} "
+        f"skipped={skipped} errors={errors} freed_mb={freed}"
+    )
+
+
 def build_report(args: argparse.Namespace) -> dict[str, object]:
     patterns = compile_patterns(args.pattern or DEFAULT_PATTERNS)
     processes = load_processes()
@@ -401,7 +737,60 @@ def main() -> int:
         child.add_argument("--kill", action="store_true")
         child.add_argument("--dry-run", action="store_true")
 
+    # Incident #9770 Track 2 — surgical per-session subtree reap.
+    subtree = subparsers.add_parser("subtree")
+    subtree.add_argument("--json", action="store_true")
+    subtree.add_argument(
+        "--root-pid",
+        type=int,
+        default=None,
+        help="tmux pane PID of the torn-down session (subtree root)",
+    )
+    subtree.add_argument(
+        "--pids-json",
+        default=None,
+        help="reap a previously-captured PID+metadata set (JSON list)",
+    )
+    subtree.add_argument(
+        "--capture-only",
+        action="store_true",
+        help="emit the captured set without reaping (daemon pre-kill capture)",
+    )
+    subtree.add_argument("--pattern", action="append")
+    subtree.add_argument("--trigger", default="subtree")
+    subtree.add_argument("--grace-seconds", type=float, default=1.0)
+
+    # Shell-side glue for the subtree reap: parse the captured array out of a
+    # capture-only report (so bash never hand-rolls JSON), and render a redacted
+    # one-line audit summary. Kept here (not a separate helper) so the whole
+    # subtree contract lives in one file.
+    extract = subparsers.add_parser("subtree-extract-captured")
+    extract.add_argument("--report", required=True)
+    audit = subparsers.add_parser("subtree-audit-summary")
+    audit.add_argument("--report", required=True)
+
     args = parser.parse_args()
+
+    if args.command == "subtree":
+        report = build_subtree_report(args)
+        if args.json:
+            print(json.dumps(report, ensure_ascii=False, indent=2))
+        else:
+            print(f"mode: {report.get('mode')}")
+            print(f"root_pid: {report.get('root_pid')}")
+            print(f"captured: {report.get('captured_count', 0)}")
+            print(f"killed: {report.get('killed_count', 0)}")
+            print(f"skipped: {report.get('skipped_count', 0)}")
+        return 0
+
+    if args.command == "subtree-extract-captured":
+        print(extract_captured_pids(args.report))
+        return 0
+
+    if args.command == "subtree-audit-summary":
+        print(subtree_audit_summary(args.report))
+        return 0
+
     if args.command == "scan":
         args.kill = False
     elif args.dry_run:

--- a/bridge-mcp-cleanup.py
+++ b/bridge-mcp-cleanup.py
@@ -270,6 +270,35 @@ def read_proc_identity(pid: int) -> tuple[str, int, int] | None:
     return None
 
 
+def read_proc_lstart(pid: int) -> str:
+    """Read a pid's ABSOLUTE process start timestamp via `ps -o lstart=`.
+
+    `lstart` is the wall-clock instant the process started (e.g.
+    "Thu Jun  5 12:47:56 2026"). It is portable on both macOS and Linux, stable
+    for the entire life of that exact process, and — combined with the numeric
+    pid — a UNIQUE process identity: a recycled pid is a NEW process with a
+    DIFFERENT start time. We read it in a dedicated ps call (not folded into
+    read_proc_identity) because lstart carries internal spaces that would make a
+    single positional split against `command=` fragile.
+
+    Returns the whitespace-normalized timestamp, or "" if the pid is gone /
+    unreadable (callers treat "" as "cannot prove identity" → refuse to signal).
+    """
+    try:
+        completed = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError:
+        return ""
+    # Collapse internal runs of whitespace so the captured form and the
+    # re-read form compare byte-for-byte regardless of ps padding.
+    return " ".join(completed.stdout.split())
+
+
 def still_killable(
     pid: int,
     expected_command: str,
@@ -341,21 +370,30 @@ def still_killable_subtree(
     pid: int,
     expected_command: str,
     expected_pattern: re.Pattern[str],
+    expected_lstart: str,
     min_observed_age: int,
 ) -> bool:
     """PID-reuse guard for the SUBTREE reap path (#9770 Track 2).
 
-    Identical to `still_killable` EXCEPT it deliberately drops the parent-PID
-    constraint. On the daemon idle-kill path we capture the codex/app-server/MCP
-    descendants of a pane PID and reap them AFTER `tmux kill-session` — which
-    tears the pane down, so the captured codex REPARENTS to init/launchd. That
-    reparent is the expected, benign signal of the teardown we initiated, not a
-    PID-reuse event, so a ppid check would wrongly refuse to reap the very leak
-    we are trying to close. PID reuse is still defended by the triple (a) the
-    pid still exists, (b) it still matches the within-subtree allowlist, (c) its
-    command string is byte-identical to the captured command, and (d) it is no
-    younger than when captured (a recycled pid is a fresh, younger process).
+    This path deliberately drops the parent-PID constraint: on the daemon
+    idle-kill path we capture the codex/app-server/MCP descendants of a pane PID
+    and reap them AFTER `tmux kill-session`, which tears the pane down so the
+    captured codex REPARENTS to init/launchd. That reparent is the expected,
+    benign signal of the teardown we initiated, not a PID-reuse event, so a ppid
+    check would wrongly refuse to reap the very leak we are trying to close.
+
+    Because the ppid check is gone, the PID-reuse defense is anchored on the
+    process's ABSOLUTE start time (`lstart`): pid + start-time is a unique
+    process identity, so a numeric pid recycled between capture and reap — now an
+    unrelated process that merely happens to share the command string — has a
+    DIFFERENT start time and is REFUSED here. This exact-match is the identity
+    guarantee; the allowlist + byte-identical command + age-not-younger checks
+    are secondary coarse filters, NOT the identity check. An empty captured or
+    live `lstart` (unreadable) fails closed — we never signal a pid we cannot
+    prove the identity of.
     """
+    if not expected_lstart:
+        return False
     identity = read_proc_identity(pid)
     if identity is None:
         return False
@@ -364,6 +402,12 @@ def still_killable_subtree(
         return False
     if command != expected_command:
         return False
+    # Identity check: the live process must have the SAME absolute start time as
+    # the one we captured. A recycled pid is a fresh process with a later start.
+    live_lstart = read_proc_lstart(pid)
+    if not live_lstart or live_lstart != expected_lstart:
+        return False
+    # Secondary coarse filter only (start-time already proved identity).
     if age < min_observed_age:
         return False
     return True
@@ -374,13 +418,15 @@ def kill_pid_subtree(
     grace_seconds: float,
     expected_command: str,
     expected_pattern: re.Pattern[str],
+    expected_lstart: str,
     min_observed_age: int,
 ) -> tuple[bool, str]:
-    """SIGTERM→grace→SIGKILL with ppid-agnostic PID-reuse revalidation before
-    every signal. Fail-soft + idempotent: ESRCH is success/no-op; a vanished or
-    identity-changed pid is skipped rather than signalled."""
+    """SIGTERM→grace→SIGKILL with ppid-agnostic, start-time-anchored PID-reuse
+    revalidation before every signal. Fail-soft + idempotent: ESRCH is
+    success/no-op; a vanished or identity-changed pid is skipped rather than
+    signalled."""
     # PID-reuse revalidation IMMEDIATELY before SIGTERM.
-    if not still_killable_subtree(pid, expected_command, expected_pattern, min_observed_age):
+    if not still_killable_subtree(pid, expected_command, expected_pattern, expected_lstart, min_observed_age):
         return True, "skipped-pid-reuse"
     try:
         os.kill(pid, signal.SIGTERM)
@@ -398,9 +444,9 @@ def kill_pid_subtree(
     # Revalidate again before escalating to SIGKILL — the pid may have exited
     # (and possibly been recycled) during the grace window. A process that has
     # become a zombie (SIGTERM took effect, parent has not reaped it yet) no
-    # longer matches the captured command, so this correctly reports it as
-    # already-terminated rather than re-signalling a recycled pid.
-    if not still_killable_subtree(pid, expected_command, expected_pattern, min_observed_age):
+    # longer matches the captured command/start-time, so this correctly reports
+    # it as already-terminated rather than re-signalling a recycled pid.
+    if not still_killable_subtree(pid, expected_command, expected_pattern, expected_lstart, min_observed_age):
         return True, "terminated"
     try:
         os.kill(pid, signal.SIGKILL)
@@ -456,9 +502,11 @@ def capture_subtree(root_pid: int, patterns: list[re.Pattern[str]]) -> list[dict
     session's tmux pane PID), with per-PID metadata for later revalidation.
 
     Returns a leaf-to-root–ordered list (highest pid first as a cheap proxy) of
-    {pid, ppid, age_seconds, rss_kb, pattern, command}. Only processes whose
-    command matches the within-subtree allowlist are captured — a non-codex
-    child the user opened in the same pane is intentionally left out.
+    {pid, ppid, age_seconds, rss_kb, pattern, command, lstart}. `lstart` is the
+    absolute process start timestamp that anchors the PID-reuse identity check at
+    reap time. Only processes whose command matches the within-subtree allowlist
+    are captured — a non-codex child the user opened in the same pane is
+    intentionally left out.
     """
     processes = load_processes()
     captured: list[dict[str, object]] = []
@@ -474,6 +522,10 @@ def capture_subtree(root_pid: int, patterns: list[re.Pattern[str]]) -> list[dict
                 "rss_kb": proc.rss_kb,
                 "pattern": pattern,
                 "command": proc.command,
+                # Absolute start time = the PID-reuse identity anchor. Captured
+                # here (while the process is still the one we walked) so a later
+                # reap can prove the live pid is the SAME process.
+                "lstart": read_proc_lstart(proc.pid),
             }
         )
     # Reap children before their parents: a parent that re-spawns a child
@@ -521,14 +573,24 @@ def reap_captured(
             enriched["kill_status"] = "skipped-no-pattern"
             skipped.append(enriched)
             continue
-        # ppid-agnostic revalidation: the captured codex reparents to init when
-        # we tear its pane down on the daemon path, which is expected — see
-        # kill_pid_subtree / still_killable_subtree.
+        expected_lstart = str(item.get("lstart") or "")
+        if not expected_lstart:
+            # Fail closed: without a captured start time we cannot prove the
+            # live pid is the SAME process (PID-reuse defense), so refuse to
+            # signal it. This only happens if capture could not read lstart.
+            enriched["kill_status"] = "skipped-no-lstart"
+            skipped.append(enriched)
+            continue
+        # ppid-agnostic revalidation anchored on the absolute start time: the
+        # captured codex reparents to init when we tear its pane down on the
+        # daemon path (expected), but a recycled pid has a different lstart and
+        # is refused — see kill_pid_subtree / still_killable_subtree.
         ok, status = kill_pid_subtree(
             pid,
             grace_seconds,
             str(item.get("command", "")),
             expected_pattern,
+            expected_lstart,
             int(item.get("age_seconds", 0)),
         )
         enriched["kill_status"] = status

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -880,6 +880,17 @@ bridge_run_cleanup_mcp_orphans() {
   [[ "${BRIDGE_MCP_ORPHAN_CLEANUP_ENABLED:-1}" == "1" ]] || return 0
   [[ "$min_age" =~ ^[0-9]+$ ]] || min_age=0
 
+  # Incident #9770 Track 2: surgically reap THIS session's own codex
+  # app-server + Pencil MCP subtree on clean pane exit. The pane is still
+  # alive here (this runs in the exit handler before the tmux session is
+  # gone), so a single resolve of the pane PID is race-free. Scoped to the
+  # pane's descendants only — a live roster codex in a different pane is
+  # never reachable. Fail-soft; must not block exit.
+  if command -v bridge_codex_subtree_reap_for_session >/dev/null 2>&1; then
+    bridge_codex_subtree_reap_for_session "$SESSION" "$AGENT" "session-exit:${AGENT}" \
+      >/dev/null 2>&1 || true
+  fi
+
   # Give orphaned MCP grandchildren a brief chance to be reparented to init
   # before scanning, otherwise the conservative detector can miss them.
   sleep 0.2

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -10424,6 +10424,8 @@ bridge_kill_agent_session() {
   local agent="$1"
   local session
   local attempt
+  local codex_subtree_capture=""
+  local codex_subtree_root_pid=""
 
   session="$(bridge_agent_session "$agent")"
   if [[ -z "$session" ]]; then
@@ -10434,6 +10436,17 @@ bridge_kill_agent_session() {
   if ! bridge_tmux_session_exists "$session"; then
     bridge_warn "이미 종료된 세션입니다: $agent/$session"
     return 1
+  fi
+
+  # Incident #9770 Track 2: capture this session's codex app-server + Pencil
+  # MCP subtree BEFORE the tmux kill, while the pane PID is still resolvable.
+  # `tmux kill-session` reparents the codex chain to a non-PPID-1 ancestor on
+  # macOS where the global orphan cleaner cannot reach it, so we resolve the
+  # set up front and reap it explicitly after the session is gone. Scoped to
+  # the pane subtree only — never a live roster codex in a different pane.
+  if command -v bridge_codex_subtree_capture >/dev/null 2>&1; then
+    codex_subtree_root_pid="$(bridge_codex_subtree_pane_pid "$session" 2>/dev/null || true)"
+    codex_subtree_capture="$(bridge_codex_subtree_capture "$session" 2>/dev/null || true)"
   fi
 
   bridge_tmux_kill_session "$session"
@@ -10448,6 +10461,20 @@ bridge_kill_agent_session() {
     return 1
   fi
   sleep 0.2
+  # Reap the captured codex subtree (fail-soft). When the pane PID was
+  # unresolvable, codex_subtree_root_pid is empty and the helper no-ops + the
+  # _for_session fallback below records the skip-audit instead of a global
+  # sweep.
+  if command -v bridge_codex_subtree_reap_captured >/dev/null 2>&1; then
+    if [[ -n "$codex_subtree_root_pid" ]]; then
+      bridge_codex_subtree_reap_captured "$agent" "$codex_subtree_root_pid" \
+        "$codex_subtree_capture" "session-kill:${agent}" >/dev/null 2>&1 || true
+    else
+      bridge_audit_log daemon codex_subtree_reap_skipped_no_pane codex \
+        --detail "label=${agent}" --detail "session=${session}" \
+        --detail "reason=pane-pid-unresolvable" >/dev/null 2>&1 || true
+    fi
+  fi
   bridge_mcp_orphan_cleanup_after_session_stop "$agent" >/dev/null 2>&1 || true
   bridge_agent_port_aware_orphan_cleanup_after_session_stop "$agent" \
     >/dev/null 2>&1 || true

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1672,6 +1672,154 @@ bridge_mcp_orphan_cleanup_after_session_stop() {
   bridge_mcp_orphan_cleanup "session-stop:${agent}" "$min_age" 1
 }
 
+# ---------------------------------------------------------------------------
+# Incident #9770 Track 2 — surgical per-session codex app-server subtree reap.
+#
+# Codex launches in a tmux pane (bridge-state.sh:111/113/161) and internally
+# spawns a `codex app-server` child + Pencil `mcp-server-darwin-arm64`
+# grandchildren whose PIDs are tracked nowhere. The global orphan cleaner
+# (bridge_mcp_orphan_cleanup) deliberately does NOT match codex (a live roster
+# `codex resume` must never be a global-kill candidate), so on teardown the
+# app-server reparents to a non-PPID-1 ancestor on macOS and survives → a
+# linear memory leak (incident #9770).
+#
+# These helpers reap ONLY the descendant subtree of the SPECIFIC torn-down
+# session's tmux pane PID, filtered to the codex/app-server/MCP allowlist that
+# lives in bridge-mcp-cleanup.py (`subtree` subcommand). The blast-radius
+# guarantee is by construction: a live roster codex / in-progress reviewer is a
+# descendant of ITS OWN live pane, never of a different torn-down session, and
+# the operator's interactive codex is not a bridge-pane descendant at all — so
+# neither can ever appear in the captured set. The Python is invoked
+# file-as-argv (no heredoc-stdin → footgun #11).
+bridge_codex_subtree_enabled() {
+  [[ "${BRIDGE_CODEX_SUBTREE_REAP_ENABLED:-1}" == "1" ]]
+}
+
+# Resolve the tmux pane PID for a session, validated numeric. Empty on failure.
+bridge_codex_subtree_pane_pid() {
+  local session="$1"
+  local pane_pid=""
+
+  [[ -n "$session" ]] || return 0
+  pane_pid="$(bridge_tmux_session_pane_pid "$session" 2>/dev/null || true)"
+  [[ "$pane_pid" =~ ^[0-9]+$ ]] || return 0
+  printf '%s' "$pane_pid"
+}
+
+# Capture (without reaping) the codex/app-server/MCP descendants of the
+# session's pane. Used on the daemon idle/orphan-kill path BEFORE
+# `tmux kill-session`, so the set is resolved while the pane is still alive and
+# then reaped after the kill. Emits the captured-set JSON on stdout (the full
+# `subtree --capture-only` report). Emits nothing when the pane PID cannot be
+# resolved (caller treats that as skip+audit, never a global sweep).
+bridge_codex_subtree_capture() {
+  local session="$1"
+  local pane_pid=""
+
+  bridge_codex_subtree_enabled || return 0
+  pane_pid="$(bridge_codex_subtree_pane_pid "$session")"
+  [[ -n "$pane_pid" ]] || return 0
+
+  bridge_require_python
+  python3 "$BRIDGE_SCRIPT_DIR/bridge-mcp-cleanup.py" subtree \
+    --root-pid "$pane_pid" --capture-only --json 2>/dev/null || true
+}
+
+# Reap a previously-captured subtree set (the JSON emitted by
+# bridge_codex_subtree_capture). Revalidates each PID against its captured
+# metadata immediately before every signal (PID-reuse defense, in the Python).
+# Fail-soft + idempotent; never breaks the caller's teardown.
+bridge_codex_subtree_reap_captured() {
+  local label="$1"
+  local root_pid="$2"
+  local captured_json="$3"
+  local trigger="${4:-codex-subtree}"
+  local pids_json=""
+  local report=""
+
+  bridge_codex_subtree_enabled || return 0
+  [[ "$root_pid" =~ ^[0-9]+$ ]] || return 0
+
+  # Extract the captured array from the capture-only report; if absent or the
+  # report is empty, there is nothing to reap.
+  pids_json="$(bridge_codex_subtree_extract_captured "$captured_json")"
+  [[ -n "$pids_json" && "$pids_json" != "[]" ]] || return 0
+
+  bridge_require_python
+  report="$(python3 "$BRIDGE_SCRIPT_DIR/bridge-mcp-cleanup.py" subtree \
+    --root-pid "$root_pid" --pids-json "$pids_json" --trigger "$trigger" \
+    --json 2>/dev/null || true)"
+  bridge_codex_subtree_audit "$label" "$root_pid" "$report"
+}
+
+# One-shot capture+reap of the session's own pane subtree. Used on the clean
+# pane-exit path (bridge-run.sh) and bridge_kill_agent_session, where the pane
+# is still alive at reap time so a single resolve is race-free. Skips + audits
+# (never a global sweep) when the pane PID is unresolvable.
+bridge_codex_subtree_reap_for_session() {
+  local session="$1"
+  local label="${2:-$session}"
+  local trigger="${3:-codex-subtree}"
+  local pane_pid=""
+  local report=""
+
+  bridge_codex_subtree_enabled || return 0
+  [[ -n "$session" ]] || return 0
+
+  pane_pid="$(bridge_codex_subtree_pane_pid "$session")"
+  if [[ -z "$pane_pid" ]]; then
+    bridge_audit_log daemon codex_subtree_reap_skipped_no_pane codex \
+      --detail "label=${label}" --detail "session=${session}" \
+      --detail "reason=pane-pid-unresolvable" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  bridge_require_python
+  report="$(python3 "$BRIDGE_SCRIPT_DIR/bridge-mcp-cleanup.py" subtree \
+    --root-pid "$pane_pid" --trigger "$trigger" --json 2>/dev/null || true)"
+  bridge_codex_subtree_audit "$label" "$pane_pid" "$report"
+}
+
+# Parse the `captured` array out of a `subtree --capture-only` JSON report,
+# re-emitting it as a compact JSON list for `--pids-json`. Empty string when the
+# report is missing/unparseable (caller no-ops). Pure stdlib json; no secrets.
+bridge_codex_subtree_extract_captured() {
+  local report="$1"
+
+  [[ -n "$report" ]] || return 0
+  bridge_require_python
+  python3 "$BRIDGE_SCRIPT_DIR/bridge-mcp-cleanup.py" subtree-extract-captured \
+    --report "$report" 2>/dev/null || true
+}
+
+# Emit a redacted audit row for a subtree reap. Only safe metadata leaves the
+# process: pane_pid, captured/killed/skipped counts, freed-MB estimate — never
+# the command strings (which can carry cwd/paths). Best-effort.
+bridge_codex_subtree_audit() {
+  local label="$1"
+  local root_pid="$2"
+  local report="$3"
+  local summary=""
+
+  [[ -n "$report" ]] || return 0
+  bridge_require_python
+  # The helper prints space-separated `key=value` tokens (already redacted) or
+  # nothing when there was no reap activity worth recording.
+  summary="$(python3 "$BRIDGE_SCRIPT_DIR/bridge-mcp-cleanup.py" subtree-audit-summary \
+    --report "$report" 2>/dev/null || true)"
+  [[ -n "$summary" ]] || return 0
+
+  local -a detail_args=()
+  detail_args+=(--detail "label=${label}")
+  detail_args+=(--detail "pane_pid=${root_pid}")
+  local token=""
+  for token in $summary; do
+    detail_args+=(--detail "$token")
+  done
+  bridge_audit_log daemon codex_session_subtree_reaped codex \
+    "${detail_args[@]}" >/dev/null 2>&1 || true
+}
+
 bridge_dynamic_agent_ids() {
   local agent
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -142,6 +142,11 @@ add_required 8807-cron-backfill-coalesce
 # scripts/smoke/* catch-all → add_all_required_static — still re-runs the
 # reaper-pattern smoke.
 add_required 8807-mcp-reaper-patterns
+# Incident #9770 Track 2: surgical per-session codex app-server / Pencil MCP
+# subtree reap. In the full static suite so a change to bridge-mcp-cleanup.py,
+# the helper, or any of the three teardown seams (bridge-run.sh /
+# bridge_kill_agent_session / daemon idle-kill) re-runs the #1-invariant proof.
+add_required 9770-codex-teardown-reap
 # #8945 Track A: the engine-aware urgent-nudge-body smoke. In the full static
 # suite so a scripts/smoke/* or lib/bridge-agents.sh change re-runs it via the
 # catch-all. (1067-codex-provisioning is already listed above.)
@@ -491,7 +496,23 @@ select_for_path() {
         # corrupts the preserved mode. Pull the smoke on every bridge-state.sh
         # move so a refactor cannot silently revert to the wrong-order class.
         add_required 1402-stat-platform-order
+        # Incident #9770 Track 2: lib/bridge-state.sh hosts the codex subtree
+        # reap helpers (bridge_codex_subtree_capture / _reap_captured /
+        # _reap_for_session / _audit) that all three teardown seams call, plus
+        # the redacted audit summary. Pull 9770-codex-teardown-reap on every
+        # bridge-state.sh move so a refactor cannot drop a helper, leak command
+        # strings into the audit, or weaken the within-subtree allowlist filter.
+        add_required 9770-codex-teardown-reap
       fi
+      ;;
+
+    bridge-run.sh)
+      # Incident #9770 Track 2: bridge-run.sh's bridge_run_cleanup_mcp_orphans
+      # is the clean-pane-exit teardown seam that one-shot captures+reaps the
+      # session's own codex pane subtree (while the pane is still alive). Pull
+      # 9770-codex-teardown-reap on every bridge-run.sh move so a refactor
+      # cannot drop the clean-exit subtree reap or its skip+audit fallback.
+      add_required 9770-codex-teardown-reap
       ;;
   esac
 
@@ -1444,6 +1465,13 @@ select_for_path() {
       # pressure-relief ordering and the single-invocation invariant cannot
       # silently regress.
       add_required 8807-mcp-reaper-patterns
+      # Incident #9770 Track 2: bridge-daemon.sh's reap_idle_orphan_sessions is
+      # one of the three central teardown seams that capture the codex pane
+      # subtree BEFORE `tmux kill-session` and reap it after. Pull
+      # 9770-codex-teardown-reap on every bridge-daemon.sh move so a refactor
+      # cannot drop the capture-before-kill ordering or the skip+audit (never a
+      # global sweep) when the pane PID is unresolvable.
+      add_required 9770-codex-teardown-reap
       # PR-B / #1520b: bridge-daemon.sh's bridge_daemon_autostart_allowed
       # gained the credential-pending hold predicate (return-hold-without-
       # backoff while the marker is present + the credential absent, lazy
@@ -1478,6 +1506,14 @@ select_for_path() {
       # the control matrix and the pre-TERM/pre-KILL revalidation cannot
       # regress.
       add_required 8807-mcp-reaper-patterns
+      # Incident #9770 Track 2: the reaper now hosts the surgical per-session
+      # subtree mode (capture_subtree / reap_captured / kill_pid_subtree +
+      # SUBTREE_ALLOWLIST_PATTERNS, kept OUT of DEFAULT_PATTERNS). Pull
+      # 9770-codex-teardown-reap on every reaper move so a refactor cannot
+      # weaken the #1 invariant (a live roster codex / in-progress review is
+      # never killed), leak codex names into the global DEFAULT_PATTERNS, or
+      # regress the per-signal PID-reuse revalidation.
+      add_required 9770-codex-teardown-reap
       ;;
 
     lib/bridge-daemon-control.sh|scripts/install-daemon-systemd.sh|scripts/sudoers-templates/agent-bridge-daemon-refresh.sudo.template)

--- a/scripts/smoke/9770-codex-teardown-reap-helper.py
+++ b/scripts/smoke/9770-codex-teardown-reap-helper.py
@@ -29,6 +29,7 @@ import ast
 import importlib.util
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -391,6 +392,101 @@ def cmd_default_patterns_codex_free(reaper_path: str) -> int:
     return 0
 
 
+def cmd_start_time_identity(reaper_path: str) -> int:
+    """(h) PID-reuse identity guard — the regression guard for the codex
+    Phase-4 BLOCKING finding. A captured entry with the SAME pid + SAME command
+    + a relaxed/equal age (which would have passed the old `age >= captured_age`
+    check) but a DIFFERENT absolute start time (lstart) must NOT be killed: a
+    recycled pid is a different process with a different start time.
+
+    Driven against a real live codex-named process so read_proc_lstart returns a
+    genuine timestamp. We do not actually recycle the pid (impossible on demand);
+    instead we assert the predicate + reap path refuse the mismatched-lstart
+    identity while accepting the exact one.
+    """
+    mod = _load_module(reaper_path)
+    child = subprocess.Popen(
+        ["codex app-server", "120"],
+        executable="/bin/sleep",
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        pid = child.pid
+        true_lstart = ""
+        for _ in range(60):
+            true_lstart = mod.read_proc_lstart(pid)
+            if true_lstart:
+                break
+            time.sleep(0.05)
+        if not true_lstart:
+            print("could not read live child lstart", file=sys.stderr)
+            return 1
+        cmd = "codex app-server 120"
+        pat = re.compile(r"(?:^|/)codex\s+app-server\b")
+
+        # Exact identity (correct lstart) IS killable.
+        if not mod.still_killable_subtree(pid, cmd, pat, true_lstart, 0):
+            print("exact-identity (correct lstart) was wrongly refused", file=sys.stderr)
+            return 1
+        # THE BUG: same pid + same command + captured_age 0 (would pass old age
+        # check) but WRONG lstart → MUST refuse.
+        if mod.still_killable_subtree(pid, cmd, pat, "Mon Jan  1 00:00:00 2000", 0):
+            print("PID-REUSE REGRESSION: a wrong-lstart same-command pid was accepted (captured_age=0)", file=sys.stderr)
+            return 1
+        # Same, but with an age that aged PAST the captured value (old check:
+        # later_age >= captured_age=0 → accept). Wrong lstart must still refuse.
+        if mod.still_killable_subtree(pid, cmd, pat, "Mon Jan  1 00:00:00 2000", 99999):
+            print("PID-REUSE REGRESSION: wrong-lstart accepted under relaxed/older age", file=sys.stderr)
+            return 1
+        # Empty captured lstart → fail closed.
+        if mod.still_killable_subtree(pid, cmd, pat, "", 0):
+            print("empty captured lstart was not fail-closed", file=sys.stderr)
+            return 1
+
+        # End-to-end through reap_captured: a captured set whose lstart is wrong
+        # must SKIP (not kill) and the process must survive; the kill_status must
+        # be the pid-reuse skip, not a kill.
+        wrong = [{
+            "pid": pid, "ppid": 1, "age_seconds": 0, "rss_kb": 0,
+            "pattern": pat.pattern, "command": cmd,
+            "lstart": "Mon Jan  1 00:00:00 2000",
+        }]
+        res = mod.reap_captured(wrong, [pat], 0.2)
+        if res["killed"]:
+            print(f"reap_captured KILLED a wrong-lstart pid: {res['killed']}", file=sys.stderr)
+            return 1
+        statuses = {str(i.get("kill_status")) for i in res["skipped"]}
+        if "skipped-pid-reuse" not in statuses:
+            print(f"reap_captured did not skip-pid-reuse the wrong-lstart pid: {res}", file=sys.stderr)
+            return 1
+        time.sleep(0.3)
+        if not _alive_running(pid):
+            print("the wrong-lstart process was killed (must survive)", file=sys.stderr)
+            return 1
+
+        # A captured set with NO lstart must fail closed (skipped-no-lstart).
+        missing = [{
+            "pid": pid, "ppid": 1, "age_seconds": 0, "rss_kb": 0,
+            "pattern": pat.pattern, "command": cmd, "lstart": "",
+        }]
+        res2 = mod.reap_captured(missing, [pat], 0.2)
+        statuses2 = {str(i.get("kill_status")) for i in res2["skipped"]}
+        if "skipped-no-lstart" not in statuses2 or res2["killed"]:
+            print(f"reap_captured did not fail-closed on missing lstart: {res2}", file=sys.stderr)
+            return 1
+
+        print("[ok] (h) start-time identity — wrong-lstart same-command pid refused (incl relaxed age); missing lstart fails closed")
+        return 0
+    finally:
+        try:
+            child.kill()
+            child.wait(timeout=2)
+        except Exception:
+            pass
+
+
 def main(argv: list[str]) -> int:
     if len(argv) < 3:
         print("usage: 9770-codex-teardown-reap-helper.py <subcommand> <reaper.py>", file=sys.stderr)
@@ -402,6 +498,7 @@ def main(argv: list[str]) -> int:
         "no-pane-skip": cmd_no_pane_skip,
         "idempotent": cmd_idempotent,
         "default-patterns-codex-free": cmd_default_patterns_codex_free,
+        "start-time-identity": cmd_start_time_identity,
     }
     fn = table.get(command)
     if fn is None:

--- a/scripts/smoke/9770-codex-teardown-reap-helper.py
+++ b/scripts/smoke/9770-codex-teardown-reap-helper.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Helper for scripts/smoke/9770-codex-teardown-reap.sh (incident #9770 Track 2).
+
+Drives the surgical per-session codex-subtree reap in bridge-mcp-cleanup.py
+against lightweight stand-in process trees that MIMIC the codex / codex
+app-server / Pencil mcp-server-darwin-arm64 command names and the pane→child
+parentage — without ever spawning a real codex. Invoked file-as-argv (no
+heredoc-stdin — lint-heredoc-ban C3 ban; see KNOWN_ISSUES.md §26):
+
+    9770-...-helper.py reap-survival     <reaper.py>   # (a)(c)(d)(e)
+    9770-...-helper.py capture-then-reap <reaper.py>   # (b) daemon ordering
+    9770-...-helper.py no-pane-skip      <reaper.py>   # (f)
+    9770-...-helper.py idempotent        <reaper.py>   # (g)
+
+Each subcommand exits non-zero (message on stderr) on failure so the calling
+smoke can `|| smoke_fail`.
+
+Stand-in shape: a `/bin/sh` "pane root" that exec-renames /bin/sleep children
+to the codex/app-server/MCP names (and one unrelated non-codex child), then
+blocks. We treat the `/bin/sh` PID as the tmux pane PID and pass it as
+--root-pid. A SECOND such pane root models a live roster codex in a different
+pane; a detached `setsid` codex-named sleep models the operator's non-bridge
+codex outside any pane.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _load_module(reaper_path: str):
+    spec = importlib.util.spec_from_file_location("bridge_mcp_cleanup", reaper_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- stand-in process-tree primitives ------------------------------------
+
+# Each pane is a /bin/sh that renames sleep children via `exec -a`. We capture
+# the child PIDs by having the shell print them, then read them back.
+_PANE_SH = (
+    'exec -a "codex app-server" /bin/sleep 600 & echo "codex=$!"; '
+    'exec -a "mcp-server-darwin-arm64 --stdio" /bin/sleep 600 & echo "mcp=$!"; '
+    'exec -a "some-editor --file x" /bin/sleep 600 & echo "editor=$!"; '
+    'echo "root=$$"; '
+    "sleep 600"
+)
+
+
+class Pane:
+    def __init__(self) -> None:
+        self.proc = subprocess.Popen(
+            ["/bin/sh", "-c", _PANE_SH],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        self.pids: dict[str, int] = {}
+        # Read the four announced PIDs (codex / mcp / editor / root).
+        assert self.proc.stdout is not None
+        for _ in range(4):
+            line = self.proc.stdout.readline().strip()
+            if not line or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            try:
+                self.pids[key] = int(val)
+            except ValueError:
+                pass
+
+    @property
+    def root(self) -> int:
+        # The /bin/sh root PID == the Popen child PID.
+        return self.proc.pid
+
+    def teardown(self) -> None:
+        for pid in list(self.pids.values()) + [self.proc.pid]:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+        try:
+            self.proc.wait(timeout=2)
+        except Exception:
+            pass
+
+
+def _dead(pid: int) -> bool:
+    """True iff pid is gone OR a zombie (<defunct>) — both mean the process was
+    successfully terminated. A non-reaping stand-in parent leaves a zombie that
+    `os.kill(pid,0)` still reports as alive, so we must check the ps state."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "stat=", "-p", str(pid)],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        ).stdout.strip()
+    except OSError:
+        return False
+    if not out:
+        return True
+    return out.startswith("Z")
+
+
+def _alive_running(pid: int) -> bool:
+    return not _dead(pid)
+
+
+def _wait_started(pids: list[int], timeout: float = 3.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if all(_alive_running(p) for p in pids):
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _reap(mod, root_pid: int) -> dict:
+    """Invoke the reaper's one-shot subtree reap (capture+reap) in-process via the
+    module API, mirroring `subtree --root-pid N`."""
+    args = type("A", (), {})()
+    args.pattern = None
+    args.root_pid = root_pid
+    args.pids_json = None
+    args.capture_only = False
+    args.trigger = "smoke"
+    args.grace_seconds = 0.4
+    return mod.build_subtree_report(args)
+
+
+# --- subcommands ----------------------------------------------------------
+
+
+def cmd_reap_survival(reaper_path: str) -> int:
+    """(a) clean-exit reaps A's codex+MCP subtree; (c) a 2nd live roster codex in
+    a DIFFERENT pane survives; (d) a non-bridge codex outside any pane survives;
+    (e) a same-pane non-codex child survives (name-scoped within-subtree filter).
+    """
+    mod = _load_module(reaper_path)
+    pane_a = Pane()
+    pane_b = Pane()
+    # Operator-style non-bridge codex outside ANY pane (detached new session).
+    nb = subprocess.Popen(
+        ["codex", "600"],
+        executable="/bin/sleep",
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        need = [
+            pane_a.pids["codex"], pane_a.pids["mcp"], pane_a.pids["editor"],
+            pane_b.pids["codex"], pane_b.pids["mcp"], nb.pid,
+        ]
+        if not _wait_started(need):
+            print("stand-in processes did not all start", file=sys.stderr)
+            return 1
+
+        report = _reap(mod, pane_a.root)
+
+        # (a) pane A's codex + MCP captured (2) and reaped; editor NOT captured.
+        if report["captured_count"] != 2:
+            print(f"expected 2 captured (codex+mcp), got {report['captured_count']}: {report.get('captured')}", file=sys.stderr)
+            return 1
+        captured_cmds = " ".join(str(c.get("command", "")) for c in report["captured"])
+        if "some-editor" in captured_cmds:
+            print(f"(e) same-pane non-codex editor was captured — within-subtree filter not name-scoped: {captured_cmds}", file=sys.stderr)
+            return 1
+
+        time.sleep(0.5)
+        # (a) pane A codex + MCP dead.
+        if not _dead(pane_a.pids["codex"]):
+            print("(a) pane A codex NOT reaped", file=sys.stderr)
+            return 1
+        if not _dead(pane_a.pids["mcp"]):
+            print("(a) pane A MCP NOT reaped", file=sys.stderr)
+            return 1
+        # (e) pane A's non-codex editor SURVIVES.
+        if not _alive_running(pane_a.pids["editor"]):
+            print("(e) pane A same-pane non-codex editor was killed (must survive)", file=sys.stderr)
+            return 1
+        # (c) pane B codex + MCP SURVIVE — the #1 invariant.
+        if not _alive_running(pane_b.pids["codex"]):
+            print("(c) #1 INVARIANT VIOLATION: pane B live codex was killed by pane A teardown", file=sys.stderr)
+            return 1
+        if not _alive_running(pane_b.pids["mcp"]):
+            print("(c) #1 INVARIANT VIOLATION: pane B MCP was killed by pane A teardown", file=sys.stderr)
+            return 1
+        # (d) non-bridge codex SURVIVES.
+        if not _alive_running(nb.pid):
+            print("(d) operator non-bridge codex outside any pane was killed (must survive)", file=sys.stderr)
+            return 1
+
+        print("[ok] (a) A's codex+MCP reaped; (c) pane B codex survives; (d) non-bridge codex survives; (e) same-pane editor survives")
+        return 0
+    finally:
+        pane_a.teardown()
+        pane_b.teardown()
+        try:
+            nb.kill()
+            nb.wait(timeout=2)
+        except Exception:
+            pass
+
+
+def cmd_capture_then_reap(reaper_path: str) -> int:
+    """(b) daemon idle-kill ordering: capture the subtree BEFORE the pane dies,
+    then reap the captured set AFTER — and prove that rediscovery after the pane
+    is gone would find nothing (so capture-before-kill is load-bearing)."""
+    mod = _load_module(reaper_path)
+    pane = Pane()
+    pane_b = Pane()
+    try:
+        need = [pane.pids["codex"], pane.pids["mcp"], pane_b.pids["codex"]]
+        if not _wait_started(need):
+            print("stand-in processes did not start", file=sys.stderr)
+            return 1
+
+        # Capture BEFORE the kill (the pane root is still alive).
+        cap_args = type("A", (), {})()
+        cap_args.pattern = None
+        cap_args.root_pid = pane.root
+        cap_args.pids_json = None
+        cap_args.capture_only = True
+        cap_args.trigger = "smoke"
+        cap_args.grace_seconds = 0.4
+        cap_report = mod.build_subtree_report(cap_args)
+        captured = cap_report["captured"]
+        if len(captured) != 2:
+            print(f"capture-before-kill expected 2, got {len(captured)}", file=sys.stderr)
+            return 1
+
+        # Kill the pane root (mimics `tmux kill-session`). The codex/mcp children
+        # reparent away from the now-dead /bin/sh.
+        os.kill(pane.root, signal.SIGKILL)
+        try:
+            pane.proc.wait(timeout=2)
+        except Exception:
+            pass
+        time.sleep(0.3)
+
+        # Rediscovery AFTER the pane is gone finds nothing under the (dead) root
+        # — this is exactly why capture-before-kill is required.
+        post_args = type("A", (), {})()
+        post_args.pattern = None
+        post_args.root_pid = pane.root
+        post_args.pids_json = None
+        post_args.capture_only = True
+        post_args.trigger = "smoke"
+        post_args.grace_seconds = 0.4
+        post_report = mod.build_subtree_report(post_args)
+        if post_report["captured_count"] != 0:
+            print(f"post-kill rediscovery unexpectedly found {post_report['captured_count']} (pane root dead)", file=sys.stderr)
+            return 1
+
+        # Reap the PRE-captured set after the kill.
+        reap_args = type("A", (), {})()
+        reap_args.pattern = None
+        reap_args.root_pid = pane.root
+        reap_args.pids_json = json.dumps(captured)
+        reap_args.capture_only = False
+        reap_args.trigger = "smoke"
+        reap_args.grace_seconds = 0.4
+        reap_report = mod.build_subtree_report(reap_args)
+
+        time.sleep(0.5)
+        if not _dead(pane.pids["codex"]):
+            print("(b) captured-before-kill codex NOT reaped after kill", file=sys.stderr)
+            return 1
+        if not _dead(pane.pids["mcp"]):
+            print("(b) captured-before-kill MCP NOT reaped after kill", file=sys.stderr)
+            return 1
+        # #1 invariant still holds across the daemon path.
+        if not _alive_running(pane_b.pids["codex"]):
+            print("(b) #1 INVARIANT VIOLATION: pane B codex killed by daemon path", file=sys.stderr)
+            return 1
+        reaped = reap_report["killed_count"] + reap_report["skipped_count"]
+        if reaped < 2:
+            print(f"(b) reap report did not act on the 2 captured pids: {reap_report}", file=sys.stderr)
+            return 1
+        print("[ok] (b) captured-before-kill subtree reaped after kill; post-kill rediscovery empty; pane B survives")
+        return 0
+    finally:
+        pane.teardown()
+        pane_b.teardown()
+
+
+def cmd_no_pane_skip(reaper_path: str) -> int:
+    """(f) unresolvable pane → skip, no global sweep, no error. A negative
+    root-pid never resolves to a real pane; the report must show 0 captured /
+    0 killed and never touch unrelated codex processes."""
+    mod = _load_module(reaper_path)
+    # A live codex-named process that MUST NOT be touched by a no-pane reap.
+    bystander = subprocess.Popen(
+        ["codex app-server", "600"],
+        executable="/bin/sleep",
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        if not _wait_started([bystander.pid]):
+            print("bystander codex did not start", file=sys.stderr)
+            return 1
+        # root_pid=-1 models "pane PID unresolvable"; descendants_of finds none.
+        report = _reap(mod, -1)
+        if report["captured_count"] != 0 or report["killed_count"] != 0:
+            print(f"(f) unresolvable-pane reap was not a no-op: {report}", file=sys.stderr)
+            return 1
+        time.sleep(0.3)
+        if not _alive_running(bystander.pid):
+            print("(f) unresolvable-pane reap KILLED an unrelated codex (global-sweep regression!)", file=sys.stderr)
+            return 1
+        print("[ok] (f) unresolvable pane → no-op, no global sweep, bystander codex survives")
+        return 0
+    finally:
+        try:
+            bystander.kill()
+            bystander.wait(timeout=2)
+        except Exception:
+            pass
+
+
+def cmd_idempotent(reaper_path: str) -> int:
+    """(g) a 2nd reap pass over the same pane finds nothing / is ESRCH-clean."""
+    mod = _load_module(reaper_path)
+    pane = Pane()
+    try:
+        if not _wait_started([pane.pids["codex"], pane.pids["mcp"]]):
+            print("stand-in processes did not start", file=sys.stderr)
+            return 1
+        first = _reap(mod, pane.root)
+        if first["captured_count"] != 2:
+            print(f"(g) first pass expected 2 captured, got {first['captured_count']}", file=sys.stderr)
+            return 1
+        time.sleep(0.5)
+        # Second pass: children are dead/zombie; capture finds nothing, no error.
+        second = _reap(mod, pane.root)
+        if second["captured_count"] != 0:
+            print(f"(g) 2nd pass should find nothing, found {second['captured_count']}: {second.get('captured')}", file=sys.stderr)
+            return 1
+        if second["killed_count"] != 0 or second.get("error_count", 0) != 0:
+            print(f"(g) 2nd pass not clean: {second}", file=sys.stderr)
+            return 1
+        print("[ok] (g) idempotent — 2nd reap pass finds nothing, ESRCH-clean")
+        return 0
+    finally:
+        pane.teardown()
+
+
+def cmd_default_patterns_codex_free(reaper_path: str) -> int:
+    """Assert DEFAULT_PATTERNS (the GLOBAL orphan path) still does NOT match
+    codex / app-server / Pencil MCP — the codex allowlist lives only in the
+    subtree path, so a live roster `codex resume` can never become a
+    global-cleanup candidate."""
+    src = Path(reaper_path).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    patterns: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "DEFAULT_PATTERNS":
+                    patterns = [ast.literal_eval(elt) for elt in node.value.elts]
+    if not patterns:
+        print("could not extract DEFAULT_PATTERNS", file=sys.stderr)
+        return 1
+    joined = " ".join(patterns)
+    for needle in ("codex", "app-server", "mcp-server-darwin-arm64"):
+        if needle in joined:
+            print(f"DEFAULT_PATTERNS now matches '{needle}' — global orphan path must stay codex-free", file=sys.stderr)
+            return 1
+    print("[ok] DEFAULT_PATTERNS stays codex/app-server/Pencil-MCP free")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print("usage: 9770-codex-teardown-reap-helper.py <subcommand> <reaper.py>", file=sys.stderr)
+        return 2
+    command, reaper = argv[1], argv[2]
+    table = {
+        "reap-survival": cmd_reap_survival,
+        "capture-then-reap": cmd_capture_then_reap,
+        "no-pane-skip": cmd_no_pane_skip,
+        "idempotent": cmd_idempotent,
+        "default-patterns-codex-free": cmd_default_patterns_codex_free,
+    }
+    fn = table.get(command)
+    if fn is None:
+        print(f"unknown subcommand: {command}", file=sys.stderr)
+        return 2
+    return fn(reaper)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/smoke/9770-codex-teardown-reap-helper.py
+++ b/scripts/smoke/9770-codex-teardown-reap-helper.py
@@ -15,12 +15,13 @@ heredoc-stdin — lint-heredoc-ban C3 ban; see KNOWN_ISSUES.md §26):
 Each subcommand exits non-zero (message on stderr) on failure so the calling
 smoke can `|| smoke_fail`.
 
-Stand-in shape: a `/bin/sh` "pane root" that exec-renames /bin/sleep children
-to the codex/app-server/MCP names (and one unrelated non-codex child), then
-blocks. We treat the `/bin/sh` PID as the tmux pane PID and pass it as
---root-pid. A SECOND such pane root models a live roster codex in a different
-pane; a detached `setsid` codex-named sleep models the operator's non-bridge
-codex outside any pane.
+Stand-in shape: a `bash` "pane root" that exec-renames /bin/sleep children to
+the codex/app-server/MCP names (and one unrelated non-codex child) via the bash
+`exec -a` builtin, then blocks. bash is resolved explicitly (NOT `/bin/sh`,
+which is dash on Ubuntu and has no `exec -a`). We treat the pane-root PID as the
+tmux pane PID and pass it as --root-pid. A SECOND such pane root models a live
+roster codex in a different pane; a detached `setsid` codex-named sleep models
+the operator's non-bridge codex outside any pane.
 """
 
 from __future__ import annotations
@@ -30,6 +31,7 @@ import importlib.util
 import json
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
@@ -47,8 +49,31 @@ def _load_module(reaper_path: str):
 
 # --- stand-in process-tree primitives ------------------------------------
 
-# Each pane is a /bin/sh that renames sleep children via `exec -a`. We capture
-# the child PIDs by having the shell print them, then read them back.
+
+def _resolve_bash() -> str:
+    """Resolve a bash interpreter for the pane stand-in.
+
+    The pane body uses `exec -a` to set argv[0] on the /bin/sleep children so
+    their `ps` command matches the codex/app-server/MCP allowlist. `exec -a` is
+    a BASH builtin — on Ubuntu `/bin/sh` is dash, which has no `exec -a`, so the
+    stand-ins would never start (the CI portability bug). Always run the pane
+    body under bash explicitly.
+    """
+    found = shutil.which("bash")
+    if found:
+        return found
+    for candidate in ("/bin/bash", "/usr/bin/bash", "/opt/homebrew/bin/bash", "/usr/local/bin/bash"):
+        if os.path.exists(candidate):
+            return candidate
+    # Last resort: let the OS resolve `bash` from PATH at exec time.
+    return "bash"
+
+
+_BASH_BIN = _resolve_bash()
+
+# Each pane is a bash "pane root" that renames /bin/sleep children via the bash
+# `exec -a` builtin. We capture the child PIDs by having the shell print them,
+# then read them back.
 _PANE_SH = (
     'exec -a "codex app-server" /bin/sleep 600 & echo "codex=$!"; '
     'exec -a "mcp-server-darwin-arm64 --stdio" /bin/sleep 600 & echo "mcp=$!"; '
@@ -61,7 +86,7 @@ _PANE_SH = (
 class Pane:
     def __init__(self) -> None:
         self.proc = subprocess.Popen(
-            ["/bin/sh", "-c", _PANE_SH],
+            [_BASH_BIN, "-c", _PANE_SH],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
@@ -81,7 +106,7 @@ class Pane:
 
     @property
     def root(self) -> int:
-        # The /bin/sh root PID == the Popen child PID.
+        # The bash pane-root PID == the Popen child PID.
         return self.proc.pid
 
     def teardown(self) -> None:
@@ -250,7 +275,7 @@ def cmd_capture_then_reap(reaper_path: str) -> int:
             return 1
 
         # Kill the pane root (mimics `tmux kill-session`). The codex/mcp children
-        # reparent away from the now-dead /bin/sh.
+        # reparent away from the now-dead bash pane root.
         os.kill(pane.root, signal.SIGKILL)
         try:
             pane.proc.wait(timeout=2)

--- a/scripts/smoke/9770-codex-teardown-reap.sh
+++ b/scripts/smoke/9770-codex-teardown-reap.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/9770-codex-teardown-reap.sh — incident #9770 Track 2.
+#
+# Codex launches in a tmux pane and internally spawns a `codex app-server`
+# child + Pencil `mcp-server-darwin-arm64` grandchildren whose PIDs are tracked
+# nowhere. On teardown the global MCP orphan cleaner (DEFAULT_PATTERNS) does NOT
+# match codex — a live roster `codex resume` must never be a global-kill
+# candidate — so on macOS the app-server reparents to a non-PPID-1 ancestor and
+# survives → a linear memory leak.
+#
+# The fix is a SURGICAL per-session subtree reap rooted at the torn-down
+# session's known tmux pane PID (bridge-mcp-cleanup.py `subtree` subcommand,
+# wired into bridge-run.sh clean exit + bridge_kill_agent_session + the daemon
+# idle/orphan-session kill). This smoke proves the #1 invariant — a live roster
+# codex / in-progress review is NEVER killed — using lightweight stand-in
+# processes that MIMIC the codex/app-server/MCP command names + pane parentage.
+# It does NOT spawn a real codex, real tmux, or a real bridge daemon.
+#
+# CI-faithful + self-contained: it drives the REAL bridge-mcp-cleanup.py subtree
+# logic + sources the REAL lib/bridge-state.sh glue, and grep-pins the three
+# teardown seam call sites + the two new audit actions.
+
+set -euo pipefail
+
+SMOKE_NAME="9770-codex-teardown-reap"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REAPER_PY="$SMOKE_REPO_ROOT/bridge-mcp-cleanup.py"
+HELPER_PY="$SCRIPT_DIR/9770-codex-teardown-reap-helper.py"
+RUN_SH="$SMOKE_REPO_ROOT/bridge-run.sh"
+DAEMON_SH="$SMOKE_REPO_ROOT/bridge-daemon.sh"
+STATE_SH="$SMOKE_REPO_ROOT/lib/bridge-state.sh"
+AGENTS_SH="$SMOKE_REPO_ROOT/lib/bridge-agents.sh"
+
+smoke_require_cmd ps
+smoke_require_cmd python3
+
+smoke_log "A1: bridge-mcp-cleanup.py compiles + subtree subcommand wired"
+python3 -c "import py_compile; py_compile.compile('$REAPER_PY', doraise=True)" || \
+  smoke_fail "bridge-mcp-cleanup.py failed py_compile"
+python3 "$REAPER_PY" subtree --root-pid $$ --capture-only --json >/dev/null || \
+  smoke_fail "subtree subcommand not callable"
+
+smoke_log "A2: changed shell files are syntactically valid (bash 4+)"
+# lib/bridge-agents.sh uses `[[ -v assoc[key] ]]` (bash 4.3+), so the `-n` parse
+# must run under a bash 4+ interpreter — the same contract smoke-test.sh enforces
+# for the whole suite. Resolve one (prefer the interpreter already running this
+# smoke), and fail loudly rather than silently passing under macOS bash 3.2.
+BASH4_BIN=""
+for candidate in "${BASH:-}" /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+  [[ -n "$candidate" && -x "$candidate" ]] || continue
+  major="$("$candidate" -c 'printf %s "${BASH_VERSINFO[0]:-0}"' 2>/dev/null || printf 0)"
+  if [[ "$major" =~ ^[0-9]+$ ]] && (( major >= 4 )); then
+    BASH4_BIN="$candidate"
+    break
+  fi
+done
+[[ -n "$BASH4_BIN" ]] || smoke_fail "no bash 4+ interpreter available for bash -n"
+for f in "$RUN_SH" "$DAEMON_SH" "$STATE_SH" "$AGENTS_SH"; do
+  "$BASH4_BIN" -n "$f" || smoke_fail "$(basename "$f") failed bash -n"
+done
+
+# ---------------------------------------------------------------------------
+# The crux: the #1 invariant + negative controls, driven against the real
+# subtree reaper with stand-in process trees.
+# ---------------------------------------------------------------------------
+smoke_log "B: (a) clean-exit reap + (c) 2nd live codex survives + (d) non-bridge codex survives + (e) same-pane non-codex survives"
+python3 "$HELPER_PY" reap-survival "$REAPER_PY" || \
+  smoke_fail "reap-survival assertions failed (#1 invariant or negative control)"
+
+smoke_log "C: (b) daemon idle-kill — capture BEFORE kill, reap captured set AFTER"
+python3 "$HELPER_PY" capture-then-reap "$REAPER_PY" || \
+  smoke_fail "capture-then-reap (daemon ordering) failed"
+
+smoke_log "D: (f) unresolvable pane → skip, no global sweep"
+python3 "$HELPER_PY" no-pane-skip "$REAPER_PY" || \
+  smoke_fail "no-pane-skip (global-sweep guard) failed"
+
+smoke_log "E: (g) idempotent 2nd reap pass is ESRCH-clean"
+python3 "$HELPER_PY" idempotent "$REAPER_PY" || \
+  smoke_fail "idempotent 2nd pass failed"
+
+# ---------------------------------------------------------------------------
+# DEFAULT_PATTERNS must stay codex-free: the global orphan path is untouched, so
+# a live roster `codex resume` can never become a global-cleanup candidate.
+# ---------------------------------------------------------------------------
+smoke_log "F: DEFAULT_PATTERNS does NOT include codex / app-server / Pencil MCP"
+python3 "$HELPER_PY" default-patterns-codex-free "$REAPER_PY" || \
+  smoke_fail "DEFAULT_PATTERNS now matches codex/app-server/Pencil MCP — global orphan path must stay codex-free"
+
+# ---------------------------------------------------------------------------
+# Shell glue: source the real lib stack in an isolated BRIDGE_HOME and exercise
+# the audit-summary redaction (no command strings leak) + extract round-trip.
+# ---------------------------------------------------------------------------
+smoke_log "G: audit summary is redacted (counts only, no command strings)"
+audit_summary="$(python3 "$REAPER_PY" subtree-audit-summary --report \
+  '{"mode":"subtree","captured_count":2,"killed_count":2,"skipped_count":0,"error_count":0,"freed_mb_estimate":3.3,"captured":[{"command":"codex app-server --cwd /Users/secret/path"}]}')"
+smoke_assert_contains "$audit_summary" "captured=2" "audit summary captured count"
+smoke_assert_contains "$audit_summary" "killed=2" "audit summary killed count"
+smoke_assert_not_contains "$audit_summary" "/Users/secret/path" "audit summary must NOT leak command paths"
+smoke_assert_not_contains "$audit_summary" "codex app-server" "audit summary must NOT leak command strings"
+
+empty_summary="$(python3 "$REAPER_PY" subtree-audit-summary --report \
+  '{"captured_count":0,"killed_count":0,"skipped_count":0,"error_count":0}')"
+smoke_assert_eq "" "$empty_summary" "audit summary empty when no activity"
+
+# ---------------------------------------------------------------------------
+# Seam coverage: all three central teardown paths invoke the subtree reap, and
+# the two new audit actions exist.
+# ---------------------------------------------------------------------------
+smoke_log "H: all three teardown seams wire the subtree reap"
+grep -q 'bridge_codex_subtree_reap_for_session' "$RUN_SH" || \
+  smoke_fail "bridge-run.sh clean-exit does not call bridge_codex_subtree_reap_for_session"
+grep -q 'bridge_codex_subtree_capture' "$AGENTS_SH" || \
+  smoke_fail "bridge_kill_agent_session does not capture the codex subtree before kill"
+grep -q 'bridge_codex_subtree_reap_captured' "$AGENTS_SH" || \
+  smoke_fail "bridge_kill_agent_session does not reap the captured codex subtree after kill"
+grep -q 'bridge_codex_subtree_capture' "$DAEMON_SH" || \
+  smoke_fail "daemon idle/orphan kill does not capture the codex subtree before kill"
+grep -q 'bridge_codex_subtree_reap_captured' "$DAEMON_SH" || \
+  smoke_fail "daemon idle/orphan kill does not reap the captured codex subtree after kill"
+
+smoke_log "I: capture happens BEFORE the tmux kill on both external-kill seams"
+# In bridge_kill_agent_session the capture line must precede bridge_tmux_kill_session.
+cap_ln="$(grep -n 'bridge_codex_subtree_capture' "$AGENTS_SH" | head -n1 | cut -d: -f1)"
+kill_ln="$(awk '/bridge_kill_agent_session\(\)/{f=1} f&&/bridge_tmux_kill_session "\$session"/{print NR; exit}' "$AGENTS_SH")"
+[[ -n "$cap_ln" && -n "$kill_ln" ]] || smoke_fail "could not locate capture/kill lines in bridge_kill_agent_session"
+(( cap_ln < kill_ln )) || smoke_fail "codex subtree capture must precede tmux kill in bridge_kill_agent_session"
+
+smoke_log "J: the two new audit actions are emitted"
+grep -q 'codex_session_subtree_reaped' "$STATE_SH" || \
+  smoke_fail "codex_session_subtree_reaped audit action missing"
+grep -rq 'codex_subtree_reap_skipped_no_pane' "$STATE_SH" "$AGENTS_SH" "$DAEMON_SH" || \
+  smoke_fail "codex_subtree_reap_skipped_no_pane audit action missing"
+
+smoke_log "PASS: $SMOKE_NAME"

--- a/scripts/smoke/9770-codex-teardown-reap.sh
+++ b/scripts/smoke/9770-codex-teardown-reap.sh
@@ -83,6 +83,10 @@ smoke_log "E: (g) idempotent 2nd reap pass is ESRCH-clean"
 python3 "$HELPER_PY" idempotent "$REAPER_PY" || \
   smoke_fail "idempotent 2nd pass failed"
 
+smoke_log "E2: (h) PID-reuse identity — wrong start-time (same pid+command, relaxed age) is NOT killed"
+python3 "$HELPER_PY" start-time-identity "$REAPER_PY" || \
+  smoke_fail "start-time identity regression guard failed (PID-reuse defense)"
+
 # ---------------------------------------------------------------------------
 # DEFAULT_PATTERNS must stay codex-free: the global orphan path is untouched, so
 # a live roster `codex resume` can never become a global-cleanup candidate.


### PR DESCRIPTION
## Incident #9770 Track 2 — codex app-server teardown leak

Recurrence-prevention for the codex `app-server` / Pencil MCP teardown leak. **SECURITY-CRITICAL** process-kill code; the #1 invariant is that **a live roster codex / in-progress review / the operator's own codex is NEVER killed** — only ever the subtree of the SPECIFIC torn-down session. Patch owns the one-time cleanup of the ~37 already-leaked processes, so this PR is recurrence-prevention only (no global historical sweep).

### Root cause
Codex launches in a tmux pane (`bridge-state.sh`) → spawns a `codex app-server` child → Pencil `mcp-server-darwin-arm64` grandchildren, none with tracked PIDs. The global MCP orphan cleaner's `DEFAULT_PATTERNS` deliberately does NOT match codex (a live `codex resume` must never be a global-kill candidate), and `is_orphan_candidate` only fires for PPID∈{0,1}. After `tmux kill-session` the app-server reparents to a non-PPID-1 ancestor on macOS → survives → a linear memory leak (~38 app-servers / 3.3GB + 74 MCP children / 0.7GB over 2 days).

### The agreed fix — Option ① (codex plan-review #9779 = `implement-ok`)
Surgical per-session subtree reap rooted at the torn-down session's **known tmux pane PID**. The blast-radius guarantee is **by construction**: we only ever enumerate descendants of the SPECIFIC torn-down pane, filtered to a within-subtree codex/app-server/MCP allowlist. A live roster codex is a descendant of *its own* live pane, never of a different torn-down session; the operator's interactive codex is not a bridge-pane descendant at all — so neither can be in the kill set, with no roster-exclusion list to get wrong.

### The 5 hardening constraints (codex-enforced)
1. **Root = known tmux pane PID.** Resolve via `bridge_tmux_session_pane_pid`. Pane PID unresolvable → **skip + audit/warn, NEVER a global sweep**.
2. **Capture BEFORE kill (external-kill paths).** `bridge_kill_agent_session` and the daemon `reap_idle_orphan_sessions` capture the filtered descendant set (with per-PID command + age metadata) BEFORE `tmux kill-session`, then reap **only that captured set** after. No global rediscovery once the pane is gone. The clean-exit seam (`bridge-run.sh`) is a one-shot capture+reap while the pane is still alive.
3. **Reap = explicit PIDs, leaf-to-root** (NOT PGID). SIGTERM → grace → SIGKILL. Idempotent + fail-soft: ESRCH = success/no-op; permission/kill failures warn+audit, never break stop/delete/reap.
4. **Revalidate before EACH signal.** Not self/parent; still exists; still matches the narrow allowlist; command byte-identical to capture; age ≥ captured age (PID-reuse defense). The subtree path deliberately **drops the ppid check** because the captured codex reparents to init when we tear its pane down — that is expected, not PID reuse; the command + age + allowlist triple still defends recycled PIDs.
5. **DEFAULT_PATTERNS untouched.** codex / app-server / Pencil-MCP live ONLY in `SUBTREE_ALLOWLIST_PATTERNS` (subtree path). The global orphan path stays PPID-orphan + the existing patterns only.

### Implementation
- **`bridge-mcp-cleanup.py`** — new `subtree` subcommand: `descendants_of()` BFS over one ps snapshot, `capture_subtree` / `reap_captured` / `kill_pid_subtree` / `still_killable_subtree`, plus `subtree-extract-captured` / `subtree-audit-summary` glue so bash never hand-rolls JSON. Reuses the existing `read_proc_identity` / ps-walk; macOS `ps -axo` path (no /proc assumption).
- **`lib/bridge-state.sh`** — `bridge_codex_subtree_capture` / `_reap_captured` / `_reap_for_session` / `_audit`. Python invoked **file-as-argv** (no heredoc-stdin → footgun #11).
- **Three central seams wired:** `bridge-run.sh` clean exit, `bridge_kill_agent_session` (`lib/bridge-agents.sh`), daemon idle/orphan-session kill (`bridge-daemon.sh`).
- **New redacted audit actions:** `codex_session_subtree_reaped`, `codex_subtree_reap_skipped_no_pane` (counts + freed-MB only — never command strings, which carry cwd/paths).

### Tests
`scripts/smoke/9770-codex-teardown-reap.sh` (+ file-as-argv helper), registered in ci-select static suite **and** the per-file arms for the reaper + all three seams. Lightweight stand-in processes mimic the codex/app-server/MCP names + pane parentage (no real codex spawned):
- (a) clean-exit reaps A's subtree;
- (b) daemon idle-kill captures-before-kill + reaps A's reparented subtree;
- (c) **2nd live roster codex in a different pane SURVIVES** (the #1 invariant);
- (d) **non-bridge codex outside any pane SURVIVES**;
- (e) **same-pane non-codex child SURVIVES** (name-scoped within-subtree filter);
- (f) unresolvable pane → skip+audit, no global sweep;
- (g) idempotent 2nd pass is ESRCH-clean.

### Verification (green)
- `bash -n` (bash 5.3.9) + `shellcheck` clean on all changed `.sh`.
- `python3 -m py_compile` on `bridge-mcp-cleanup.py` + the smoke helper.
- `scripts/lint-heredoc-ban.sh --baseline-check` **PASS** (Python file-as-argv, no heredoc-stdin to subprocess).
- `scripts/smoke/9770-codex-teardown-reap.sh` **PASS** (all of a–g).
- `scripts/ci-select-smoke.sh` selects the new smoke for each of the 5 touched files.
- `./scripts/smoke-test.sh`: the only failure in this dev env is a **pre-existing** #365 iso-agent-env test that fails **identically on `origin/main`** (a live `~/.agent-bridge` install defeats that test's isolation here) — not caused by this change (verified: same single `[error]` + 122 `[ok]` on both branch and baseline before the `set -e` abort).
- Internal `codex:codex-rescue` review: **`implement-ok`** (r1 `needs-more` on the ci-select per-file wiring was fixed in r2).
- `lint-raw-pathlib-on-isolated` / `iso-helper-ratchet` not applicable — no isolated-path code touched.

### Pre-merge gate
The **live-VM reap proof against a real codex leak** (confirm the actual leaked app-servers are reaped on a host with the real Pencil MCP + a live roster codex that must survive) is an **orchestrator / patch pre-merge gate** — the isolated smoke proves the logic + the #1 invariant with stand-ins, but the empirical macOS reap against real codex/Pencil processes is owned by the orchestrator.

No VERSION/CHANGELOG bump (operator-cued release).

(#9770 Track 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
