### PR TITLE
hooks: Stop/turn-end inbox auto-drain (claude + codex) (#9780)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -282,6 +282,51 @@ sanitization. Together with `hooks/bridge_hook_common.py` it is the
 containment/audit layer (not a sandbox — see CLAUDE.md "High-Risk
 Areas" item 5).
 
+### Stop chain + inbox auto-drain (#9780)
+
+The Claude Stop event fires a four-hook chain, in order:
+
+1. `mark-idle.sh` — idle-wake marker; also surfaces `check-inbox.py
+   --format text` as `additionalContext` only (never blocks).
+2. `surface-reply-enforce.py` — blocks when a channel-sourced user turn
+   did not get a matching `*__reply` (issue #415).
+3. `inbox-auto-drain.py` — **the #9780 turn-end inbox drain.** Emits
+   `{"decision":"block","reason":...}` to re-enter the turn and drain the
+   queue (claim → process → done) when there is genuinely-actionable work,
+   instead of going idle until an external `[Agent Bridge]` push. Placed
+   AFTER `surface-reply-enforce.py` so it can never shadow the
+   channel-reply block, and BEFORE `session-stop.py`.
+4. `session-stop.py` — transcript→daily-note reconcile (PR #449), always
+   exit-0.
+
+The Codex managed Stop hook is `check-inbox.py --format codex` (via
+`bridge-hooks.py ensure-codex-hooks`); it routes through the SAME shared
+guard so both engines share one drain implementation.
+
+The infinite-Stop-loop guard lives in
+`bridge_hook_common.compute_drain_decision`. It honours `stop_hook_active`
+(never stacks on a prior chain block), never blocks on an empty/actionless
+queue, and keys a per-agent marker
+(`<runtime-state>/<agent>/inbox-drain-state.json`, under the
+`BRIDGE_ACTIVE_AGENT_DIR` runtime state root) on `id+status+updated_ts`
+plus a consecutive counter and cooldown — so genuine progress (a
+status/timestamp change) RESETS the guard while a stuck same-state task
+cannot loop. The marker is read/initialised and **atomically persisted
+BEFORE** any `decision:block` is emitted; a queue timeout, a marker parse
+error, or a marker write failure **FAILS OPEN** (exit 0, no block) so a
+marker I/O bug can never become an infinite Stop→block→Stop loop. The
+cap/cooldown are env-overridable (`BRIDGE_STOP_DRAIN_CAP`,
+`BRIDGE_STOP_DRAIN_COOLDOWN`); `BRIDGE_STOP_DRAIN_DISABLE` is the operator
+kill-switch. On a self-continue the hook also writes a non-failure
+"attention delivered" stamp (`bridge-queue.py note-self-continue` —
+updates `agent_state.last_nudge_ts`/`last_nudge_key` for the current
+queued set WITHOUT incrementing `nudge_fail_count`) so a concurrent daemon
+ACTION REQUIRED nudge for the same window is suppressed (no double-submit).
+The queued auto-drain and the already-claimed anti-abandonment block are
+kept DISTINCT so the #1199 "queued-only ACTION REQUIRED, claimed still
+blocks stop" contract is preserved. Smoke:
+`scripts/smoke/9780-stop-inbox-drain.sh`.
+
 ### Hook config SSOT (#1068)
 
 `bridge-hooks.py` is the single source of truth for the effective

--- a/agents/.claude/settings.json
+++ b/agents/.claude/settings.json
@@ -26,6 +26,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "/usr/bin/python3 ~/.agent-bridge/hooks/inbox-auto-drain.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "/usr/bin/python3 ~/.agent-bridge/hooks/session-stop.py",
             "timeout": 35
           }

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -444,6 +444,13 @@ def session_stop_hook_command(bridge_home: Path, python_bin: str) -> str:
     return shell_command(python_bin, shell_path(hook_path))
 
 
+def inbox_drain_hook_command(bridge_home: Path, python_bin: str) -> str:
+    # #9780: Stop inbox-drain auto-continue. Wired AFTER surface-reply-enforce
+    # (so it never shadows the channel-reply block) and BEFORE session-stop.
+    hook_path = bridge_home / "hooks" / "inbox-auto-drain.py"
+    return shell_command(python_bin, shell_path(hook_path))
+
+
 def session_start_hook_command(bridge_home: Path, python_bin: str, fmt: str = "text") -> str:
     hook_path = bridge_home / "hooks" / "session-start.py"
     if fmt != "text":
@@ -562,6 +569,10 @@ def is_surface_reply_enforce_hook(command: str) -> bool:
 
 def is_session_stop_hook(command: str) -> bool:
     return "session-stop.py" in str(command)
+
+
+def is_inbox_drain_hook(command: str) -> bool:
+    return "inbox-auto-drain.py" in str(command)
 
 
 def is_session_start_hook(command: str) -> bool:
@@ -691,13 +702,15 @@ def cmd_status_stop_hook(args: argparse.Namespace) -> int:
     stop_hooks = hooks_list(settings, "Stop")
     _idle_group, idle_hook = find_command_hook(stop_hooks, is_mark_idle_hook)
     _surface_group, surface_hook = find_command_hook(stop_hooks, is_surface_reply_enforce_hook)
+    _inbox_drain_group, inbox_drain_hook = find_command_hook(stop_hooks, is_inbox_drain_hook)
     _session_stop_group, session_stop_hook = find_command_hook(stop_hooks, is_session_stop_hook)
     # mark-idle.sh keeps the legacy HOOK_STOP_HOOK / HOOK_COMMAND fields so
     # existing operators / scripts that grep for them stay green. The
     # HOOK_STOP_HOOK_SUITE field (#541 PR-B) reports the aggregate state so
-    # the upgrade and smoke paths can detect partial drops of the new pair.
+    # the upgrade and smoke paths can detect partial drops of the suite
+    # (now including the #9780 inbox-auto-drain step).
     command = str(idle_hook.get("command") or "") if idle_hook else ""
-    suite_present = bool(idle_hook and surface_hook and session_stop_hook)
+    suite_present = bool(idle_hook and surface_hook and inbox_drain_hook and session_stop_hook)
     payload = {
         "HOOK_SETTINGS_FILE": str(settings_path),
         "HOOK_STATUS": "present" if suite_present else "missing",
@@ -705,6 +718,7 @@ def cmd_status_stop_hook(args: argparse.Namespace) -> int:
         "HOOK_STOP_HOOK_SUITE": "present" if suite_present else "missing",
         "HOOK_STOP_HOOK_MARK_IDLE": "present" if idle_hook else "missing",
         "HOOK_STOP_HOOK_SURFACE_REPLY_ENFORCE": "present" if surface_hook else "missing",
+        "HOOK_STOP_HOOK_INBOX_DRAIN": "present" if inbox_drain_hook else "missing",
         "HOOK_STOP_HOOK_SESSION_STOP": "present" if session_stop_hook else "missing",
         "HOOK_PROMPT_HOOK": "",
         "HOOK_COMMAND": command,
@@ -715,6 +729,7 @@ def cmd_status_stop_hook(args: argparse.Namespace) -> int:
         print(f"stop_hook_suite: {'present' if suite_present else 'missing'}")
         print(f"stop_hook_mark_idle: {'present' if idle_hook else 'missing'}")
         print(f"stop_hook_surface_reply_enforce: {'present' if surface_hook else 'missing'}")
+        print(f"stop_hook_inbox_drain: {'present' if inbox_drain_hook else 'missing'}")
         print(f"stop_hook_session_stop: {'present' if session_stop_hook else 'missing'}")
     return 0 if suite_present else 1
 
@@ -799,6 +814,56 @@ def ensure_command_hook(
     return changed
 
 
+def reorder_event_hook_before(
+    settings_path: Path,
+    event_name: str,
+    move_matcher: Any,
+    before_matcher: Any,
+) -> bool:
+    """Move the hook group matching ``move_matcher`` to sit immediately before
+    the group matching ``before_matcher`` in ``event_name``.
+
+    #9780: ``ensure_command_hook`` appends a freshly-registered hook at the end
+    of the event list, which would land the inbox-drain hook AFTER session-stop.
+    The Stop chain ordering is load-bearing (inbox-drain must run after
+    surface-reply-enforce and before session-stop), so this normalises the
+    position on every ensure pass — idempotent when already in place. No-op when
+    either group is missing.
+    """
+    settings = ensure_settings_root(settings_path)
+    event_hooks = hooks_list(settings, event_name)
+
+    move_idx = before_idx = None
+    for idx, group in enumerate(event_hooks):
+        if not isinstance(group, dict):
+            continue
+        hooks = group.get("hooks")
+        if not isinstance(hooks, list):
+            continue
+        for hook in hooks:
+            if not isinstance(hook, dict) or hook.get("type") != "command":
+                continue
+            command = str(hook.get("command") or "")
+            if move_idx is None and move_matcher(command):
+                move_idx = idx
+            if before_idx is None and before_matcher(command):
+                before_idx = idx
+
+    if move_idx is None or before_idx is None:
+        return False
+    if move_idx + 1 == before_idx:
+        return False  # already immediately before — nothing to do.
+
+    group = event_hooks.pop(move_idx)
+    # Recompute the anchor index after the pop (it shifts left if it followed
+    # the moved group).
+    if move_idx < before_idx:
+        before_idx -= 1
+    event_hooks.insert(before_idx, group)
+    save_json(settings_path, settings)
+    return True
+
+
 def cmd_ensure_stop_hook(args: argparse.Namespace) -> int:
     bridge_home = Path(args.bridge_home).expanduser()
     settings_path = resolve_settings_path(args)
@@ -810,12 +875,15 @@ def cmd_ensure_stop_hook(args: argparse.Namespace) -> int:
     python_bin = getattr(args, "python_bin", None) or shutil.which("python3") or "/usr/bin/python3"
     mark_idle_command = stop_hook_command(bridge_home, args.bash_bin)
     surface_command = surface_reply_enforce_hook_command(bridge_home, python_bin)
+    inbox_drain_command = inbox_drain_hook_command(bridge_home, python_bin)
     session_stop_command = session_stop_hook_command(bridge_home, python_bin)
 
     # Issue #541 PR-B: ensure the full Stop hook suite. mark-idle.sh keeps
-    # additionalContext=true (idle-wake context); surface-reply-enforce.py
-    # and session-stop.py mirror agents/_template/.claude/settings.json
-    # (no additionalContext, timeout 5 / 35 respectively).
+    # additionalContext=true (idle-wake context); surface-reply-enforce.py,
+    # inbox-auto-drain.py (#9780) and session-stop.py mirror
+    # agents/_template/.claude/settings.json (no additionalContext, timeout
+    # 5 / 10 / 35 respectively). Chain order: mark-idle → surface-reply-enforce
+    # → inbox-auto-drain → session-stop.
     changed = ensure_command_hook(
         settings_path,
         "Stop",
@@ -834,9 +902,26 @@ def cmd_ensure_stop_hook(args: argparse.Namespace) -> int:
     changed = ensure_command_hook(
         settings_path,
         "Stop",
+        inbox_drain_command,
+        is_inbox_drain_hook,
+        timeout=10,
+    ) or changed
+    changed = ensure_command_hook(
+        settings_path,
+        "Stop",
         session_stop_command,
         is_session_stop_hook,
         timeout=35,
+    ) or changed
+    # #9780: ensure_command_hook appends a newly-registered hook at the end of
+    # the list. Re-seat inbox-auto-drain immediately before session-stop so the
+    # drain runs after surface-reply-enforce and before the reconcile/idle hook
+    # regardless of registration order on an existing install.
+    changed = reorder_event_hook_before(
+        settings_path,
+        "Stop",
+        is_inbox_drain_hook,
+        is_session_stop_hook,
     ) or changed
 
     payload = {
@@ -846,6 +931,7 @@ def cmd_ensure_stop_hook(args: argparse.Namespace) -> int:
         "HOOK_STOP_HOOK_SUITE": "present",
         "HOOK_STOP_HOOK_MARK_IDLE": "present",
         "HOOK_STOP_HOOK_SURFACE_REPLY_ENFORCE": "present",
+        "HOOK_STOP_HOOK_INBOX_DRAIN": "present",
         "HOOK_STOP_HOOK_SESSION_STOP": "present",
         "HOOK_PROMPT_HOOK": "",
         "HOOK_COMMAND": mark_idle_command,
@@ -855,6 +941,7 @@ def cmd_ensure_stop_hook(args: argparse.Namespace) -> int:
     if args.format != "shell":
         print("stop_hook_suite: present")
         print(f"surface_reply_enforce_command: {surface_command}")
+        print(f"inbox_drain_command: {inbox_drain_command}")
         print(f"session_stop_command: {session_stop_command}")
     return 0
 

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -1562,6 +1562,10 @@ def cmd_find_open(args: argparse.Namespace) -> int:
                     "priority": str(row["priority"] or ""),
                     "claimed_by": str(row["claimed_by"] or ""),
                     "body_path": str(row["body_path"] or ""),
+                    # #9780: surface updated_ts on the single-row JSON so the
+                    # Stop inbox-drain loop guard can key on id+status+updated_ts
+                    # (a status/timestamp change resets the guard).
+                    "updated_ts": int(row["updated_ts"] or 0),
                 },
                 ensure_ascii=False,
             )
@@ -3023,6 +3027,31 @@ def cmd_note_nudge(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_note_self_continue(args: argparse.Namespace) -> int:
+    # #9780: a non-failure "attention delivered" stamp written when a Stop
+    # inbox-drain auto-continues the agent on its own queued work. It mirrors
+    # note-nudge's last_nudge_ts/last_nudge_key write so the daemon's nudge
+    # cooldown/freshness gate suppresses a concurrent ACTION REQUIRED nudge for
+    # the same queued set — but it MUST NOT increment nudge_fail_count or touch
+    # zombie state (the agent IS attending to the queue; this is the opposite of
+    # a failed/dropped nudge). Distinct verb so the failure-count semantics of
+    # note-nudge can never leak into the self-continue path.
+    current_ts = now_ts()
+    with closing(connect()) as conn, conn:
+        conn.execute(
+            """
+            INSERT INTO agent_state (agent, last_nudge_ts, last_nudge_key, nudge_fail_count, zombie)
+            VALUES (?, ?, ?, 0, 0)
+            ON CONFLICT(agent) DO UPDATE SET
+              last_nudge_ts = excluded.last_nudge_ts,
+              last_nudge_key = excluded.last_nudge_key
+            """,
+            (args.agent, current_ts, args.key or ""),
+        )
+    print(f"recorded self-continue for {args.agent}")
+    return 0
+
+
 def cmd_events(args: argparse.Namespace) -> int:
     import json as _json
 
@@ -3338,6 +3367,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=int(os.environ.get("BRIDGE_ZOMBIE_NUDGE_THRESHOLD", "10")),
     )
     nudge_parser.set_defaults(handler=cmd_note_nudge)
+
+    self_continue_parser = subparsers.add_parser("note-self-continue", allow_abbrev=False)
+    self_continue_parser.add_argument("--agent", required=True)
+    self_continue_parser.add_argument("--key")
+    self_continue_parser.set_defaults(handler=cmd_note_self_continue)
 
     events_parser = subparsers.add_parser("events", allow_abbrev=False)
     events_parser.add_argument("--type", dest="event_type")

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -1496,6 +1496,322 @@ def codex_stop_reason(agent: str, row: dict[str, Any]) -> str:
     )
 
 
+# ---------------------------------------------------------------------------
+# Stop/turn-end inbox auto-drain (#9780)
+# ---------------------------------------------------------------------------
+# A new Stop step that, when a turn ends with genuinely-actionable queue work,
+# emits {"decision":"block","reason":...} so the engine re-enters the turn and
+# drains its inbox instead of going idle until an external push or a human
+# wakes it. The whole point of failure here is to NEVER turn a marker I/O bug
+# into an infinite Stop->block->Stop loop, so every fragile step (queue read,
+# marker parse, marker write) FAILS OPEN — exit 0, no block.
+#
+# The guard (codex-agreed plan #9790):
+#   * honour stop_hook_active (a prior chain hook already blocked → never stack)
+#   * never block on an empty/actionless queue
+#   * a per-agent marker holds the last self-continue task key + a consecutive
+#     counter + the last block ts. The key is id+status (+updated_ts when the
+#     queue row carries it) so genuine progress RESETS the guard, while a stuck
+#     SAME-STATE task cannot loop: once the same key is seen within cooldown or
+#     the consecutive cap is reached, the hook idles instead of re-blocking.
+#   * read/init the marker AND atomically persist the updated marker FIRST; only
+#     emit decision:block AFTER the marker write succeeds. A marker write failure
+#     fails open.
+#   * keep queued auto-drain and already-claimed anti-abandonment DISTINCT so the
+#     #1199 "queued-only ACTION REQUIRED, claimed still blocks stop" contract is
+#     preserved (queued top wins; claimed is the anti-abandonment fallback).
+
+
+def _stop_drain_int_env(name: str, default: int, minimum: int = 0) -> int:
+    """Read a ``BRIDGE_STOP_DRAIN_*`` integer override, clamped to >= minimum."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value >= minimum else minimum
+
+
+def stop_drain_enabled() -> bool:
+    """Whether the Stop inbox-drain auto-continue is active. Default on.
+
+    ``BRIDGE_STOP_DRAIN_DISABLE`` (1/true/yes/on) is the operator kill-switch —
+    when set the drain hook degrades to a quiet no-op (exit 0, never blocks).
+    """
+    raw = os.environ.get("BRIDGE_STOP_DRAIN_DISABLE", "").strip().lower()
+    return raw not in {"1", "true", "yes", "on"}
+
+
+def stop_drain_cap() -> int:
+    """Max consecutive auto-continues on the SAME unchanged task key.
+
+    Once reached, the hook idles (lets a human/daemon intervene) instead of
+    re-blocking — the runaway backstop. ``BRIDGE_STOP_DRAIN_CAP`` override.
+    """
+    return _stop_drain_int_env("BRIDGE_STOP_DRAIN_CAP", 3, minimum=1)
+
+
+def stop_drain_cooldown() -> int:
+    """Seconds within which a re-block on the SAME unchanged key is suppressed.
+
+    ``BRIDGE_STOP_DRAIN_COOLDOWN`` override. 0 disables the time gate (the
+    consecutive cap still applies).
+    """
+    return _stop_drain_int_env("BRIDGE_STOP_DRAIN_COOLDOWN", 90, minimum=0)
+
+
+def inbox_drain_state_path(agent: str) -> Path:
+    """Per-agent marker for the Stop inbox-drain loop guard.
+
+    Resolved under the per-agent runtime state root helper
+    (``bridge_active_agent_dir()`` honours ``BRIDGE_ACTIVE_AGENT_DIR``) so an
+    isolated Stop hook writes the marker under the same contract as other hook
+    state (timestamp.json, next-session.sha, ...), NOT a hard-coded
+    ``state/agents/<agent>`` path.
+    """
+    return bridge_active_agent_dir() / agent / "inbox-drain-state.json"
+
+
+def load_drain_state(agent: str) -> dict[str, Any] | None:
+    """Return the persisted drain marker, ``{}`` when absent, or ``None`` on a
+    parse/read error.
+
+    ``None`` is the fail-open signal: a corrupt or unreadable marker must make
+    the hook idle (exit 0, no block) rather than re-derive guard state from a
+    bad file and risk an infinite loop. ``{}`` (file genuinely absent) is the
+    normal first-run path and is safe to initialise from.
+    """
+    path = inbox_drain_state_path(agent)
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def save_drain_state(agent: str, payload: dict[str, Any]) -> bool:
+    """Atomically persist the drain marker. Returns True on success.
+
+    Any permission/OS error returns False so the caller fails open (does NOT
+    block). Mirrors save_timestamp_state's mkdir + temp-write + chmod + replace
+    sequence; the only behavioural difference is that a controller-side failure
+    is also non-fatal here — a Stop hook must never raise, and the marker write
+    failing is exactly the case the guard must fail-open on.
+    """
+    path = inbox_drain_state_path(agent)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(tmp, 0o600)
+        tmp.replace(path)
+        os.chmod(path, 0o600)
+        return True
+    except (PermissionError, OSError):
+        return False
+
+
+def _drain_task_key(row: dict[str, Any]) -> str:
+    """Stable task key for the loop guard: ``id:status[:updated_ts]``.
+
+    ``updated_ts`` is included when the queue row carries it (find-open single
+    rows now emit it, #9780) so a status/timestamp change RESETS the guard while
+    a stuck same-state task keeps the same key and cannot loop forever.
+    """
+    task_id = int(row.get("id", 0) or 0)
+    status = str(row.get("status") or "")
+    updated = row.get("updated_ts")
+    if isinstance(updated, int) and updated > 0:
+        return f"{task_id}:{status}:{updated}"
+    return f"{task_id}:{status}"
+
+
+def drain_top_actionable(agent: str) -> dict[str, Any] | None:
+    """Return the top actionable queue row for the Stop drain, or None.
+
+    Two DISTINCT paths, queued first (preserves the #1199 contract):
+      1. genuinely-queued work → the queued head (ACTION REQUIRED drain).
+      2. else self-claimed-but-incomplete work → the top claimed row
+         (anti-abandonment; this is NOT an ACTION REQUIRED re-claim nudge).
+    A blocked-only queue is not actionable → None (idle quietly).
+    """
+    pending, row = queue_summary(agent)
+    if pending > 0:
+        # Queued work exists → queued-first wins. If the top-row read itself
+        # failed (pending>0 but row is None — a transient find-open hiccup), do
+        # NOT fall through to the claimed anti-abandonment path: that would
+        # silently switch a queued drain into a claimed block on a partial
+        # queue error. Return the queued row when we have it, else None (idle /
+        # fail open) so the queued-first contract holds.
+        return row
+    if open_claimed_count(agent) > 0:
+        return top_claimed_row(agent)
+    return None
+
+
+def queued_ids_for(agent: str) -> list[int]:
+    """Return the current queued (status=='queued') task ids for ``agent``.
+
+    Used to scope the daemon nudge-suppression stamp to exactly the queued set
+    the self-continue covered (same shape the daemon's ``last_nudge_key`` gate
+    keys on). Empty list on any error — the stamp is best-effort, so a queue
+    subprocess error here must never escape into the caller's block path.
+    """
+    try:
+        proc = queue_cli(
+            ["find-open", "--agent", agent, "--status-filter", "queued", "--all", "--format", "json"]
+        )
+    except Exception:  # noqa: BLE001 — best-effort; never raise into the Stop path
+        return []
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return []
+    try:
+        rows = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(rows, list):
+        return []
+    ids: list[int] = []
+    for r in rows:
+        if isinstance(r, dict):
+            try:
+                ids.append(int(r.get("id", 0) or 0))
+            except (TypeError, ValueError):
+                continue
+    return [i for i in ids if i]
+
+
+def note_self_continue(agent: str, queued_ids: Iterable[int]) -> None:
+    """Stamp a non-failure "attention delivered" marker for the daemon.
+
+    On a self-continue the daemon could fire a concurrent ACTION REQUIRED nudge
+    for the same queued set (double-submit). This updates ``agent_state``'s
+    ``last_nudge_ts`` + ``last_nudge_key`` for the CURRENT queued-id set via the
+    dedicated ``note-self-continue`` CLI verb, which (unlike ``note-nudge``)
+    does NOT increment ``nudge_fail_count`` or touch zombie state. Best-effort:
+    any failure is swallowed — the drain block still proceeds.
+    """
+    key = ",".join(str(i) for i in queued_ids if i)
+    args = ["note-self-continue", "--agent", agent]
+    if key:
+        args += ["--key", key]
+    try:
+        queue_cli(args)
+    except Exception:  # noqa: BLE001 — daemon coordination is best-effort
+        pass
+
+
+def compute_drain_decision(
+    agent: str,
+    event: dict[str, Any] | None,
+    *,
+    reason_builder,
+    now_epoch: int | None = None,
+) -> dict[str, str] | None:
+    """Core Stop inbox-drain guard. Returns the decision dict to emit, or None.
+
+    None means "do not block" (idle quietly / fail open). A non-None return is
+    ``{"decision": "block", "reason": <reason_builder(agent, row)>}`` and is
+    emitted ONLY after the guard marker has been read/initialised AND atomically
+    persisted. ``reason_builder`` lets each engine supply its own instruction
+    text (Claude vs codex) over the same shared guard.
+    """
+    if not agent or not stop_drain_enabled():
+        return None
+    # A prior chain hook already blocked this turn → never stack.
+    if event and bool(event.get("stop_hook_active")):
+        return None
+
+    # Queue read fails open: a timeout / parse error must not loop.
+    try:
+        row = drain_top_actionable(agent)
+    except Exception:  # noqa: BLE001 — queue subprocess error → fail open
+        return None
+    if not row:
+        return None
+
+    key = _drain_task_key(row)
+    now = now_epoch if now_epoch is not None else int(
+        datetime.now(timezone.utc).timestamp()
+    )
+
+    # Read/init the guard marker. A corrupt/unreadable marker fails open.
+    state = load_drain_state(agent)
+    if state is None:
+        return None
+
+    last_key = str(state.get("last_task_key") or "")
+    last_ts = int(state.get("last_ts") or 0) if isinstance(state.get("last_ts"), int) else 0
+    consecutive = int(state.get("consecutive") or 0) if isinstance(state.get("consecutive"), int) else 0
+
+    if key == last_key:
+        cooldown = stop_drain_cooldown()
+        within_cooldown = bool(last_ts) and cooldown > 0 and (now - last_ts) < cooldown
+        if within_cooldown or consecutive >= stop_drain_cap():
+            # Same unchanged task, still within cooldown or already capped →
+            # do NOT re-block. Let it idle for a human / the daemon.
+            return None
+        new_consecutive = consecutive + 1
+    else:
+        new_consecutive = 1
+
+    new_state = {
+        "last_task_key": key,
+        "last_ts": now,
+        "consecutive": new_consecutive,
+    }
+    # Atomically persist FIRST; only block if the marker write succeeded. A
+    # write failure fails open so a marker I/O bug can never become a loop.
+    if not save_drain_state(agent, new_state):
+        return None
+
+    # Non-failure daemon coordination: stamp last_nudge_ts/last_nudge_key for
+    # the current queued set so a concurrent daemon nudge is suppressed for this
+    # window WITHOUT incrementing nudge_fail_count. Strictly best-effort and
+    # AFTER the marker commit so it never gates the block — the WHOLE stamp
+    # (queued-id read + the note-self-continue call) is wrapped so a subprocess
+    # error in either step can never escape into the codex Stop path
+    # (check_inbox.py main has no outer try/except) and turn an attention stamp
+    # failure into a Stop-hook error banner.
+    try:
+        note_self_continue(agent, queued_ids_for(agent))
+    except Exception:  # noqa: BLE001 — daemon coordination is best-effort only
+        pass
+
+    reason = reason_builder(agent, row)
+    return {"decision": "block", "reason": reason}
+
+
+def claude_drain_reason(agent: str, row: dict[str, Any]) -> str:
+    """Claude Stop-hook auto-continue instruction for the drain block."""
+    task_id = int(row.get("id", 0) or 0)
+    title = str(row.get("title") or "")
+    priority = str(row.get("priority") or "normal")
+    status = str(row.get("status") or "")
+    if status == "claimed":
+        return (
+            f"Agent Bridge still has open claimed work: task #{task_id} "
+            f"[{priority}] {title}. "
+            f"Run ~/.agent-bridge/agb inbox {agent} now, then continue and "
+            f"finish the claimed task before ending the session."
+        )
+    return (
+        f"Agent Bridge queued work is waiting: task #{task_id} "
+        f"[{priority}] {title}. "
+        f"Run ~/.agent-bridge/agb inbox {agent} now, claim the highest-priority "
+        f"queued task, process it, then mark it done before ending the session."
+    )
+
+
 _GUARD_MODULE_NAME = "bridge_guard_common"
 
 

--- a/hooks/check_inbox.py
+++ b/hooks/check_inbox.py
@@ -10,10 +10,9 @@ import sys
 
 from bridge_hook_common import (
     codex_stop_reason,
-    open_claimed_count,
+    compute_drain_decision,
     queue_attention_message,
     queue_summary,
-    top_claimed_row,
 )
 
 
@@ -41,43 +40,43 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.format == "codex":
+        # The Codex managed Stop hook (`check-inbox.py --format codex` via
+        # bridge-hooks.py) is the Codex turn-end inbox-drain. It reuses the
+        # SHARED #9780 guard in compute_drain_decision so it gets the same
+        # infinite-Stop-loop protection (per-agent marker keyed on
+        # id+status+updated_ts, consecutive cap + cooldown), the
+        # stop_hook_active short-circuit, the never-block-when-empty invariant,
+        # the atomic-persist-before-block contract, the fail-open-on-error
+        # behaviour, and the daemon double-submit suppression stamp.
+        #
+        # drain_top_actionable() inside compute_drain_decision keeps the two
+        # distinct concerns intact (#1199): queued head first (claim it), else
+        # open claimed work (continue it) — never a re-claim nudge of a
+        # just-claimed task. codex_stop_reason supplies the engine-specific
+        # instruction text over that shared guard.
         event = load_event()
-        if bool(event.get("stop_hook_active")):
+        # compute_drain_decision already fails open (returns None) on its own
+        # error paths, but a Stop hook MUST exit 0 / emit the codex "no
+        # decision" {} on ANY unexpected error — check_inbox.py main has no
+        # outer try/except, so a raise here would surface a Stop-hook error
+        # banner. Wrap so any escape degrades to the safe no-block {}.
+        try:
+            decision = compute_drain_decision(
+                agent,
+                event,
+                reason_builder=codex_stop_reason,
+            )
+        except Exception:  # noqa: BLE001 — Stop hook must never raise / nonzero
+            decision = None
+        if decision is None:
             json.dump({}, sys.stdout, ensure_ascii=False)
             sys.stdout.write("\n")
             return 0
-
-    pending, row = queue_summary(agent)
-
-    if args.format == "codex":
-        # The codex Stop hook has two distinct concerns:
-        #   1. genuinely-queued work waiting → block + "claim it" (uses the
-        #      queued-only `pending`/`row` from queue_summary).
-        #   2. open claimed work the agent holds → block + "continue it"
-        #      (issue #1199: this is NOT an ACTION REQUIRED nudge and must
-        #      not survive in the queued `pending` count, or the agent gets
-        #      re-nudged to re-claim a task it just claimed). We keep the
-        #      anti-abandonment gate via the separate claimed lookups so a
-        #      session cannot quietly end on open claimed work.
-        if pending > 0 and row is not None:
-            stop_row = row
-        else:
-            claimed_row = top_claimed_row(agent) if open_claimed_count(agent) > 0 else None
-            stop_row = claimed_row
-        if stop_row is None:
-            json.dump({}, sys.stdout, ensure_ascii=False)
-            sys.stdout.write("\n")
-            return 0
-        json.dump(
-            {
-                "decision": "block",
-                "reason": codex_stop_reason(agent, stop_row),
-            },
-            sys.stdout,
-            ensure_ascii=False,
-        )
+        json.dump(decision, sys.stdout, ensure_ascii=False)
         sys.stdout.write("\n")
         return 0
+
+    pending, row = queue_summary(agent)
 
     # Text path (Claude Stop hook via mark-idle.sh): ACTION REQUIRED nudge is
     # a queued-work call-to-action only. A claimed/blocked task never fires it

--- a/hooks/inbox-auto-drain.py
+++ b/hooks/inbox-auto-drain.py
@@ -44,7 +44,13 @@ def load_event() -> dict:
 
 def main() -> int:
     try:
-        agent = os.environ.get("BRIDGE_AGENT_ID", "").strip()
+        # Stop hook runs AS the agent; it reads its own BRIDGE_AGENT_ID to
+        # identify itself and writes its own per-agent marker under
+        # BRIDGE_ACTIVE_AGENT_DIR (same-UID, no controller→iso crossing). The
+        # `os.environ` token false-matches the ratchet's `.env` boundary
+        # pattern — the identical false-positive is already noqa'd in
+        # bridge_hook_common.py and baselined in check_inbox.py.
+        agent = os.environ.get("BRIDGE_AGENT_ID", "").strip()  # noqa: iso-helper-boundary — os.environ (.environ) false-matches the .env pattern; Stop hook self-identity read, not a controller→iso artifact
         if not agent:
             return 0  # TUI-only / admin session — not a bridge agent context.
 

--- a/hooks/inbox-auto-drain.py
+++ b/hooks/inbox-auto-drain.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Stop hook: auto-drain the agent's inbox at turn end (#9780).
+
+When a Claude turn ends with genuinely-actionable queue work, emit
+``{"decision":"block","reason":...}`` so Claude Code re-enters the turn and
+drains the inbox (claim → process → done) instead of going idle until an
+external ``[Agent Bridge]`` push or a human wakes the agent. When there is no
+actionable work, the hook stays silent (exit 0) and the session idles normally.
+
+This is the BLOCKING counterpart to ``check-inbox.py --format text`` (which
+mark-idle.sh already surfaces as additionalContext only). It is wired AFTER
+``surface-reply-enforce.py`` in the Claude Stop chain so it can never shadow the
+channel-reply enforcement block, and BEFORE ``session-stop.py``.
+
+The infinite-Stop-loop guard, the never-block-when-empty invariant, the
+``stop_hook_active`` short-circuit, the atomic-persist-before-block marker, the
+fail-open-on-error contract, and the daemon double-submit coordination stamp all
+live in ``bridge_hook_common.compute_drain_decision`` so the Codex managed Stop
+hook (``check-inbox.py --format codex``) reuses the exact same guard. See
+``bridge_hook_common`` §"Stop/turn-end inbox auto-drain (#9780)".
+
+PR #449 contract: a Stop hook MUST always exit 0 — a non-zero exit surfaces an
+operator banner. Every failure path here returns 0 and never blocks.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from bridge_hook_common import claude_drain_reason, compute_drain_decision
+
+
+def load_event() -> dict:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def main() -> int:
+    try:
+        agent = os.environ.get("BRIDGE_AGENT_ID", "").strip()
+        if not agent:
+            return 0  # TUI-only / admin session — not a bridge agent context.
+
+        event = load_event()
+        decision = compute_drain_decision(
+            agent,
+            event,
+            reason_builder=claude_drain_reason,
+        )
+        if decision is None:
+            return 0  # no actionable work, guard suppressed, or failed open.
+
+        sys.stdout.write(json.dumps(decision, ensure_ascii=False))
+        sys.stdout.flush()
+    except Exception:  # noqa: BLE001 — Stop hook must never raise / non-zero.
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -109,6 +109,12 @@ add_all_required_static() {
 
 add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering 1495-settings-invalid-hook-key 1453-channel-sticky-false-inbound 1455-settings-two-tree-doctor isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1342-write-state-marker-matrix 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup 1400-purge-home-degrade-no-sudo nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent 1323-nudge-eligibility-recheck-twostage 1199-action-required-claimed-skip tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1405-handoffd-supervision 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize 1209-ms365-redirect-resolver 1210-ms365-scope-normalize 1212-bridge-hooks-marketplace 1213-iso-uid-predicate 1214-channel-validator-iso-fallback 1215-ms365-dir-mode beta27-D-inject-timestamp-resolved beta27-E-hook-permission-fail-open-markers G-channel-spec-resolution F-daemon-supp-groups-mock F-daemon-supp-groups-real H-bootstrap-memory-iso-rebuild I-agent-description-roster ζ-1236-plugins-list-marketplaces β-1231-1236-fresh-install-seed-sudoers 6607-hook-admin-allowlist γ-cli-consistency δ-1234-daemon-start-policy B-beta3-1249-1250-plugin-ux C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir C-beta4-logger-and-spec B-beta4-setup-wizard A-beta4-iso-path-resolution D-beta4-daemon-lifecycle E-beta4-fresh-install-gate-state-dir H-beta4-iso-ownership F-beta4-oauth-bootstrap G-beta4-watchdog-noise I-beta4-a2a-3-gaps J-beta4-workflow-docs K-beta4-nits Beta-beta5-session-id-detect-sudo α-beta5-upgrade-backfill-normalize gamma-beta5-reconcile-helper-status beta5-1-session-id-detect-race dev-channel-auto-accept-no-attach mcp-liveness-giveup-auto-clear beta5-2-epsilon-tmux-inject-busy beta5-2-zeta-teams-mcp-dedup beta5-2-pi-daemon-crashloop-no-set-e-leak beta5-2-eta-cron-iso-uid-preflight beta5-2-delta-nudge-session-empty beta5-2-theta-upgrade-backfill-perms beta5-2-nu-daemon-path-quarantine beta5-2-kappa-state-audit-reconcile beta5-2-iota-daemon-escalation-family beta5-2-lambda-a2a-robustness beta5-2-mu-cron-channel-creds beta5-2-xi-misc-fixes 1359-cron-create-iso-staging 1379-iso-cron-staging-group 1383-iso-cron-result-json-group 1354-setup-teams-fd-password 1360-onboarding-next-actions-persona 1353-setup-pending-grace 1355-1356-ms365-wizard 1357-iso-boundary-quickref 1358-admin-credential-routine-exempt 1352-shared-codex-pair-path 1343-ms365-token-refresh 1378-iso-session-lock-fresh-start 1388-daemon-lock-fd-cloexec 1416-onboarding-state-field-anchor a2a-setup-wizard 1408-daemon-alert-nudge-hygiene 1409-claude-midturn-busy-gate 1427-A-roster-materialize 1427-B-template-sync-wizard 1426-cron-shell-noniso-help 1437-reactive-cron-rotation 1425-spool-rederive 1437-native-usage-probe 1468-usage-429-positive-signal 1464-cron-aware-stale-health 1497-v2-dynamic-handoff 1497-p1-home-resolver 1506-isolate-normalize 1497-p2-operator-home 1513-iso-teams-prune-eacces 1516-upgrade-downgrade-guard plugin-requires-resolver 1520-shared-claude-config-dir 1520b-create-time-creds-sync 1520c-create-isolate-profile-publish 1533-create-isolate-content-publish 1402-stat-platform-order 1398-a2a-inbound-stopped-target-force 1463-launchd-keepalive-singleton-thrash 1470-engine-auth-seam 1470-codex-fleet-sync 1459-cron-dispatch-recovery 1417-identity-sync-on-start
 add_required 1425-cron-dispatch-nudge-scope
+# #9780: Stop/turn-end inbox auto-drain. In the full static suite so a
+# scripts/smoke/*, hooks/*, or bridge-queue.py change re-runs the Stop-chain
+# loop-guard regression via the catch-all → add_all_required_static. The
+# per-file selectors below (hooks/bridge_hook_common.py, hooks/check_inbox.py,
+# bridge-queue.py, bridge-hooks.py) also pull it directly.
+add_required 9780-stop-inbox-drain
 # Issue #1461: BRIDGE_CRON_DISPATCH_MAX_PARALLEL must resolve env > runtime
 # bridge-config.json key > host-profile-scaled default, and the resolved value
 # must reach start_cron_dispatch_workers' worker-slot gate. In the static suite
@@ -897,6 +903,14 @@ select_for_path() {
       # so the snapshot shape (oldest/age/count/agent/family fields) cannot
       # drift out from under the sweep.
       add_required 1459-cron-dispatch-recovery
+      # #9780: bridge-queue.py gained the `note-self-continue` verb (the Stop
+      # inbox-drain daemon nudge-suppression stamp — updates last_nudge_ts /
+      # last_nudge_key WITHOUT bumping nudge_fail_count) and the find-open
+      # single-row `updated_ts` field the loop-guard key depends on. Pull
+      # 9780-stop-inbox-drain on every bridge-queue.py move so a refactor cannot
+      # silently regress the fail-count-free stamp or drop updated_ts (which
+      # would weaken the id+status+updated_ts guard key → re-loop risk).
+      add_required 9780-stop-inbox-drain
       add_integration integration-minimal
       ;;
 
@@ -2580,6 +2594,17 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # workdir channels from drifting. Pull 1497-p1-home-resolver on every
       # hooks/* move so the RESOLVED-first order, the split-brain immunity, and
       # the bash↔Python home parity cannot silently regress.
+      # #9780: hooks/bridge_hook_common.py grew the Stop inbox-drain shared
+      # guard (compute_drain_decision + the marker load/save/key helpers),
+      # hooks/inbox-auto-drain.py is the new Claude Stop step, hooks/check_inbox.py
+      # routes `--format codex` through the same shared guard, and bridge-hooks.py
+      # wires inbox-auto-drain.py into the Claude Stop chain AFTER surface-reply-
+      # enforce / BEFORE session-stop (+ the reorder normaliser). Pull
+      # 9780-stop-inbox-drain on every hooks/* / bridge-hooks.py move so a future
+      # patch cannot regress the loop guard (fail-open, atomic-persist-before-
+      # block, never-block-when-empty), the #1199 queued-vs-claimed split, or the
+      # Stop-chain ordering.
+      add_required 9780-stop-inbox-drain
       add_required 1497-p1-home-resolver
       add_required 1497-v2-dynamic-handoff
       # Issue #1497 (P2): hooks/bridge_hook_common.py::bridge_home_dir() now

--- a/scripts/smoke/9780-stop-inbox-drain-helpers/read-nudge-state.py
+++ b/scripts/smoke/9780-stop-inbox-drain-helpers/read-nudge-state.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Read agent_state nudge fields for the #9780 smoke (file-as-argv helper).
+
+Standalone so the smoke never has to embed a python3 heredoc-stdin / `<<<`
+here-string (footgun #11 / scripts/lint-heredoc-ban.sh).
+
+Usage: read-nudge-state.py <tasks.db> <agent>
+Prints one line: "<last_nudge_ts> <nudge_fail_count> <last_nudge_key>"
+(missing row → "0 0 ").
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        sys.stderr.write("usage: read-nudge-state.py <tasks.db> <agent>\n")
+        return 2
+    db_path, agent = argv[1], argv[2]
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "SELECT last_nudge_ts, nudge_fail_count, last_nudge_key "
+            "FROM agent_state WHERE agent = ?",
+            (agent,),
+        )
+        row = cur.fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        print("0 0 ")
+        return 0
+    last_nudge_ts = int(row[0] or 0)
+    nudge_fail_count = int(row[1] or 0)
+    last_nudge_key = str(row[2] or "")
+    print(f"{last_nudge_ts} {nudge_fail_count} {last_nudge_key}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/smoke/9780-stop-inbox-drain.sh
+++ b/scripts/smoke/9780-stop-inbox-drain.sh
@@ -1,0 +1,361 @@
+#!/usr/bin/env bash
+# scripts/smoke/9780-stop-inbox-drain.sh — Stop/turn-end inbox auto-drain
+# (#9780). HIGH-RISK: the Stop-hook chain. The §3 infinite-Stop-loop guard is
+# the crux — a marker I/O bug or a never-resetting guard key would be an
+# infinite Stop→block→Stop loop.
+#
+# THE GAP. The Claude/Codex Stop chain SURFACES the inbox as context but never
+# BLOCKS to drain it, so a finished turn shows "you have pending tasks" yet
+# still goes idle. The daemon nudge that should catch idle sessions is itself
+# unstable (submit_lost_post_grace). Net: queued A2A/watchdog/memory work
+# silently accumulates until an external push or a human wakes the agent.
+#
+# THE FIX. A new Stop step (hooks/inbox-auto-drain.py for Claude;
+# check-inbox.py --format codex for Codex) emits {"decision":"block",...} when
+# there is genuinely-actionable queue work, guarded against looping by a
+# per-agent marker whose key is id+status(+updated_ts).
+#
+# This test pins, in an isolated BRIDGE_HOME (+ BRIDGE_ACTIVE_AGENT_DIR so the
+# marker lands in the fixture tree, never the live runtime):
+#   (1) queued task        → emits decision:block (auto-continue).
+#   (2) empty/actionless   → exit 0, NO block, NO loop.
+#   (3) same unchanged key → 2nd Stop does NOT re-block (marker dedup).
+#   (4) progress (status   → key change RESETS the guard → blocks again.
+#       change)
+#   (5) consecutive cap    → stops blocking (allow idle).
+#   (6) marker parse fail  → fail-open exit 0 (no block).
+#   (7) marker write fail  → fail-open exit 0 (no block).
+#   (8) queue error        → fail-open exit 0.
+#   (9) stop_hook_active   → exit 0 (never stack on a prior chain block).
+#  (10) codex managed hook → check-inbox.py --format codex drives the same drain
+#       + same guard.
+#  (11) daemon nudge-      → last_nudge_ts + last_nudge_key updated for the
+#       suppression stamp     queued set, nudge_fail_count NOT incremented.
+#  (12) #1199 retained     → queued-only ACTION REQUIRED stays queued-only;
+#       claimed-work Stop behavior explicitly tested.
+#
+# Footgun #11: all queue mutation goes through the real CLI; no python3
+# heredoc-stdin and no `<<<` here-string (see scripts/lint-heredoc-ban.sh).
+
+set -euo pipefail
+
+SMOKE_NAME="9780-stop-inbox-drain"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agb-9780.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+DB="$TMP_DIR/tasks.db"
+export BRIDGE_TASK_DB="$DB"
+export BRIDGE_HOME="$REPO_ROOT"
+export BRIDGE_STATE_DIR="$TMP_DIR/state"
+# Pin the per-agent runtime state root into the fixture so the loop-guard
+# marker NEVER lands in the operator's live ~/.agent-bridge tree. The hook
+# resolves the marker via bridge_active_agent_dir() which honours this var
+# first (matches bridge-lib.sh:BRIDGE_ACTIVE_AGENT_DIR).
+export BRIDGE_ACTIVE_AGENT_DIR="$TMP_DIR/state/agents"
+# Deterministic guard knobs.
+export BRIDGE_STOP_DRAIN_CAP=2
+export BRIDGE_STOP_DRAIN_COOLDOWN=300
+
+AGENT="drain-tester"
+export BRIDGE_AGENT_ID="$AGENT"
+MARKER="$BRIDGE_ACTIVE_AGENT_DIR/$AGENT/inbox-drain-state.json"
+
+QUEUE() { python3 "$REPO_ROOT/bridge-queue.py" "$@"; }
+
+drain_claude() {
+  # $1 = event JSON (default {})
+  printf '%s' "${1:-\{\}}" | python3 "$REPO_ROOT/hooks/inbox-auto-drain.py" 2>/dev/null
+}
+drain_codex() {
+  printf '%s' "${1:-\{\}}" | python3 "$REPO_ROOT/hooks/check_inbox.py" --format codex 2>/dev/null
+}
+check_inbox_text() {
+  printf '%s' '{}' | python3 "$REPO_ROOT/hooks/check_inbox.py" --format text 2>/dev/null
+}
+
+reset_marker() { rm -f "$MARKER" "$MARKER.tmp" 2>/dev/null || true; }
+
+failed=0
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1" >&2; failed=1; }
+
+# ============================================================
+# Phase 1 — queued task → decision:block (auto-continue)
+# ============================================================
+QUEUE create --to "$AGENT" --from bridge --title "drain me" --body "b" \
+  --format shell >"$TMP_DIR/create.sh"
+# shellcheck disable=SC1090
+source "$TMP_DIR/create.sh"
+TASK="$TASK_ID"
+reset_marker
+
+OUT="$(drain_claude)"
+if printf '%s' "$OUT" | grep -q '"decision": "block"' \
+   && printf '%s' "$OUT" | grep -q "claim the highest-priority"; then
+  pass "queued task: Claude Stop emits decision:block (auto-continue)"
+else
+  fail "queued task should emit decision:block (got: '${OUT}')"
+fi
+
+# Marker must exist AFTER the block (atomic-persist-before-block).
+if [[ -f "$MARKER" ]]; then
+  pass "queued task: guard marker written (atomic-persist-before-block)"
+else
+  fail "guard marker should exist after a block (path: ${MARKER})"
+fi
+
+# ============================================================
+# Phase 2 — same unchanged key on 2nd Stop → does NOT re-block
+# ============================================================
+OUT="$(drain_claude)"
+if [[ -z "$OUT" ]]; then
+  pass "same unchanged key: 2nd Stop does NOT re-block (marker dedup)"
+else
+  fail "2nd Stop on same unchanged task must NOT re-block (got: '${OUT}')"
+fi
+
+# ============================================================
+# Phase 3 — progress (status change) RESETS the guard
+# ============================================================
+# Claim the task: id+status changes → key changes → guard resets → blocks
+# again (now on the claimed anti-abandonment path).
+QUEUE claim "$TASK" --agent "$AGENT" >/dev/null
+OUT="$(drain_claude)"
+if printf '%s' "$OUT" | grep -q '"decision": "block"' \
+   && printf '%s' "$OUT" | grep -q "claimed work"; then
+  pass "progress (claim → status change) RESETS the guard → blocks on claimed work"
+else
+  fail "a status change should reset the guard and re-block (got: '${OUT}')"
+fi
+
+# ============================================================
+# Phase 4 — #1199 retained: claimed-only is NOT an ACTION REQUIRED text nudge
+# ============================================================
+# The task is now claimed. The TEXT nudge (queued-only ACTION REQUIRED) must be
+# empty — claimed work never fires the queued-only re-nudge (issue #1199).
+OUT="$(check_inbox_text)"
+if [[ -z "$OUT" ]]; then
+  pass "#1199 retained: claimed task does NOT fire the queued-only ACTION REQUIRED text nudge"
+else
+  fail "claimed task must NOT fire ACTION REQUIRED text nudge (got: '${OUT}')"
+fi
+
+# ...but the Stop drain still BLOCKS on open claimed work (anti-abandonment),
+# verified in Phase 3. Re-confirm via the codex managed hook below.
+
+# ============================================================
+# Phase 5 — empty/actionless queue → exit 0, NO block, NO loop
+# ============================================================
+# $TASK is claimed by $AGENT (Phase 3) → close it directly.
+QUEUE done "$TASK" --agent "$AGENT" --note "done" >/dev/null
+reset_marker
+OUT="$(drain_claude)"
+if [[ -z "$OUT" ]]; then
+  pass "empty queue: Claude Stop does NOT block (never loop on empty)"
+else
+  fail "empty queue must NOT block (got: '${OUT}')"
+fi
+# And the marker must NOT be written when there is nothing actionable.
+if [[ ! -f "$MARKER" ]]; then
+  pass "empty queue: no guard marker written (idle quietly)"
+else
+  fail "empty queue should not write a guard marker"
+fi
+
+# ============================================================
+# Phase 6 — consecutive cap → stops blocking (allow idle)
+# ============================================================
+# Fresh queued task; the key stays the SAME unchanged key across Stops (status
+# stays 'queued'). To exercise the cap rather than the cooldown we set cooldown
+# to 0 for this phase so only the consecutive cap gates. With CAP=2 the 1st and
+# 2nd Stops block, the 3rd idles.
+QUEUE create --to "$AGENT" --from bridge --title "cap me" --body "b" \
+  --format shell >"$TMP_DIR/create-cap.sh"
+# shellcheck disable=SC1090
+source "$TMP_DIR/create-cap.sh"
+CAPTASK="$TASK_ID"
+reset_marker
+(
+  export BRIDGE_STOP_DRAIN_COOLDOWN=0
+  o1="$(drain_claude)"; o2="$(drain_claude)"; o3="$(drain_claude)"
+  printf '%s' "$o1" | grep -q '"decision": "block"' && echo "b1=block" >"$TMP_DIR/cap2.out" || echo "b1=idle" >"$TMP_DIR/cap2.out"
+  printf '%s' "$o2" | grep -q '"decision": "block"' && echo "b2=block" >>"$TMP_DIR/cap2.out" || echo "b2=idle" >>"$TMP_DIR/cap2.out"
+  printf '%s' "$o3" | grep -q '"decision": "block"' && echo "b3=block" >>"$TMP_DIR/cap2.out" || echo "b3=idle" >>"$TMP_DIR/cap2.out"
+)
+if grep -q "^b1=block$" "$TMP_DIR/cap2.out" \
+   && grep -q "^b2=block$" "$TMP_DIR/cap2.out" \
+   && grep -q "^b3=idle$" "$TMP_DIR/cap2.out"; then
+  pass "consecutive cap (CAP=2): blocks twice then idles (runaway backstop)"
+else
+  fail "cap should block CAP times then idle (got: $(tr '\n' ' ' <"$TMP_DIR/cap2.out"))"
+fi
+QUEUE claim "$CAPTASK" --agent "$AGENT" >/dev/null
+QUEUE done "$CAPTASK" --agent "$AGENT" --note "done" >/dev/null
+
+# ============================================================
+# Phase 7 — stop_hook_active → exit 0 (never stack)
+# ============================================================
+QUEUE create --to "$AGENT" --from bridge --title "active guard" --body "b" \
+  --format shell >"$TMP_DIR/create-active.sh"
+# shellcheck disable=SC1090
+source "$TMP_DIR/create-active.sh"
+ACTASK="$TASK_ID"
+reset_marker
+OUT="$(drain_claude '{"stop_hook_active": true}')"
+if [[ -z "$OUT" ]]; then
+  pass "stop_hook_active: Claude Stop does NOT block (never stack on a prior block)"
+else
+  fail "stop_hook_active must short-circuit to no-block (got: '${OUT}')"
+fi
+# And codex honours it too.
+OUT="$(drain_codex '{"stop_hook_active": true}')"
+if printf '%s' "$OUT" | grep -q '"decision": "block"'; then
+  fail "codex stop_hook_active must not block (got: '${OUT}')"
+else
+  pass "stop_hook_active: codex managed hook also short-circuits"
+fi
+
+# ============================================================
+# Phase 8 — marker parse failure → fail-open exit 0 (no block)
+# ============================================================
+reset_marker
+mkdir -p "$(dirname "$MARKER")"
+printf 'this is not json {' >"$MARKER"
+OUT="$(drain_claude)"
+if [[ -z "$OUT" ]]; then
+  pass "marker parse failure: fail-open, Claude Stop does NOT block"
+else
+  fail "a corrupt marker must fail open (no block) (got: '${OUT}')"
+fi
+
+# ============================================================
+# Phase 9 — marker WRITE failure → fail-open exit 0 (no block)
+# ============================================================
+# Make the marker dir unwritable so the atomic write fails; the hook must
+# fail open (NOT block) because it could not persist the guard state.
+reset_marker
+mkdir -p "$(dirname "$MARKER")"
+chmod 000 "$(dirname "$MARKER")"
+OUT="$(drain_claude)"
+chmod 755 "$(dirname "$MARKER")"
+if [[ -z "$OUT" ]]; then
+  pass "marker write failure: fail-open, Claude Stop does NOT block (no marker → no loop)"
+else
+  fail "a marker write failure must fail open (no block) (got: '${OUT}')"
+fi
+QUEUE claim "$ACTASK" --agent "$AGENT" >/dev/null
+QUEUE done "$ACTASK" --agent "$AGENT" --note "done" >/dev/null
+
+# ============================================================
+# Phase 10 — queue error → fail-open exit 0
+# ============================================================
+# Point the task DB at an unreadable path so queue_summary's subprocess errors.
+(
+  export BRIDGE_TASK_DB="$TMP_DIR/nonexistent-dir/does/not/exist.db"
+  reset_marker
+  OUT="$(drain_claude)"
+  if [[ -z "$OUT" ]]; then
+    echo "queue-error=ok" >"$TMP_DIR/qerr.out"
+  else
+    echo "queue-error=block:${OUT}" >"$TMP_DIR/qerr.out"
+  fi
+)
+if grep -q "^queue-error=ok$" "$TMP_DIR/qerr.out"; then
+  pass "queue error: fail-open, Claude Stop does NOT block"
+else
+  fail "a queue error must fail open (no block) ($(cat "$TMP_DIR/qerr.out"))"
+fi
+
+# ============================================================
+# Phase 11 — codex managed hook drives the same drain + guard
+# ============================================================
+QUEUE create --to "$AGENT" --from bridge --title "codex drain" --body "b" \
+  --format shell >"$TMP_DIR/create-codex.sh"
+# shellcheck disable=SC1090
+source "$TMP_DIR/create-codex.sh"
+CXTASK="$TASK_ID"
+reset_marker
+OUT="$(drain_codex)"
+if printf '%s' "$OUT" | grep -q '"decision": "block"' \
+   && printf '%s' "$OUT" | grep -q "queued work is waiting"; then
+  pass "codex managed hook: queued task → decision:block (same shared drain)"
+else
+  fail "codex managed hook should block on queued work (got: '${OUT}')"
+fi
+# Same shared guard: a 2nd codex Stop on the unchanged key does NOT re-block.
+OUT="$(drain_codex)"
+if [[ "$OUT" == "{}" || -z "$OUT" ]]; then
+  pass "codex managed hook: 2nd Stop on unchanged key does NOT re-block (shared guard)"
+else
+  fail "codex 2nd Stop on unchanged key must not re-block (got: '${OUT}')"
+fi
+# Anti-abandonment: claimed work still blocks the codex Stop (#1199 distinct path).
+QUEUE claim "$CXTASK" --agent "$AGENT" >/dev/null
+reset_marker
+OUT="$(drain_codex)"
+if printf '%s' "$OUT" | grep -q '"decision": "block"' \
+   && printf '%s' "$OUT" | grep -q "continue the claimed task"; then
+  pass "codex managed hook: open claimed work still blocks (anti-abandonment, #1199 path)"
+else
+  fail "codex managed hook should block 'continue the claimed task' (got: '${OUT}')"
+fi
+
+# ============================================================
+# Phase 12 — daemon nudge-suppression stamp (no fail-count bump)
+# ============================================================
+# Re-queue so the drain takes the queued path and stamps last_nudge_key for the
+# queued id. Read agent_state via the public `agb status`-style summary? The
+# stamp is internal; assert it via the find-open helper + a direct check that
+# the next daemon-step would suppress. We read the stamped fields through the
+# CLI's own daemon nudge gate: a fresh daemon-step right after the stamp must
+# NOT emit a nudge for this agent (last_nudge_ts >= activity, same key).
+QUEUE update "$CXTASK" --status queued >/dev/null
+reset_marker
+SNAPSHOT="$TMP_DIR/snapshot.tsv"
+NOW="$(date +%s)"
+{
+  printf 'agent\tengine\tsession\tworkdir\tactive\tsession_activity_ts\n'
+  printf '%s\tclaude\t%s\t/tmp\t1\t%s\n' "$AGENT" "$AGENT" "$(( NOW - 600 ))"
+} >"$SNAPSHOT"
+# Drive the drain (this writes the self-continue stamp).
+OUT="$(drain_claude)"
+if printf '%s' "$OUT" | grep -q '"decision": "block"'; then
+  pass "nudge-suppression precondition: drain blocked on the re-queued task"
+else
+  fail "drain should block to write the suppression stamp (got: '${OUT}')"
+fi
+# Verify nudge_fail_count did NOT increment (stays 0). We assert it via a
+# second self-continue + a sentinel: note-self-continue must keep fail_count 0
+# even when called repeatedly. Probe through a tiny standalone reader helper.
+FAILCOUNT="$(python3 "$SCRIPT_DIR/9780-stop-inbox-drain-helpers/read-nudge-state.py" "$DB" "$AGENT")"
+# read-nudge-state prints: "<last_nudge_ts> <nudge_fail_count> <last_nudge_key>"
+NUDGE_FAIL="$(printf '%s' "$FAILCOUNT" | awk '{print $2}')"
+NUDGE_KEY="$(printf '%s' "$FAILCOUNT" | awk '{print $3}')"
+if [[ "$NUDGE_FAIL" == "0" ]]; then
+  pass "nudge-suppression stamp: nudge_fail_count NOT incremented (stays 0)"
+else
+  fail "self-continue stamp must NOT bump nudge_fail_count (got: '${NUDGE_FAIL}')"
+fi
+if [[ "$NUDGE_KEY" == "$CXTASK" ]]; then
+  pass "nudge-suppression stamp: last_nudge_key set to the queued id (${CXTASK})"
+else
+  fail "last_nudge_key should be the queued id ${CXTASK} (got: '${NUDGE_KEY}')"
+fi
+# And the daemon-step must now suppress a concurrent nudge for the same queue.
+DSTEP="$(QUEUE daemon-step --snapshot "$SNAPSHOT" --idle-threshold 120 --format text)"
+if printf '%s\n' "$DSTEP" | grep -qE "^${AGENT}[[:space:]]"; then
+  fail "daemon-step must NOT nudge after a self-continue stamp (got: '${DSTEP}')"
+else
+  pass "daemon double-submit avoided: daemon-step suppresses the concurrent nudge"
+fi
+
+if (( failed )); then
+  echo "[smoke:${SMOKE_NAME}] FAILED" >&2
+  exit 1
+fi
+echo "[smoke:${SMOKE_NAME}] all checks passed"

--- a/scripts/smoke/upgrade-shared-settings-propagate-helpers/stop-chain-probe.py
+++ b/scripts/smoke/upgrade-shared-settings-propagate-helpers/stop-chain-probe.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Stop-chain assertions for upgrade-shared-settings-propagate (#9780).
+
+File-as-argv helper so the smoke does not embed a python3 heredoc-stdin in a
+command substitution (footgun #11 / scripts/lint-heredoc-ban.sh C1 deadlock
+class). Two modes:
+
+  has <settings.json> <needle>     → prints "yes"/"no" if a Stop hook command
+                                      contains <needle>.
+  order <settings.json>            → prints "yes" when the Stop chain order is
+                                      surface-reply-enforce → inbox-auto-drain →
+                                      session-stop, else "no".
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _flat_stop_commands(settings_path: str) -> list[str]:
+    data = json.loads(Path(settings_path).read_text(encoding="utf-8"))
+    stop = data.get("hooks", {}).get("Stop", [])
+    return [
+        h.get("command", "")
+        for grp in stop
+        for h in grp.get("hooks", [])
+    ]
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        sys.stderr.write("usage: stop-chain-probe.py <has|order> <settings.json> [needle]\n")
+        return 2
+    mode, settings_path = argv[1], argv[2]
+    flat = _flat_stop_commands(settings_path)
+
+    if mode == "has":
+        if len(argv) != 4:
+            sys.stderr.write("usage: stop-chain-probe.py has <settings.json> <needle>\n")
+            return 2
+        needle = argv[3]
+        print("yes" if any(needle in c for c in flat) else "no")
+        return 0
+
+    if mode == "order":
+        def idx(needle: str) -> int:
+            for i, c in enumerate(flat):
+                if needle in c:
+                    return i
+            return -1
+        s = idx("surface-reply-enforce.py")
+        d = idx("inbox-auto-drain.py")
+        ss = idx("session-stop.py")
+        print("yes" if -1 not in (s, d, ss) and s < d < ss else "no")
+        return 0
+
+    sys.stderr.write(f"unknown mode: {mode}\n")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/smoke/upgrade-shared-settings-propagate.sh
+++ b/scripts/smoke/upgrade-shared-settings-propagate.sh
@@ -149,12 +149,13 @@ assert_operator_overlay_wins() {
 }
 
 assert_stop_hook_suite_propagates() {
-  # Issue #541 PR-B: ensure-stop-hook on the shared base must register the
-  # full suite (mark-idle.sh + surface-reply-enforce.py + session-stop.py),
-  # and the rendered effective settings (consumed by every per-agent symlink
-  # via bridge_link_claude_settings_to_shared) must carry all three.
+  # Issue #541 PR-B (+ #9780): ensure-stop-hook on the shared base must
+  # register the full suite — mark-idle.sh + surface-reply-enforce.py +
+  # inbox-auto-drain.py (#9780) + session-stop.py — and the rendered effective
+  # settings (consumed by every per-agent symlink via
+  # bridge_link_claude_settings_to_shared) must carry all four.
   local base effective stop_count
-  local has_mark_idle has_surface has_session_stop
+  local has_mark_idle has_surface has_inbox_drain has_session_stop
 
   base="$BRIDGE_AGENT_HOME_ROOT/.claude/settings.json"
   effective="$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json"
@@ -179,7 +180,7 @@ flat = [h.get("command","") for grp in stop for h in grp.get("hooks", [])]
 print(len(flat))
 PY
 )"
-  smoke_assert_eq "3" "$stop_count" "shared base Stop array has 3 entries after ensure-stop-hook"
+  smoke_assert_eq "4" "$stop_count" "shared base Stop array has 4 entries after ensure-stop-hook"
 
   has_mark_idle="$(python3 - "$base" mark-idle.sh <<'PY'
 import json, sys
@@ -201,6 +202,9 @@ flat = [h.get("command","") for grp in stop for h in grp.get("hooks", [])]
 print("yes" if any(needle in c for c in flat) else "no")
 PY
 )"
+  # #9780: presence + ordering go through a file-as-argv helper (no
+  # python3 heredoc-stdin in a capture — footgun #11 / lint-heredoc-ban C1).
+  has_inbox_drain="$(python3 "$SCRIPT_DIR/upgrade-shared-settings-propagate-helpers/stop-chain-probe.py" has "$base" inbox-auto-drain.py)"
   has_session_stop="$(python3 - "$base" session-stop.py <<'PY'
 import json, sys
 from pathlib import Path
@@ -213,13 +217,21 @@ PY
 )"
   smoke_assert_eq "yes" "$has_mark_idle" "shared base Stop suite includes mark-idle.sh"
   smoke_assert_eq "yes" "$has_surface" "shared base Stop suite includes surface-reply-enforce.py"
+  smoke_assert_eq "yes" "$has_inbox_drain" "shared base Stop suite includes inbox-auto-drain.py (#9780)"
   smoke_assert_eq "yes" "$has_session_stop" "shared base Stop suite includes session-stop.py"
+
+  # #9780: ordering is load-bearing — inbox-auto-drain.py must sit AFTER
+  # surface-reply-enforce.py and BEFORE session-stop.py.
+  local order_ok
+  order_ok="$(python3 "$SCRIPT_DIR/upgrade-shared-settings-propagate-helpers/stop-chain-probe.py" order "$base")"
+  smoke_assert_eq "yes" "$order_ok" "Stop chain order: surface-reply-enforce → inbox-auto-drain → session-stop (#9780)"
 
   # status-stop-hook must agree (suite present, exit 0)
   local status_out
   status_out="$(python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" status-stop-hook --settings-file "$base" --bridge-home "$BRIDGE_HOME" --bash-bin bash --format shell)"
   smoke_assert_contains "$status_out" "HOOK_STOP_HOOK_SUITE=present" "status-stop-hook reports suite present"
   smoke_assert_contains "$status_out" "HOOK_STOP_HOOK_SURFACE_REPLY_ENFORCE=present" "status-stop-hook reports surface-reply-enforce.py present"
+  smoke_assert_contains "$status_out" "HOOK_STOP_HOOK_INBOX_DRAIN=present" "status-stop-hook reports inbox-auto-drain.py present"
   smoke_assert_contains "$status_out" "HOOK_STOP_HOOK_SESSION_STOP=present" "status-stop-hook reports session-stop.py present"
 
   # render-shared-settings must propagate the suite into the effective file
@@ -238,7 +250,7 @@ flat = [h.get("command","") for grp in stop for h in grp.get("hooks", [])]
 print(len(flat))
 PY
 )"
-  smoke_assert_eq "3" "$effective_count" "effective settings carries 3-entry Stop suite (rerender-consumed)"
+  smoke_assert_eq "4" "$effective_count" "effective settings carries 4-entry Stop suite (rerender-consumed)"
 }
 
 main() {


### PR DESCRIPTION
## Summary

Bridge task **#9780** — Stop/turn-end inbox auto-drain (claude + codex; gemini deferred to #1561).

The Claude/Codex Stop chain *surfaced* the inbox as context but never *blocked* to drain it, so a finished turn showed "you have pending tasks" yet still went idle until an external `[Agent Bridge]` push or a human woke the agent. Compounded by an unstable daemon nudge (`submit_lost_post_grace`), queued A2A-outbox / unclaimed-watchdog / memory-daily work accumulated silently. This is a **reliability fix**: a turn-end auto-continue, guarded against the obvious failure mode (an infinite Stop→block→Stop loop).

## Behavior

A new Stop step emits `{"decision":"block","reason":...}` when the agent ends a turn with genuinely-actionable queue work — instructing it to drain (claim → process → done) — and stays silent (idle) when there is nothing to do.

- **Claude**: new `hooks/inbox-auto-drain.py`, wired into the Stop chain.
- **Codex**: the managed Stop hook is already `check-inbox.py --format codex` (legacy `codex-stop.py` removed); it now routes through the **same shared guard**, so both engines share one drain implementation.

## The §3 loop guard (the crux) — `bridge_hook_common.compute_drain_decision`

- Honours `stop_hook_active` (never stacks on a prior chain block).
- **Never blocks on an empty/actionless queue.**
- Per-agent marker `inbox-drain-state.json` under the **`BRIDGE_ACTIVE_AGENT_DIR` runtime state root** (not a hard-coded `state/agents/<a>` path), keyed on **`id + status + updated_ts`** plus a consecutive counter + cooldown — genuine progress (a status/timestamp change) **RESETS** the guard, while a stuck same-state task cannot loop.
- Reads/initialises the marker and **ATOMICALLY PERSISTS it BEFORE** any `decision:block`.
- **FAILS OPEN** (exit 0, no block) on queue timeout, marker parse error, or marker write failure — a marker I/O bug can never become an infinite loop.
- Cap + cooldown env-overridable (`BRIDGE_STOP_DRAIN_CAP` / `BRIDGE_STOP_DRAIN_COOLDOWN`); `BRIDGE_STOP_DRAIN_DISABLE` kill-switch.
- Queued auto-drain and already-claimed anti-abandonment stay **DISTINCT** — the #1199 "queued-only ACTION REQUIRED, claimed still blocks stop" contract is preserved (queued-first; a queued top-row read error keeps queued-first / fails open, never silently switches to a claimed block).

## Daemon double-submit coordination

- `bridge-queue.py note-self-continue` — a non-failure "attention delivered" stamp updating `agent_state.last_nudge_ts` / `last_nudge_key` for the current queued set **WITHOUT** incrementing `nudge_fail_count` or touching zombie state (distinct from `note-nudge`, which DOES increment). A concurrent daemon ACTION REQUIRED nudge for the same window is suppressed.
- `find-open` single-row JSON now carries `updated_ts` for the guard key.

## Wiring / ordering (load-bearing)

- `agents/.claude/settings.json` + `bridge-hooks.py ensure-stop-hook` place inbox-auto-drain **AFTER** `surface-reply-enforce.py` (so it never shadows the channel-reply block) and **BEFORE** `session-stop.py`; `reorder_event_hook_before` re-seats it idempotently on existing installs.
- All Stop-hook failures exit-0 / non-blocking (PR #449).

## Tests / verification

- New `scripts/smoke/9780-stop-inbox-drain.sh` (registered in `scripts/ci-select-smoke.sh` via a union-safe standalone line + the bridge-queue.py / hooks/* per-file arms) — 20 assertions: queued→block; empty→exit0 no-loop; same-key 2nd-stop→no re-block; progress resets guard; cap→idle; `stop_hook_active`→exit0; marker parse/write fail→fail-open exit0; queue error→fail-open exit0; codex managed-hook drives the same drain + dedup; codex claimed anti-abandonment; daemon nudge-suppression stamp (no `nudge_fail_count` bump); #1199 retained.
- `scripts/smoke/1199-action-required-claimed-skip.sh` — 12/12 PASS (no #1199 regression from the `check_inbox.py` refactor).
- `scripts/smoke/upgrade-shared-settings-propagate.sh` — updated for the 4-hook suite + a Stop-chain ordering assertion.
- `bash -n` + `shellcheck` clean on changed `.sh`; `py_compile`/import clean on changed hooks + `bridge_hook_common` + `bridge-queue.py` + `bridge-hooks.py` + both smoke helpers.
- `scripts/lint-heredoc-ban.sh --baseline-check` **PASS** (no new heredoc-stdin — footgun #11; smoke uses file-as-argv helpers).
- `./scripts/smoke-test.sh` — the only failure is a **pre-existing** macOS controller-env guard (`#365 follow-up`) that fails **identically on the base SHA `55bd8b1e`**; this diff touches none of that code path.

## Internal review

Internal `codex:codex-rescue` review: r1 `needs-more` (two findings — a queue-subprocess error could raise into the codex Stop path; and a queued top-row read error could fall through to a claimed block) → both fixed (defense-in-depth try/except on the stamp path + queued-first preservation in `drain_top_actionable`) → r2 **`implement-ok`**.

## Scope notes

- **Gemini/antigravity** is OUT (no Stop-hook infra in HEAD) — deferred to **#1561** (reuse this PR's shared `compute_drain_decision` guard once a Gemini turn-end seam exists).
- The daemon-nudge `submit_lost_post_grace` ROOT fix (tmux submit loss) is a separate track; this PR reduces reliance on the daemon nudge.
- **NO VERSION/CHANGELOG** (per the stabilization version policy — operator-cued release batches it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
