### PR TITLE
core: de-heredoc bridge-core.sh remaining footgun-11 sites (#1466)

### DIFF
--- a/.lint-heredoc-baseline.tsv
+++ b/.lint-heredoc-baseline.tsv
@@ -206,10 +206,7 @@ lib/bridge-channels.sh	144	C3	28c211234a01352ec3a0c87c4ce9cab53ba60e168fa4663482
 lib/bridge-channels.sh	237	H3	8b19f0a7707fef140d1598934bd1208cb7fecaa437dc0e50d49609323eef73ac	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-channels.sh	371	C3	011f1d4418e8f0e4cd28ce77a92161e0945c93eb9c8684bd2add1a8ddbe741be	interpreter heredoc, no capture	patch	Phase 3 PR C
 lib/bridge-core.sh	514	C3	c5a19ca66d0088387de551f481ce08c0218765bdc1221891c961bb801d2ea2f7	interpreter heredoc, no capture	patch	Phase 3 PR C
-lib/bridge-core.sh	684	C3	aef38fbc7564d9de6b2815ae358b26d9825bfb3f22fc31a8dab46b9c8d49d9f0	interpreter heredoc, no capture	patch	Phase 3 PR C
-lib/bridge-core.sh	823	H3	7f7d4271f82d264c46d0c2422682d01605a432c0cb26abe55cab67d0259b5683	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
-lib/bridge-core.sh	1131	C1	70a49191ce1893945509406b7a5958498a35d5a13f7ea313cc6fcb8e22361100	interpreter heredoc (stripper false-positive: phantom capture from nested-quote bash-c-python at L714)	patch	process-boundary-safe
-lib/bridge-core.sh	1152	C1	70a49191ce1893945509406b7a5958498a35d5a13f7ea313cc6fcb8e22361100	interpreter heredoc (stripper false-positive: phantom capture from nested-quote bash-c-python at L714)	patch	process-boundary-safe
+lib/bridge-core.sh	818	H3	57c30e1fe048f6b4fab20ea8714175de73c6d88cd0e2b6b41b3dfc183ff9c509	here-string/procsub, non-interpreter consumer	claude	#1466 de-heredoc — process-boundary-safe procsub (was <<< here-string at L823)
 lib/bridge-cron.sh	1125	H3	35b27cdf94bea1e16d55b7480469958cce5ee843d0216db616ff389351e17801	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-cron.sh	1126	H3	5f60048d8c2bcee42ee39ed4d116dc02d56b1e0338b43fc3566ca862a142ff20	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-discord.sh	40	H3	b7fa996e0677d162d0061308f4f1561a488c85997ab55a095544e4d61e676bee	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -681,12 +681,7 @@ bridge_sha1() {
   local text="$1"
 
   bridge_require_python
-  python3 - "$text" <<'PY'
-import hashlib
-import sys
-
-print(hashlib.sha1(sys.argv[1].encode("utf-8")).hexdigest())
-PY
+  python3 -c 'import hashlib, sys; print(hashlib.sha1(sys.argv[1].encode("utf-8")).hexdigest())' "$text"
 }
 
 # Batch variant of bridge_sha1 — one python3 spawn hashes N inputs. Reads
@@ -820,7 +815,7 @@ bridge_queue_source_shell() {
 
   queue_output="$(bridge_queue_cli "$@")" || return $?
   # shellcheck disable=SC1090
-  source /dev/stdin <<<"$queue_output"
+  source /dev/stdin < <(printf '%s\n' "$queue_output")
 }
 
 bridge_reset_roster_maps() {
@@ -1128,20 +1123,14 @@ bridge_path_relative_to_root() {
   local root="$2"
 
   bridge_require_python
-  python3 - "$path" "$root" <<'PY'
-import os
-import sys
-
-path = os.path.realpath(sys.argv[1])
-root = os.path.realpath(sys.argv[2])
-
-try:
-    rel = os.path.relpath(path, root)
-except Exception:
-    rel = "."
-
-print(rel)
-PY
+  # #946 L1: guard the `python3 "$BRIDGE_SCRIPT_DIR/..."` helper call so a
+  # stale/removed source checkout self-heals or fails auditably instead of
+  # raising `unbound variable` / `can't open file`. The `_check` form (not
+  # `_or_die`) is required because callers wrap this in `$( ... )`.
+  if ! bridge_resolve_script_dir_check; then
+    return 1
+  fi
+  python3 "$BRIDGE_SCRIPT_DIR/lib/bridge-path-utils.py" relative "$path" "$root"
 }
 
 bridge_path_is_within_root() {
@@ -1149,21 +1138,13 @@ bridge_path_is_within_root() {
   local root="$2"
 
   bridge_require_python
-  python3 - "$path" "$root" <<'PY'
-import os
-import sys
-
-path = os.path.realpath(sys.argv[1])
-root = os.path.realpath(sys.argv[2])
-
-try:
-    common = os.path.commonpath([path, root])
-except ValueError:
-    print("0")
-    raise SystemExit(0)
-
-print("1" if common == root else "0")
-PY
+  # #946 L1: see bridge_path_relative_to_root. `_check` form because callers
+  # wrap this in `$( ... )`; an unguarded `$BRIDGE_SCRIPT_DIR` would surface
+  # as an unbound-variable abort or a silent empty capture in daemon paths.
+  if ! bridge_resolve_script_dir_check; then
+    return 1
+  fi
+  python3 "$BRIDGE_SCRIPT_DIR/lib/bridge-path-utils.py" within "$path" "$root"
 }
 
 bridge_history_key_for() {

--- a/lib/bridge-path-utils.py
+++ b/lib/bridge-path-utils.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+
+mode = sys.argv[1]
+path = os.path.realpath(sys.argv[2])
+root = os.path.realpath(sys.argv[3])
+
+if mode == "relative":
+    try:
+        print(os.path.relpath(path, root))
+    except Exception:
+        print(".")
+elif mode == "within":
+    try:
+        common = os.path.commonpath([path, root])
+    except ValueError:
+        print("0")
+    else:
+        print("1" if common == root else "0")
+else:
+    raise SystemExit(f"unknown mode: {mode}")


### PR DESCRIPTION
## Summary

Upstreams the **lost fix** from #1466 (footgun #11 / Bash 5.3.9 `read_comsub` heredoc-stdin deadlock class). The de-heredoc'd forms have run in the live runtime for weeks across daemon/cron/queue paths; this lands them in source so an upgrade auto-merge no longer diverges. Maintainer `patch` confirmed this as a lost-fix.

Converts the four remaining in-process subprocess sites in `lib/bridge-core.sh` to deadlock-safe forms (matching the live-validated runtime end-state), adds the new `lib/bridge-path-utils.py` helper, and ratchets the heredoc-ban baseline down.

## Changes

`lib/bridge-core.sh` — 4 conversions:

| Function | Before | After |
|---|---|---|
| `bridge_sha1` | `python3 - "$text" <<'PY' … PY` | `python3 -c '…' "$text"` |
| `bridge_queue_source_shell` | `source /dev/stdin <<<"$queue_output"` | `source /dev/stdin < <(printf '%s\n' "$queue_output")` |
| `bridge_path_relative_to_root` | inline `python3 - … <<'PY'` | `python3 "$BRIDGE_SCRIPT_DIR/lib/bridge-path-utils.py" relative …` |
| `bridge_path_is_within_root` | inline `python3 - … <<'PY'` | `python3 "$BRIDGE_SCRIPT_DIR/lib/bridge-path-utils.py" within …` |

`lib/bridge-path-utils.py` — new 23-line helper (invoked file-as-argv, never via heredoc-stdin, so it cannot trip the bug it replaces). Modes: `relative` (`os.path.relpath`, `.` on exception) and `within` (`commonpath == root` → `1` else `0`).

`.lint-heredoc-baseline.tsv` — surgical ratchet: drop the 4 stale `bridge-core.sh` rows, register the 1 new procsub `H3` site. Diff vs `origin/main` touches **only** `bridge-core.sh` rows.

### Notes
- `bridge_runtime_id`'s interpreter heredoc is **intentionally left** to match the live end-state (process-boundary-safe, no capture).
- The 2 datetime/secrets `python3 -c` sites were already non-heredoc in source — untouched.
- Both new `bridge-path-utils.py` wrappers are guarded with `bridge_resolve_script_dir_check` (the #946 L1 contract every other `python3 "$BRIDGE_SCRIPT_DIR/…"` callsite honors). This is the one deliberate deviation from the live end-state, which predates the L1 hardening and carries a latent unbound-variable/silent-empty gap in daemon command-substitution paths.

## Verification

- `bash -n lib/bridge-core.sh` + `shellcheck lib/bridge-core.sh` — clean
- `python3 -m py_compile lib/bridge-path-utils.py` — clean
- Functional: `relative /a/b/c /a` → `b/c`; `within /a/b /a` → `1`; `within /x/y /a` → `0`
- Converted bash fns exercised directly: `bridge_sha1 "hello world"` → `2aae6c35…846ed`, path fns correct
- L1 guard repro: with `BRIDGE_SCRIPT_DIR` unset/stale, wrappers self-heal via `bridge_resolve_script_dir_check` instead of aborting
- `scripts/lint-heredoc-ban.sh --baseline-check` — **PASS** (full repo, RC=0)
- `iso-helper-ratchet` + `lint-raw-pathlib` — pass (helper has no boundary-artifact filenames; uses `os.path`, not `pathlib` — no baseline entries needed)
- Pre-existing smoke note: the one failing `smoke-test.sh` assertion (`SCRIPTDIR_STARTUP_OK`) reproduces identically on clean `origin/main` (isolation-v2 layout guard firing on a fresh temp `BRIDGE_HOME`) — **not** caused by this change.

Reviewed via codex pair-review to `implement-ok` (round-1 caught the missing L1 guard; round-2 confirmed the fix).

No VERSION/CHANGELOG bump (hygiene batch).

Ref #1466

🤖 Generated with [Claude Code](https://claude.com/claude-code)
