### PR TITLE
agent-bridge: skip roster load for pure queue verbs in dispatcher (#848 lost-fix)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -251,8 +251,20 @@ source "$SCRIPT_DIR/bridge-lib.sh"
 # subcommand token is also kept so that an `agb help` style invocation
 # (if a future patch adds the subcommand handler) does not eat the
 # roster cost either.
+#
+# Issue #848 (lost-fix upstream): also skip the top-level load for the
+# pure queue verbs (`show`, `claim`, `done`, `cancel`, `update`,
+# `handoff`, `summary`, `create`). The dispatch table below `exec`s
+# `bridge-task.sh "$@"` for all of these (alongside the already-listed
+# `inbox`), and `bridge-task.sh` is a separate process that owns its
+# own lazy roster loading (`ensure_roster_loaded`). So the parent-level
+# load here is pure redundant cold-start cost — the child re-derives
+# whatever roster state it needs. `handoff` is the only one that
+# validates a target against the roster, and it does so via the child's
+# own `ensure_roster_loaded` immediately before `bridge_require_agent`,
+# so it is unaffected by skipping the parent load.
 case "${1:-}" in
-  version|status|daemon|agent|task|inbox|a2a|room|iso-run|help|--help|-h|--version|-V) ;;
+  version|status|daemon|agent|task|inbox|show|claim|done|cancel|update|handoff|summary|create|a2a|room|iso-run|help|--help|-h|--version|-V) ;;
   init)
     # bridge-isolation-v2.sh's `BRIDGE_LAYOUT="${BRIDGE_LAYOUT:-legacy}"`
     # default fires during our bridge-lib.sh source above and exports the


### PR DESCRIPTION
## Summary

Upstream into rc3 source the agent-bridge dispatcher fast-path that skips `bridge_load_roster` for pure queue verbs. This is a **lost-fix**: #848 is CLOSED-as-fixed and the matured logic shipped in the live runtime, but rc2 source still pays the roster cold-start cost for these verbs. Confirmed by maintainer `patch`.

## The change

In the `agent-bridge` root dispatcher's roster-skip case (the one ending `*) bridge_load_roster ;;`), the fast-path branch already exempted `inbox` and the hot-path subcommands. The pure queue verbs `show|claim|done|cancel|update|handoff|summary|create` still fell through to `*)` and paid the full roster-hydration cold-start (~0.8–1.1s of `python3` spawns on macOS) before the dispatch table ever exec'd `bridge-task.sh`.

The fix merges the 8 missing verbs into the **existing** fast-path branch line (clean form — no redundant duplicate branch), matching the matured live-runtime behavior:

```diff
-  version|status|daemon|agent|task|inbox|a2a|room|iso-run|help|--help|-h|--version|-V) ;;
+  version|status|daemon|agent|task|inbox|show|claim|done|cancel|update|handoff|summary|create|a2a|room|iso-run|help|--help|-h|--version|-V) ;;
```

Plus an explanatory comment documenting why the verbs are roster-safe at the parent level.

## Why each verb is safe (parent-roster-independent)

The dispatch table (`agent-bridge` ~L1444) execs `bridge-task.sh "$@"` for all 8 verbs (alongside the already-skipped `inbox`). `bridge-task.sh` is a **separate process** that owns its own lazy roster loading via `ensure_roster_loaded` — so the parent-level load here was pure redundant cold-start cost; the child re-derives whatever roster state it needs.

`handoff` is the only added verb that validates a target against the roster, and it does so through the child's own `ensure_roster_loaded` immediately before `bridge_require_agent` (`bridge-task.sh` ~L918) — unaffected by skipping the parent load. `inbox` has shipped with this exact parent-skip since #815, the empirical precedent.

| Verb | Parent roster needed | Child behavior |
|------|------|------|
| show | No | direct queue I/O |
| claim / done / cancel / update / summary / create | No | child lazy-loads roster before use |
| handoff | No | child `ensure_roster_loaded` before `bridge_require_agent` |

## Verification

- `bash -n agent-bridge` PASS; `shellcheck agent-bridge` 0 findings (same as base).
- `git diff origin/main -- agent-bridge` minimal: one clean fast-path line + comment, no duplicate roster-skip branch.
- Dispatch-path trace: all 8 new verbs + `inbox` hit the skip branch, then exec `bridge-task.sh`.
- `scripts/smoke-test.sh` — one pre-existing, change-independent failure (the `#365` ephemeral-controller-env guard, reproduced identically on clean `origin/main` on this macOS host); all queue/dispatch checks pass.
- `scripts/oss-preflight.sh` — **preflight passed** (identical state to clean `origin/main`).
- Internal `codex` pair-review: **implement-ok**, no blocking findings — independently confirmed the right case statement was targeted (the L220 verb-classifier and L1444 dispatch table untouched), all 8 verbs are parent-roster-independent, and no VERSION/CHANGELOG diff.

## Scope notes

- Targets only the roster-skip dispatcher case. The L220 `BRIDGE_QUEUE_SAFE_CONTEXT` verb-classifier and the L1444 dispatch table are left untouched.
- No VERSION/CHANGELOG bump (rc3 batches later, per operator version policy).

Refs #848 (closed issue whose matured fix never reached rc2 source — upstreaming the lost-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
