### PR TITLE
feat(a2a): whole-room fan-out for A2A rooms (#1594)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -893,10 +893,19 @@ PY
           cat <<'A2A_HELP'
 Usage: agent-bridge a2a <command> [args]
 
-  send          Stage an outbound cross-bridge handoff into the outbox.
+  send          Stage an outbound cross-bridge handoff into the outbox, OR
+                fan a message out to every member of a room (--room).
+                  # 1:1 cross-bridge send:
                   agent-bridge a2a send --peer <peer> --to <agent> \
                     --title <t> [--body <text>|--body-file <path>] \
                     [--priority low|normal|high|urgent] [--dry-run]
+                  # whole-room fan-out (every OTHER member, self excluded;
+                  # local members via the queue, remote via room-scoped A2A):
+                  agent-bridge a2a send --room <room_id> \
+                    --title <t> [--body <text>|--body-file <path>] \
+                    [--to <member>] [--priority ...] [--json]
+                (--peer/--to and --room are mutually exclusive. The same
+                fan-out is also `agent-bridge room talk <room_id> --fanout`.)
   outbox        list | retry <id> | drop <id> | gc — manage the outbox.
   inbox-dedupe  list | gc — inspect/prune the receiver dedupe ledger.
   peers         list | test <peer> — inspect configured peers.
@@ -941,6 +950,11 @@ Usage: agent-bridge room <command> [args]
                   agent-bridge room join <link> [--as <agent>]
   approve|deny  Leader-only: approve/deny a join request (agent or agent@node).
   kick|leave    Remove a member (leader kick / self leave) — bumps epoch.
+  talk          Room-scoped message to other-node members (add --fanout to ALSO
+                reach same-node members via the queue).
+  send          Whole-room fan-out to EVERY other member (self excluded; local
+                via the queue + remote via room-scoped A2A). Same as
+                `agent-bridge a2a send --room <room_id>`.
   adopt-all     Create a default room with every current roster agent.
   acl           Show/set rooms_acl mode (off|enforce). P1a does NOT enforce.
 

--- a/bridge-a2a.py
+++ b/bridge-a2a.py
@@ -232,7 +232,64 @@ def _sudo_read_text(path: Path) -> str | None:
 # a2a send — stage an outbound entry into the durable outbox
 # --------------------------------------------------------------------------
 
+def _delegate_room_fanout(args: argparse.Namespace) -> int:
+    """Route `a2a send --room <id> ...` into the rooms whole-room fan-out (#1594).
+
+    The fan-out machinery (membership proof from the local leader-MAC roster
+    cache / authoritative rooms.db, OS-actor-anchored sender identity, the
+    same-node local-queue leg + the cross-node room-scoped A2A leg, partial
+    failure collection) lives in `bridge-rooms.py send` — the canonical alias of
+    `room talk --fanout`. This is the SAME code path `agent-bridge room talk`
+    uses; `a2a send --room` is the ergonomic surface over it, NOT a second
+    implementation or a new wire path. We invoke it as a subprocess (argv array,
+    never a shell string) so the OS-actor identity resolution, the rooms.db open,
+    and the receiver-enforced room gate all run exactly as they do for the
+    `room` CLI. The sender's membership is NEVER asserted from these flags — the
+    delegated command proves it against this node's own roster before sending.
+    """
+    import subprocess
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    rooms_cli = os.path.join(here, "bridge-rooms.py")
+    if not os.path.isfile(rooms_cli):
+        return die(f"bridge-rooms.py not found beside {here}") or 1
+    argv = [sys.executable or "python3", rooms_cli, "send", args.room,
+            "--title", args.title, "--priority", args.priority]
+    if args.body is not None:
+        argv += ["--body", args.body]
+    if args.body_file is not None:
+        argv += ["--body-file", args.body_file]
+    if args.to:
+        argv += ["--to", args.to]
+    if args.allow_empty_body:
+        argv.append("--allow-empty-body")
+    if getattr(args, "as_agent", None):
+        argv += ["--as", args.as_agent]
+    if args.json:
+        argv.append("--json")
+    proc = subprocess.run(argv)  # stdout/stderr stream straight through
+    return proc.returncode
+
+
 def cmd_send(args: argparse.Namespace) -> int:
+    # #1594: `--room` is the whole-room fan-out mode; it is mutually exclusive
+    # with the 1:1 `--peer`/`--to` path. Validate the surface, then delegate to
+    # the rooms fan-out (which owns membership proof + the local/remote legs).
+    if getattr(args, "room", None):
+        if args.peer:
+            return die("pass only one of --peer (1:1 send) / --room "
+                       "(whole-room fan-out)") or 1
+        if args.dry_run:
+            return die("--dry-run is not supported for --room fan-out; "
+                       "use 'agent-bridge room show <room_id>' to preview the "
+                       "roster") or 1
+        return _delegate_room_fanout(args)
+    # Below here is the 1:1 cross-bridge send — --peer + --to are required.
+    if not args.peer:
+        return die("--peer is required for a 1:1 send (or pass --room for a "
+                   "whole-room fan-out)") or 1
+    if not args.to:
+        return die("--to is required for a 1:1 send") or 1
     try:
         cfg = a2a.load_config()
         # #1331: fail-closed at send time too — surface the empty-secret
@@ -2653,14 +2710,31 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_send = sub.add_parser("send", help="stage an outbound cross-bridge handoff")
-    p_send.add_argument("--peer", required=True, help="configured peer bridge id")
-    p_send.add_argument("--to", required=True, help="target agent on the peer bridge")
+    # `--peer --to` is the 1:1 cross-bridge send. `--room <id>` is the whole-room
+    # fan-out (#1594): one message to EVERY other member of a room (self
+    # excluded) — local same-node members via the internal queue, remote members
+    # via room-scoped A2A. The two modes are mutually exclusive; `--peer`/`--to`
+    # are therefore NOT argparse-required (validated in cmd_send so a `--room`
+    # send is not forced to supply a peer it does not have).
+    p_send.add_argument("--peer", default=None, help="configured peer bridge id "
+                        "(1:1 send; mutually exclusive with --room)")
+    p_send.add_argument("--to", default=None, help="target agent on the peer "
+                        "bridge (1:1 send) or a single room member to narrow a "
+                        "--room fan-out to (agent or agent@node)")
+    p_send.add_argument("--room", default=None, help="whole-room fan-out: send "
+                        "to every OTHER member of this room id (self excluded; "
+                        "mutually exclusive with --peer)")
     p_send.add_argument("--from", dest="from_agent", default=None, help="sending agent id")
+    p_send.add_argument("--as", dest="as_agent", default=None,
+                        help="(room fan-out) recorded acting identity for a "
+                             "proven operator shell; IGNORED under iso v2")
     p_send.add_argument("--title", required=True)
     p_send.add_argument("--body", default=None)
     p_send.add_argument("--body-file", default=None)
     p_send.add_argument("--priority", default="normal")
     p_send.add_argument("--allow-empty-body", action="store_true")
+    p_send.add_argument("--json", action="store_true",
+                        help="(room fan-out) machine-readable per-recipient result")
     p_send.add_argument("--dry-run", action="store_true",
                         help="resolve + validate but do not write the outbox")
     p_send.set_defaults(func=cmd_send)

--- a/bridge-rooms.py
+++ b/bridge-rooms.py
@@ -594,6 +594,51 @@ def _invoke_test_post_hook(*, path: str, headers: dict,
     return 200, (proc.stdout or "").encode("utf-8")
 
 
+def _test_local_hook_allowed() -> bool:
+    """Paired-flag gate for the LOCAL-queue fan-out test seam (prod-inert).
+
+    Mirrors `_test_post_hook_allowed` for the same-node local leg (#1594): the
+    smoke captures the would-be `bridge-task.sh create` invocation instead of
+    shelling out to a live queue. Same paired insecure-test flags so it can
+    NEVER fire in production.
+    """
+    return (os.environ.get("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP") == "1"  # noqa: iso-helper-boundary - env var, not a .env file
+            and os.environ.get("BRIDGE_A2A_ALLOW_TEST_BIND") == "1"  # noqa: iso-helper-boundary - env var, not a .env file
+            and bool(os.environ.get("BRIDGE_ROOMS_TEST_LOCAL_HOOK")))  # noqa: iso-helper-boundary - env var, not a .env file
+
+
+def _invoke_test_local_hook(*, target_agent: str, sender_agent: str,
+                            sender_node: str, room_id: str, room_epoch: int,
+                            title: str, priority: str,
+                            body: str) -> tuple[bool, str]:
+    """Write the would-be local-queue create to the hook file; return ok.
+
+    The hook value is a script invoked with a JSON payload on argv (file-as-argv,
+    never stdin — footgun #11 hygiene). A non-zero exit is reported as a local
+    delivery failure so the smoke can exercise the partial-failure path.
+    """
+    import subprocess
+
+    hook = os.environ["BRIDGE_ROOMS_TEST_LOCAL_HOOK"]  # noqa: iso-helper-boundary - env var, not a .env file
+    payload = {
+        "target_agent": target_agent, "from": f"room:{room_id}:{sender_agent}",
+        "sender": f"{sender_agent}@{sender_node}", "room_id": room_id,
+        "room_epoch": int(room_epoch), "title": title, "priority": priority,
+        "body": body,
+    }
+    try:
+        proc = subprocess.run(
+            [hook, json.dumps(payload)], capture_output=True, text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, f"test local hook failed: {exc}"
+    if proc.returncode != 0:
+        return False, (proc.stderr or proc.stdout or "test local hook "
+                       "non-zero").strip()[-300:]
+    return True, (proc.stdout or "").strip()
+
+
 def _post_room_roster_broadcast(*, member_node: str, room_id: str,
                                 room_epoch: int, members: list,
                                 leader_node: str, timeout: float = 30.0,
@@ -854,6 +899,119 @@ def _talk_target_pairs(members: list, sender_agent: str,
     return sorted(pairs)
 
 
+def _local_target_pairs(members: list, sender_agent: str,
+                        sender_node: str, local_node_id: str,
+                        only_to: str = "") -> list:
+    """The SAME-NODE (agent, node) pairs a whole-room fan-out targets locally.
+
+    The complement of `_talk_target_pairs`: every cached member on THIS sender's
+    own node (or, when the node ids are empty as in single-node P1a, a member
+    whose node matches the sender's empty node), EXCEPT the sender itself. These
+    recipients are reachable through the LOCAL queue (`bridge-task.sh create`),
+    not a cross-node node-link hop — so `a2a send --room` delivers to them via
+    the same durable internal-queue boundary every inter-agent task uses, while
+    `_talk_target_pairs` handles the remote leg. `only_to` (`agent`/`agent@node`)
+    narrows to a single recipient. Deterministically ordered.
+
+    The membership source is the SAME cached/authoritative roster the remote leg
+    reads — a recipient is only addressed because it is already a proven member
+    of this room, never because the caller named it.
+    """
+    want_agent, _, want_node = (only_to or "").partition("@")
+    want_agent = want_agent.strip()
+    want_node = want_node.strip()
+    pairs: list = []
+    for m in members:
+        magent = str(m.get("agent", "") or "")
+        mnode = str(m.get("node", "") or "")
+        if magent == sender_agent and mnode == sender_node:
+            continue  # never send to self
+        if mnode and mnode != local_node_id:
+            continue  # other node → remote room-talk hop, not the local queue
+        if only_to:
+            if magent != want_agent:
+                continue
+            if want_node and mnode != want_node and want_node != local_node_id:
+                continue
+        pair = (magent, mnode)
+        if pair not in pairs:
+            pairs.append(pair)
+    return sorted(pairs)
+
+
+def _post_room_local(*, target_agent: str, sender_agent: str, sender_node: str,
+                     room_id: str, room_epoch: int, title: str, body: str,
+                     priority: str, timeout: float = 120.0) -> tuple[bool, str]:
+    """Deliver a room fan-out message to a SAME-NODE member via the local queue.
+
+    Routes through the EXISTING `bridge-task.sh create` boundary (the same
+    durable internal-queue path the A2A receiver uses for inbound mail, and the
+    same one every inter-agent task takes) — NOT a new transport, and NOT a
+    direct queue-db write. The `--from` is stamped as `room:<room_id>:<sender>`
+    so the recipient (and the audit log) can see this arrived as a room fan-out,
+    parallel to the receiver's `a2a:<bridge>:<agent>` provenance for remote mail.
+
+    `sender_agent` is the OS-actor-anchored caller (the fan-out already proved it
+    is a member of `room_id` before calling here); the local target was selected
+    from the SAME proven roster. The room epoch is carried in the provenance
+    header for the recipient's context — local delivery does not need the wire
+    room-scoped gate because there is no untrusted network hop: the internal
+    queue is already the controller-owned, in-host boundary, and the membership
+    was proven locally. Returns (ok, detail).
+    """
+    if _test_local_hook_allowed():
+        return _invoke_test_local_hook(
+            target_agent=target_agent, sender_agent=sender_agent,
+            sender_node=sender_node, room_id=room_id, room_epoch=room_epoch,
+            title=title, priority=priority, body=body)
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    script = os.path.join(here, "bridge-task.sh")
+    if not os.path.isfile(script):
+        return False, f"bridge-task.sh not found beside {here}"
+    bash = os.environ.get("BRIDGE_BASH_BIN", "bash")  # noqa: iso-helper-boundary - os.environ read, not a .env file
+    provenance = (
+        "<!-- A2A room fan-out — provenance -->\n"
+        f"room id   : {room_id}\n"
+        f"room epoch: {int(room_epoch)}\n"
+        f"from      : {sender_agent}@{sender_node}\n"
+        "\n---\n\n"
+    )
+    full_body = provenance + body
+    import subprocess
+    import tempfile
+
+    # Stage the body to a temp file so a multi-line / large body crosses the
+    # bridge-task.sh boundary intact (mirrors the receiver's --body-file path).
+    fd, body_path = tempfile.mkstemp(prefix="room-fanout-", suffix=".md")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(full_body)
+        argv = [
+            bash, script, "create",
+            "--to", target_agent,
+            "--from", f"room:{room_id}:{sender_agent}",
+            "--priority", priority,
+            "--title", title,
+            "--body-file", body_path,
+        ]
+        try:
+            proc = subprocess.run(
+                argv, capture_output=True, text=True, timeout=timeout,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return False, f"bridge-task.sh invocation failed: {exc}"
+    finally:
+        try:
+            os.unlink(body_path)  # noqa: raw-pathlib-controller-only - our own mkstemp temp, not an iso-metadata path
+        except OSError:
+            pass
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()[-300:]
+        return False, detail or f"bridge-task.sh exited {proc.returncode}"
+    return True, (proc.stdout or "").strip()
+
+
 def cmd_talk(args: argparse.Namespace) -> int:
     """Send a ROOM-SCOPED message to the room's OTHER member nodes (P4.3).
 
@@ -919,16 +1077,31 @@ def cmd_talk(args: argparse.Namespace) -> int:
         return die(f"{agent}@{node} is not a member of room {room_id} per the "
                    "local roster cache — refusing to send", code=1)
 
-    targets = _talk_target_pairs(members, agent, node, node,
-                                 only_to=getattr(args, "to", "") or "")
-    if not targets:
-        return die(f"no other-node members to send to in room {room_id} "
-                   "(roster has no cross-node recipients matching the filter)",
-                   code=1)
+    only_to = getattr(args, "to", "") or ""
+    fanout = bool(getattr(args, "fanout", False))
+    remote_targets = _talk_target_pairs(members, agent, node, node,
+                                        only_to=only_to)
+    # The local (same-node) leg is the whole-room fan-out addition (#1594) and
+    # fires ONLY under fan-out (`a2a send --room` / `room send` /
+    # `room talk --fanout`). Bare `room talk` stays a strictly cross-node verb
+    # (back-compat): it never touches the local queue, even with `--to` naming a
+    # same-node member (that path keeps its prior "no cross-node recipients"
+    # behavior). `--to` still narrows the fan-out's local leg to one member.
+    local_targets = (
+        _local_target_pairs(members, agent, node, node, only_to=only_to)
+        if fanout else []
+    )
+    if not remote_targets and not local_targets:
+        return die(f"no other members to send to in room {room_id} "
+                   "(roster has no recipients matching the filter)", code=1)
 
     delivered: list = []
     failed: list = []
-    for tagent, tnode in targets:
+    used_remote = False
+    used_local = False
+
+    for tagent, tnode in remote_targets:
+        used_remote = True
         try:
             status, resp = _post_room_talk(
                 member_node=tnode, room_id=room_id, room_epoch=cached_epoch,
@@ -936,36 +1109,58 @@ def cmd_talk(args: argparse.Namespace) -> int:
                 body=body_text, priority=priority,
             )
         except rooms.RoomsError as exc:
-            failed.append({"agent": tagent, "node": tnode, "error": str(exc)})
+            failed.append({"agent": tagent, "node": tnode, "leg": "remote",
+                           "error": str(exc)})
             continue
         except Exception as exc:  # noqa: BLE001 - transport/config failure
-            failed.append({"agent": tagent, "node": tnode,
+            failed.append({"agent": tagent, "node": tnode, "leg": "remote",
                            "error": f"room talk failed: {exc}"})
             continue
         if 200 <= status < 300:
-            delivered.append({"agent": tagent, "node": tnode})
+            delivered.append({"agent": tagent, "node": tnode, "leg": "remote"})
         else:
             detail = ""
             try:
                 detail = resp.decode("utf-8", "replace")[:200]
             except Exception:  # noqa: BLE001
                 detail = ""
-            failed.append({"agent": tagent, "node": tnode,
+            failed.append({"agent": tagent, "node": tnode, "leg": "remote",
                            "status": status, "detail": detail})
+
+    for tagent, tnode in local_targets:
+        used_local = True
+        try:
+            ok, detail = _post_room_local(
+                target_agent=tagent, sender_agent=agent, sender_node=node,
+                room_id=room_id, room_epoch=cached_epoch, title=args.title,
+                body=body_text, priority=priority,
+            )
+        except Exception as exc:  # noqa: BLE001 - local enqueue failure
+            failed.append({"agent": tagent, "node": tnode, "leg": "local",
+                           "error": f"local enqueue failed: {exc}"})
+            continue
+        if ok:
+            delivered.append({"agent": tagent, "node": tnode, "leg": "local"})
+        else:
+            failed.append({"agent": tagent, "node": tnode, "leg": "local",
+                           "detail": detail})
 
     payload = {
         "room_id": room_id, "epoch": cached_epoch,
-        "from": f"{agent}@{node}",
+        "sender": f"{agent}@{node}",
+        "from": f"{agent}@{node}",  # back-compat alias for the prior field name
         "delivered": delivered, "failed": failed,
+        "legs": {"local": used_local, "remote": used_remote},
     }
     if args.json:
         out(json.dumps(payload))
     else:
-        info(f"room talk on {room_id} (epoch {cached_epoch}) from {agent}@{node}: "
-             f"{len(delivered)} delivered, {len(failed)} failed")
+        info(f"room send on {room_id} (epoch {cached_epoch}) from {agent}@{node}: "
+             f"{len(delivered)} delivered, {len(failed)} failed "
+             f"(local={used_local}, remote={used_remote})")
         for f in failed:
-            info(f"  FAILED {f['agent']}@{f['node']}: "
-                 f"{f.get('error') or f.get('status')}")
+            info(f"  FAILED {f['agent']}@{f['node']} [{f.get('leg', '?')}]: "
+                 f"{f.get('error') or f.get('detail') or f.get('status')}")
     # A partial failure is a non-zero exit so callers/cron notice, but a fully
     # delivered send (or an all-targets dry filter) returns 0.
     return 0 if not failed else 2
@@ -1458,8 +1653,35 @@ def build_parser() -> argparse.ArgumentParser:
     p_talk.add_argument("--priority", default="normal")
     p_talk.add_argument("--allow-empty-body", action="store_true",
                         dest="allow_empty_body")
+    p_talk.add_argument("--fanout", action="store_true", dest="fanout",
+                        help="ALSO deliver to same-node members via the local "
+                             "queue (whole-room fan-out); default = cross-node "
+                             "members only")
     _add_common(p_talk)
     p_talk.set_defaults(func=cmd_talk)
+
+    # `send` is the canonical whole-room fan-out alias (#1594): same machinery as
+    # `talk` but fan-out ON by default (every OTHER member — local same-node via
+    # the queue + remote member-nodes via room-scoped A2A — self excluded). It is
+    # what `agent-bridge a2a send --room <room_id>` routes to. `talk` stays for
+    # back-compat (cross-node only unless --fanout). The receiver-side gate is
+    # unchanged and still independently enforces membership on every remote hop.
+    p_fan = sub.add_parser(
+        "send",
+        help="whole-room fan-out: deliver to EVERY other room member "
+             "(local via the queue + remote via room-scoped A2A)")
+    p_fan.add_argument("room_id")
+    p_fan.add_argument("--title", required=True)
+    p_fan.add_argument("--body", default=None)
+    p_fan.add_argument("--body-file", dest="body_file", default=None)
+    p_fan.add_argument("--to", default="",
+                       help="narrow to one recipient (agent or agent@node); "
+                            "default = every other member, local and remote")
+    p_fan.add_argument("--priority", default="normal")
+    p_fan.add_argument("--allow-empty-body", action="store_true",
+                       dest="allow_empty_body")
+    _add_common(p_fan)
+    p_fan.set_defaults(func=cmd_talk, fanout=True)
 
     p_adopt = sub.add_parser(
         "adopt-all",

--- a/docs/a2a-rooms.md
+++ b/docs/a2a-rooms.md
@@ -265,6 +265,67 @@ yet part of the live-mesh verification above):
 
 - **Cloudflare Zero Trust transport** — only the Tailscale transport is exercised
   on the live mesh; the transport-negotiation seam exists but ZT is unverified.
-- **`agb a2a send` whole-room fan-out** — room-scoped *delivery* (P4.3 room-talk)
-  is wired; addressing a whole room as a single `agb a2a send` target is the next
-  ergonomic step.
+
+---
+
+## Whole-room fan-out (`a2a send --room`)
+
+Sending the same message to *every* member of a room — without naming each
+recipient — is a first-class verb:
+
+```bash
+# fan a message out to every OTHER member of the room (you are excluded):
+agb a2a send --room <room_id> --title "standup" --body "what's blocking you?"
+
+# equivalently:
+agb room send <room_id> --title "standup" --body "..."
+agb room talk <room_id> --fanout --title "standup" --body "..."
+```
+
+What it does:
+
+- **You must be a member of the room.** Membership is proven from *this node's
+  own* leader-MAC roster cache / authoritative `rooms.db` — never from the flags
+  you pass — so an agent that belongs to room A cannot address room B unless it
+  is also a member of B. A non-member send is refused before anything leaves.
+- **You are excluded** from the recipient set (no self-delivery).
+- **The room roster decides the recipients.** Members on **this same node** are
+  delivered through the **local internal queue** (`bridge-task.sh create`, the
+  same durable boundary every inter-agent task uses); members on **other nodes**
+  are delivered via the **cross-node room-scoped A2A** path (node-link + HMAC +
+  the room epoch — exactly what `room talk` uses). The receiver on each remote
+  node independently re-checks membership against its own cached roster (the
+  sender-side check is an *additive* gate, it does not replace the receiver's).
+- **Partial failures don't abort the rest.** Each recipient is attempted
+  independently; failures are collected and reported per recipient.
+
+`--to <agent[@node]>` narrows a fan-out to a single member; `--priority`,
+`--body-file`, and `--allow-empty-body` work as they do for a 1:1 send. `--peer`
+(1:1 cross-bridge) and `--room` (fan-out) are mutually exclusive.
+
+With `--json`, the result is machine-readable:
+
+```json
+{
+  "room_id": "<room_id>",
+  "epoch": 7,
+  "sender": "alice@nodeA",
+  "delivered": [
+    {"agent": "dave", "node": "nodeA", "leg": "local"},
+    {"agent": "bob",  "node": "nodeB", "leg": "remote"}
+  ],
+  "failed": [
+    {"agent": "carol", "node": "nodeC", "leg": "remote",
+     "status": 403, "detail": "..."}
+  ],
+  "legs": {"local": true, "remote": true}
+}
+```
+
+`delivered`/`failed` each tag the recipient with the **leg** used (`local` vs
+`remote`), and `legs` records which legs fired at all. A fully-delivered send
+exits `0`; any partial failure exits non-zero (`2`) so cron/callers notice.
+
+> `room talk` (without `--fanout`) is unchanged: it stays cross-node only (it
+> skips same-node members). The fan-out is the additive whole-room surface over
+> the same machinery.

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -265,6 +265,22 @@ add_required rooms-p4-2-roster-broadcast
 # membership), a hostile --from/env cannot impersonate, a replay is deduped /
 # same-id-diff-body is 409, and the auth preamble is unreachable pre-auth.
 add_required rooms-p4-3-room-talk
+# A2A rooms whole-room fan-out (#1594): the `agent-bridge a2a send --room <id>`
+# (== `room send` == `room talk --fanout`) ergonomic surface over the P4.3
+# machinery — one message to EVERY OTHER member of a room (self excluded), local
+# same-node members via the LOCAL queue (bridge-task.sh create) + remote members
+# via the cross-node room-scoped A2A leg. Membership is proven from the sender's
+# OWN local roster cache / authoritative rooms.db (bridge-rooms.py cmd_talk +
+# _local_target_pairs/_post_room_local); `a2a send --room` routes there via
+# bridge-a2a.py's _delegate_room_fanout. The receiver-side room gate
+# (bridge-handoffd.py / bridge_rooms_common.py) is UNCHANGED — the sender check
+# is an ADDITIVE gate. Pins the 8 teeth: same-room fan-out allowed, a non-member
+# sender denied (nothing leaves either leg), self excluded, local-leg delivery,
+# remote-leg delivery (real receiver 200), partial-failure reported per-recipient
+# (rc=2), NO regression for `room talk` (cross-node only) + the 1:1
+# `a2a send --peer --to` surface, and the receiver membership gate stays
+# fail-closed against a rewritten non-member envelope sender.
+add_required 1594-rooms-fanout
 # A2A rooms P4.5 (design §11): two polish follow-ups from the P4.4 VM acceptance.
 # FIX 1 (UX completeness): a NON-leader node that joined a room now sees it via
 # `room show`/`room list` — cmd_show/cmd_list (bridge-rooms.py) fall back to the
@@ -993,7 +1009,7 @@ select_for_path() {
       add_required queue a2a-rooms-p1b-acl
       ;;
 
-    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|lib/daemon-helpers/a2a-receiver-exit-cause.py|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/smoke/rooms-p4-2-roster-broadcast-helper.py|scripts/smoke/rooms-p4-2-post-hook.sh|scripts/smoke/rooms-p4-3-room-talk-helper.py|scripts/smoke/rooms-p4-3-post-hook.sh|scripts/smoke/rooms-p4-5-polish.sh|scripts/smoke/rooms-p4-5-helper.py|scripts/smoke/1563-pr8-a2a-diag-recovery-helper.py|scripts/smoke/1575b-a2a-backoff-ceiling-helper.py|scripts/install-handoffd-systemd.sh)
+    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|lib/daemon-helpers/a2a-receiver-exit-cause.py|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/smoke/rooms-p4-2-roster-broadcast-helper.py|scripts/smoke/rooms-p4-2-post-hook.sh|scripts/smoke/rooms-p4-3-room-talk-helper.py|scripts/smoke/rooms-p4-3-post-hook.sh|scripts/smoke/1594-rooms-fanout-helper.py|scripts/smoke/1594-rooms-fanout-post-hook.sh|scripts/smoke/1594-rooms-fanout-local-hook.sh|scripts/smoke/rooms-p4-5-polish.sh|scripts/smoke/rooms-p4-5-helper.py|scripts/smoke/1563-pr8-a2a-diag-recovery-helper.py|scripts/smoke/1575b-a2a-backoff-ceiling-helper.py|scripts/install-handoffd-systemd.sh)
       # Issue #1032: A2A cross-bridge task handoff. Any move to the
       # receiver daemon, sender outbox/delivery-runner, shared protocol
       # module, lifecycle helper, or the smoke helper re-runs the
@@ -1157,7 +1173,7 @@ select_for_path() {
       # recovered peer's retry rows cannot regress to a multi-minute dormant backoff.
       # #1589 (A2A audit B1-B8): a2a-backpressure-openonly pins the in-transaction
       # OPEN-only backpressure count + the reaper / recover / deadline regressions.
-      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force a2a-backpressure-openonly rooms-p4-1-cross-node-join rooms-p4-2-roster-broadcast rooms-p4-3-room-talk rooms-p4-5-polish 1563-pr4-a2a-receiver-healthz 1563-pr5-fp-control-matrix 1563-pr8-a2a-diag-recovery 1575b-a2a-backoff-ceiling
+      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force a2a-backpressure-openonly rooms-p4-1-cross-node-join rooms-p4-2-roster-broadcast rooms-p4-3-room-talk 1594-rooms-fanout rooms-p4-5-polish 1563-pr4-a2a-receiver-healthz 1563-pr5-fp-control-matrix 1563-pr8-a2a-diag-recovery 1575b-a2a-backoff-ceiling
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)

--- a/scripts/smoke/1594-rooms-fanout-helper.py
+++ b/scripts/smoke/1594-rooms-fanout-helper.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Helper for the 1594-rooms-fanout smoke (A2A Rooms whole-room fan-out).
+
+File-as-argv sidecar (never a heredoc-stdin — footgun #11). Imports the REAL
+rooms / a2a / handoffd modules from the repo root so the smoke exercises the
+canonical sender (`agb a2a send --room` -> `bridge-rooms.py send` -> the
+OS-actor-anchored fan-out: membership proof from the local roster cache, the
+same-node LOCAL-queue leg + the cross-node room-scoped A2A leg, self exclusion,
+partial-failure collection) WITHOUT a live socket, Tailscale, or queue.
+
+Both legs of the fan-out are stubbed via paired-flag test hooks (the same
+prod-inert seam the existing P4.x smokes use):
+  - REMOTE leg (`_post_room_talk`): the cross-node enqueue POST is captured by
+    BRIDGE_ROOMS_TEST_POST_HOOK and (optionally) replayed through the REAL
+    receiver `do_POST` to prove the cross-node delivery + the non-member gate.
+  - LOCAL leg (`_post_room_local`): the would-be `bridge-task.sh create` is
+    captured by BRIDGE_ROOMS_TEST_LOCAL_HOOK so the smoke can assert "delivered
+    locally" without shelling out to a live queue.
+
+Subcommands (argv[1]):
+  post-hook <json>                 (BRIDGE_ROOMS_TEST_POST_HOOK target) — append
+                                   the captured remote POST JSON to $POST_CAPTURE
+                                   (one JSON object per line) and echo a stub.
+  local-hook <json>               (BRIDGE_ROOMS_TEST_LOCAL_HOOK target) — append
+                                   the captured local-queue create JSON to
+                                   $LOCAL_CAPTURE (one per line). Exit non-zero
+                                   for a target listed in $LOCAL_FAIL_FOR (CSV)
+                                   to drive the partial-failure tooth.
+  make-config <out> <this_node> <peer_node> <secret> <addr> [allowlist_csv]
+                                   write a minimal handoff config.
+  seed-cache <db> <room_id> <epoch> <from_node> <members_csv>
+                                   write a leader-MAC roster cache row directly
+                                   (members_csv = agent@node[:role],... ).
+  count-lines <file>               print the number of non-empty lines.
+  field-each <file> <key>          print body<key> for each captured line.
+  deliver-remote-to-receiver <repo_root> <cfg_json> <captured_line_idx>
+                                   <capture_file> [overrides]
+                                   replay one captured remote POST through the
+                                   REAL do_POST handler; print
+                                   "status=<n> delivered=<bool> body=<json>".
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import bridge_a2a_common as a2a  # noqa: E402
+import bridge_rooms_common as rooms  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# capture hooks
+# ---------------------------------------------------------------------------
+def _append_line(path: str, text: str) -> None:
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(text.rstrip("\n") + "\n")
+
+
+def cmd_post_hook(payload_json: str) -> int:
+    """BRIDGE_ROOMS_TEST_POST_HOOK target — capture the remote POST, stub 200."""
+    capture = os.environ.get("POST_CAPTURE")  # noqa: iso-helper-boundary - env var, not a .env file
+    if not capture:
+        print("POST_CAPTURE unset", file=sys.stderr)
+        return 1
+    _append_line(capture, payload_json)
+    print(json.dumps({"ok": True, "task_id": "stub"}))
+    return 0
+
+
+def cmd_local_hook(payload_json: str) -> int:
+    """BRIDGE_ROOMS_TEST_LOCAL_HOOK target — capture the local create.
+
+    Exits non-zero (a simulated bridge-task.sh failure) for any target listed in
+    $LOCAL_FAIL_FOR so the smoke can drive the partial-failure path.
+    """
+    capture = os.environ.get("LOCAL_CAPTURE")  # noqa: iso-helper-boundary - env var, not a .env file
+    if not capture:
+        print("LOCAL_CAPTURE unset", file=sys.stderr)
+        return 1
+    _append_line(capture, payload_json)
+    fail_for = os.environ.get("LOCAL_FAIL_FOR", "")  # noqa: iso-helper-boundary - env var, not a .env file
+    fail_set = {a.strip() for a in fail_for.split(",") if a.strip()}
+    try:
+        target = json.loads(payload_json).get("target_agent", "")
+    except (ValueError, json.JSONDecodeError):
+        target = ""
+    if target in fail_set:
+        print(f"simulated local-queue failure for {target}", file=sys.stderr)
+        return 1
+    print(f"created task #4242 for {target}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# config + cache helpers (mirror rooms-p4-3-room-talk-helper)
+# ---------------------------------------------------------------------------
+def cmd_make_config(out_path: str, this_node: str, peer_node: str,
+                    peer_secret: str, address: str,
+                    allowlist_csv: str = "") -> int:
+    allowlist = [a for a in allowlist_csv.split(",") if a] if allowlist_csv else []
+    cfg = {
+        "bridge_id": this_node,
+        "listen": {"host": "127.0.0.1", "port": 8787,
+                   "enqueue_path": "/enqueue"},
+        "timestamp_skew_seconds": 300,
+        "timestamp_skew_grace_seconds": 3600,
+        "peers": [
+            {
+                "id": peer_node,
+                "address": address,
+                "secret": peer_secret,
+                "inbound_allowlist": allowlist,
+            }
+        ],
+    }
+    Path(out_path).write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    try:
+        os.chmod(out_path, 0o600)
+    except OSError:
+        pass
+    return 0
+
+
+def _parse_members_csv(members_csv: str) -> list:
+    members: list = []
+    for entry in members_csv.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        role = "member"
+        if ":" in entry:
+            entry, role = entry.rsplit(":", 1)
+        agent, _, node = entry.partition("@")
+        members.append({"agent": agent.strip(), "node": node.strip(),
+                        "role": role.strip() or "member"})
+    members.sort(key=lambda m: (m["agent"], m["node"]))
+    return members
+
+
+def cmd_seed_cache(db: str, room_id: str, epoch: str, from_node: str,
+                   members_csv: str) -> int:
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    members = _parse_members_csv(members_csv)
+    members_json = json.dumps(members, separators=(",", ":"))
+    conn = rooms.open_rooms()
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO room_roster_cache (room_id, epoch, "
+            "members_json, from_node, mac, fetched_ts) VALUES (?, ?, ?, ?, ?, ?)",
+            (room_id, int(epoch), members_json, from_node, "leader-mac",
+             rooms.now_ts()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    print(f"seeded cache room={room_id} epoch={epoch} members={len(members)}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# capture readers
+# ---------------------------------------------------------------------------
+def _read_lines(path: str) -> list:
+    if not os.path.isfile(path):
+        return []
+    out = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                out.append(line)
+    return out
+
+
+def cmd_count_lines(path: str) -> int:
+    print(len(_read_lines(path)))
+    return 0
+
+
+def cmd_add_peer(cfg_path: str, peer_id: str, secret: str, address: str,
+                 allowlist_csv: str = "") -> int:
+    """Append a second peer to an existing handoff config (no inline heredoc)."""
+    allowlist = [a for a in allowlist_csv.split(",") if a] if allowlist_csv else []
+    with open(cfg_path, encoding="utf-8") as fh:
+        cfg = json.load(fh)
+    cfg.setdefault("peers", []).append({
+        "id": peer_id, "address": address, "secret": secret,
+        "inbound_allowlist": allowlist,
+    })
+    with open(cfg_path, "w", encoding="utf-8") as fh:
+        json.dump(cfg, fh, indent=2)
+    return 0
+
+
+def cmd_nonmember_overrides(capture_file: str, line_idx: str,
+                            bad_agent: str = "mallory") -> int:
+    """Print a deliver-remote overrides JSON that rewrites the captured hop's
+    envelope sender.agent to a NON-member + asks for a re-sign (so the receiver's
+    membership gate, not the HMAC gate, is what rejects it). No inline heredoc."""
+    captured = json.loads(_read_lines(capture_file)[int(line_idx)])
+    env = json.loads(captured.get("body", "{}"))
+    # The authenticated sender agent lives at env.sender.agent (the receiver's
+    # room gate reads it there) — NOT a top-level field. Rewrite it to a
+    # non-member so the membership gate, downstream of HMAC, is what rejects.
+    env.setdefault("sender", {})["agent"] = bad_agent
+    overrides = {"body": json.dumps(env, ensure_ascii=False,
+                                    separators=(",", ":")),
+                 "resign": True}
+    print(json.dumps(overrides, separators=(",", ":")))
+    return 0
+
+
+def cmd_target_index(capture_file: str, want: str) -> int:
+    """Print the 0-based line index of the captured remote hop targeting <want>
+    (or empty if none). Lets the smoke pick a specific recipient's hop."""
+    for i, line in enumerate(_read_lines(capture_file)):
+        env = json.loads(json.loads(line).get("body", "{}"))
+        if env.get("target_agent", "") == want:
+            print(i)
+            return 0
+    print("")
+    return 0
+
+
+def cmd_field_each(path: str, key: str) -> int:
+    """Print one value per captured line. key forms: top-level (local hook) or
+    body:<k> (the remote POST envelope body) or header:<H>."""
+    for line in _read_lines(path):
+        doc = json.loads(line)
+        if key.startswith("body:"):
+            body = json.loads(doc.get("body", "{}"))
+            val = body.get(key[len("body:"):], "")
+        elif key.startswith("header:"):
+            val = doc.get("headers", {}).get(key[len("header:"):], "")
+        else:
+            val = doc.get(key, "")
+        if isinstance(val, (list, dict)):
+            print(json.dumps(val, separators=(",", ":")))
+        else:
+            print(val)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# receiver-side replay (a trimmed copy of the p4-3 helper's machinery)
+# ---------------------------------------------------------------------------
+def _load_handoffd(repo_root: str):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "bridge_handoffd", os.path.join(repo_root, "bridge-handoffd.py"))
+    hd = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(hd)
+    return hd
+
+
+class _FakeHeaders:
+    def __init__(self, headers: dict):
+        self._h = headers
+
+    def get(self, key, default=None):
+        return self._h.get(key, default)
+
+
+class _FakeRFile:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0 or n >= len(self._data):
+            out, self._data = self._data, b""
+            return out
+        out, self._data = self._data[:n], self._data[n:]
+        return out
+
+
+class _FakeServer:
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self.config_path = ""
+
+
+def cmd_deliver_remote_to_receiver(repo_root: str, cfg_json: str,
+                                   capture_file: str, line_idx: str,
+                                   overrides_json: str = "{}") -> int:
+    """Replay ONE captured remote POST through the REAL do_POST handler.
+
+    A trimmed mirror of the P4.3 helper's `deliver-talk-to-receiver`: the enqueue
+    boundary is monkeypatched to CAPTURE the delivery decision (no bridge-task.sh
+    shell-out / live queue). `overrides_json` mutates the captured request
+    ({"client_ip","headers","body","resign"}); `resign` recomputes a valid HMAC
+    for a mutated body so the membership gate can be driven downstream of auth.
+    """
+    hd = _load_handoffd(repo_root)
+    cfg = json.loads(cfg_json)
+    captured = json.loads(_read_lines(capture_file)[int(line_idx)])
+    overrides = json.loads(overrides_json) if overrides_json else {}
+
+    path = captured.get("path", "/enqueue")
+    headers = dict(captured.get("headers", {}))
+    body = captured.get("body", "{}")
+
+    if "headers" in overrides:
+        headers.update(overrides["headers"])
+    if "body" in overrides:
+        body = overrides["body"]
+    body_bytes = body.encode("utf-8") if isinstance(body, str) else bytes(body)
+    if overrides.get("resign"):
+        peer_secret = ""
+        for p in cfg.get("peers", []):
+            if p.get("id") == headers.get("X-AGB-Peer", ""):
+                peer_secret = p.get("secret", "")
+                break
+        body_hash = a2a.body_sha256(body_bytes)
+        headers["X-AGB-Body-SHA256"] = body_hash
+        canonical = a2a.canonical_string(
+            "POST", path, headers.get("X-AGB-Peer", ""),
+            headers.get("X-AGB-Message-Id", ""),
+            headers.get("X-AGB-Timestamp", ""), body_hash)
+        headers["X-AGB-Signature"] = a2a.sign(peer_secret, canonical)
+    headers["Content-Length"] = str(len(body_bytes))
+
+    peer_id = headers.get("X-AGB-Peer", "")
+    peer_addr = ""
+    for p in cfg.get("peers", []):
+        if p.get("id") == peer_id:
+            peer_addr = p.get("address", "")
+            break
+    client_ip = overrides.get("client_ip", peer_addr or "127.0.0.1")
+
+    delivery: dict = {}
+
+    def _fake_enqueue(*, target, sender_bridge, sender_agent, priority, title,
+                      body_file):
+        delivery.update({
+            "target": target, "sender_bridge": sender_bridge,
+            "sender_agent": sender_agent, "priority": priority, "title": title,
+        })
+        return True, "9999", "created task #9999", "created task #9999"
+
+    hd.enqueue_via_bridge_task = _fake_enqueue  # type: ignore[assignment]
+
+    handler = hd.HandoffHandler.__new__(hd.HandoffHandler)
+    handler.path = path
+    handler.headers = _FakeHeaders(headers)
+    handler.rfile = _FakeRFile(body_bytes)
+    handler.client_address = (client_ip, 0)
+    handler.server = _FakeServer(cfg)
+
+    captured_reply: dict = {}
+
+    def _capture_reply(status, payload, extra_headers=None):
+        captured_reply["status"] = status
+        captured_reply["payload"] = payload
+
+    handler._reply = _capture_reply  # type: ignore[assignment]
+    handler.do_POST()
+
+    status = captured_reply.get("status", 0)
+    payload = captured_reply.get("payload", {})
+    delivered = bool(delivery)
+    print(f"status={status} delivered={delivered} "
+          f"body={json.dumps(payload, separators=(',', ':'))} "
+          f"delivery={json.dumps(delivery, separators=(',', ':'))}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+def main(argv: list) -> int:
+    if not argv:
+        print("usage: 1594-rooms-fanout-helper.py <cmd> ...", file=sys.stderr)
+        return 2
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "post-hook":
+        return cmd_post_hook(rest[0])
+    if cmd == "local-hook":
+        return cmd_local_hook(rest[0])
+    if cmd == "make-config":
+        return cmd_make_config(*rest)
+    if cmd == "add-peer":
+        return cmd_add_peer(*rest)
+    if cmd == "seed-cache":
+        return cmd_seed_cache(*rest)
+    if cmd == "count-lines":
+        return cmd_count_lines(rest[0])
+    if cmd == "field-each":
+        return cmd_field_each(rest[0], rest[1])
+    if cmd == "nonmember-overrides":
+        return cmd_nonmember_overrides(*rest)
+    if cmd == "target-index":
+        return cmd_target_index(rest[0], rest[1])
+    if cmd == "deliver-remote-to-receiver":
+        return cmd_deliver_remote_to_receiver(*rest)
+    print(f"unknown helper cmd: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/smoke/1594-rooms-fanout-local-hook.sh
+++ b/scripts/smoke/1594-rooms-fanout-local-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# scripts/smoke/1594-rooms-fanout-local-hook.sh — BRIDGE_ROOMS_TEST_LOCAL_HOOK
+# target for the rooms whole-room fan-out smoke.
+#
+# Invoked with the would-be LOCAL-leg `bridge-task.sh create` request JSON as $1
+# (file-as-argv, never stdin — footgun #11). Delegates to the helper's
+# `local-hook`, which APPENDS the captured create to $LOCAL_CAPTURE and exits
+# non-zero for any target in $LOCAL_FAIL_FOR (to drive the partial-failure
+# tooth), so the smoke can assert local delivery WITHOUT a live queue.
+set -euo pipefail
+HERE="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 "$HERE/1594-rooms-fanout-helper.py" local-hook "$1"

--- a/scripts/smoke/1594-rooms-fanout-post-hook.sh
+++ b/scripts/smoke/1594-rooms-fanout-post-hook.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# scripts/smoke/1594-rooms-fanout-post-hook.sh — BRIDGE_ROOMS_TEST_POST_HOOK
+# target for the rooms whole-room fan-out smoke.
+#
+# Invoked with the signed REMOTE-leg enqueue request JSON as $1 (file-as-argv,
+# never stdin — footgun #11). Delegates to the helper's `post-hook`, which
+# APPENDS the captured request to $POST_CAPTURE (one JSON per line) so a fan-out
+# that targets multiple remote members captures each hop.
+set -euo pipefail
+HERE="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 "$HERE/1594-rooms-fanout-helper.py" post-hook "$1"

--- a/scripts/smoke/1594-rooms-fanout.sh
+++ b/scripts/smoke/1594-rooms-fanout.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# scripts/smoke/1594-rooms-fanout.sh — A2A Rooms whole-room fan-out
+# (`agent-bridge a2a send --room` / `room send` / `room talk --fanout`, #1594).
+#
+# The fan-out is the ergonomic surface over the EXISTING P4.3 room-talk
+# machinery: one message to EVERY OTHER member of a room (self excluded), with
+# same-node members delivered via the LOCAL queue (`bridge-task.sh create`) and
+# remote members via the cross-node room-scoped A2A enqueue (node-link + HMAC +
+# room epoch). Membership is proven from the sender's OWN local leader-MAC roster
+# cache / authoritative rooms.db — never from the caller's flags. The receiver
+# gate is UNCHANGED and still independently enforces membership on every remote
+# hop; the SENDER-side membership check is an ADDITIVE gate.
+#
+# Both legs are stubbed via paired-flag test hooks (prod-inert, the same seam
+# the P4.x smokes use) so no live socket / Tailscale / queue is touched:
+#   - REMOTE leg → BRIDGE_ROOMS_TEST_POST_HOOK captures each signed enqueue POST;
+#     one captured POST is replayed through the REAL `do_POST` receiver to prove
+#     cross-node delivery AND the non-member-denied security case end to end.
+#   - LOCAL leg  → BRIDGE_ROOMS_TEST_LOCAL_HOOK captures each would-be
+#     bridge-task.sh create (and can simulate a failure for one target).
+#
+# THE REQUIRED TEETH:
+#   T1  same-room fan-out is ALLOWED for a member sender; both legs fire.
+#   T2  a NON-member sender cannot send to the room (denied + nothing leaves).
+#   T3  the sender itself is EXCLUDED from recipients (no self-delivery).
+#   T4  same-node members are delivered via the LOCAL queue leg.
+#   T5  remote members are delivered via the cross-node room-scoped A2A leg, and
+#       the REAL receiver accepts a delivered remote hop (200).
+#   T6  a partial failure (one recipient fails) does NOT abort the rest, and is
+#       reported per-recipient in the JSON summary (rc=2).
+#   T7  NO regression: `room talk` (no --fanout) stays cross-node only (skips
+#       same-node members); the 1:1 `a2a send --peer --to` surface is intact.
+#   T8  security: the receiver-side membership gate still denies a remote hop
+#       whose envelope sender is rewritten to a non-member (additive sender gate
+#       does not weaken the fail-closed receiver gate).
+
+set -euo pipefail
+
+SMOKE_NAME="1594-rooms-fanout"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+HELPER="$SCRIPT_DIR/1594-rooms-fanout-helper.py"
+POST_HOOK="$SCRIPT_DIR/1594-rooms-fanout-post-hook.sh"
+LOCAL_HOOK="$SCRIPT_DIR/1594-rooms-fanout-local-hook.sh"
+ROOMS_CLI="$SMOKE_REPO_ROOT/bridge-rooms.py"
+A2A_CLI="$SMOKE_REPO_ROOT/bridge-a2a.py"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+export BRIDGE_A2A_ROOMS_DB="$BRIDGE_STATE_DIR/handoff/rooms.db"
+mkdir -p "$BRIDGE_STATE_DIR/handoff"
+
+NODE_A="nodeA"   # the SENDER's node (alice fans out)
+NODE_B="nodeB"   # a REMOTE member node (bob)
+NODE_C="nodeC"   # a second REMOTE member node (carol)
+SECRET_B="test-pair-secret-bbbbbbbbbbbbbbbbbbbb"
+SECRET_C="test-pair-secret-cccccccccccccccccccc"
+ADDR="127.0.0.1"
+ROOM="room-fanout-001"
+EPOCH=7
+
+# Roster: alice@A (leader/sender) + dave@A (LOCAL same-node member) + bob@B and
+# carol@C (REMOTE members). The fan-out should reach dave via the local queue
+# and bob+carol via room-scoped A2A — and NEVER alice herself.
+MEMBERS_CSV="alice@${NODE_A}:leader,dave@${NODE_A}:member,bob@${NODE_B}:member,carol@${NODE_C}:member"
+
+# Sender (node A) config: bridge_id=nodeA, peers nodeB + nodeC (the remote
+# delivery targets).
+CFG_A="$SMOKE_TMP_ROOT/handoff-A.json"
+python3 "$HELPER" make-config "$CFG_A" "$NODE_A" "$NODE_B" "$SECRET_B" "$ADDR" "bob" >/dev/null
+# make-config writes a single-peer config; add the second peer (nodeC) so the
+# fan-out can address carol too (helper subcommand, no inline heredoc).
+python3 "$HELPER" add-peer "$CFG_A" "$NODE_C" "$SECRET_C" "$ADDR" "carol" >/dev/null
+
+# Sender-side rooms.db (node A) — alice's own leader cache, so the fan-out can
+# resolve the epoch + confirm alice is a member before sending.
+SENDER_DB="$SMOKE_TMP_ROOT/sender-rooms.db"
+python3 "$HELPER" seed-cache "$SENDER_DB" "$ROOM" "$EPOCH" "$NODE_A" "$MEMBERS_CSV" >/dev/null
+
+# Receiver (node B) config: bridge_id=nodeB, peer nodeA (the authenticated
+# sender), allowlist permits bob (the room talk target).
+CFG_B="$SMOKE_TMP_ROOT/handoff-B.json"
+python3 "$HELPER" make-config "$CFG_B" "$NODE_B" "$NODE_A" "$SECRET_B" "$ADDR" "bob" >/dev/null
+CFG_B_JSON="$(cat "$CFG_B")"
+
+# Member-local receiver rooms.db (node B) — the leader-MAC cache the gate reads.
+MEMBER_DB="$SMOKE_TMP_ROOT/member-rooms.db"
+python3 "$HELPER" seed-cache "$MEMBER_DB" "$ROOM" "$EPOCH" "$NODE_A" "$MEMBERS_CSV" >/dev/null
+
+POST_CAPTURE="$SMOKE_TMP_ROOT/captured-remote.jsonl"
+LOCAL_CAPTURE="$SMOKE_TMP_ROOT/captured-local.jsonl"
+
+TEST_FLAGS=("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1" "BRIDGE_A2A_ALLOW_TEST_BIND=1")
+
+# fanout_as <agent> [local_fail_for] [extra args...] — run the fan-out as
+# iso-user agent-bridge-<agent> on node A via `a2a send --room`, capturing every
+# remote POST to $POST_CAPTURE and every local create to $LOCAL_CAPTURE. Echoes
+# the JSON summary. Returns the CLI rc.
+fanout_as() {
+  local who="$1" fail_for="${2:-}"; shift 2 || shift $#
+  : >"$POST_CAPTURE"; : >"$LOCAL_CAPTURE"
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+      "BRIDGE_A2A_ROOMS_DB=$SENDER_DB" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$POST_HOOK" \
+      "BRIDGE_ROOMS_TEST_LOCAL_HOOK=$LOCAL_HOOK" \
+      "POST_CAPTURE=$POST_CAPTURE" \
+      "LOCAL_CAPTURE=$LOCAL_CAPTURE" \
+      "LOCAL_FAIL_FOR=$fail_for" \
+    python3 "$A2A_CLI" send --room "$ROOM" --json "$@"
+}
+
+deliver_remote() {
+  # deliver_remote <line_idx> [overrides_json] — replay one captured remote POST
+  # through the REAL receiver against $MEMBER_DB. NOTE: do NOT use ${2:-{}} for
+  # the default — bash parses the nested braces and appends a stray '}' to a
+  # provided value, corrupting the JSON arg. Use an explicit empty-test instead.
+  local idx="$1" overrides="${2:-}"
+  [[ -n "$overrides" ]] || overrides='{}'
+  env "BRIDGE_A2A_ROOMS_DB=$MEMBER_DB" \
+    python3 "$HELPER" deliver-remote-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$POST_CAPTURE" "$idx" "$overrides"
+}
+
+# ---------------------------------------------------------------------------
+# T1: a member sender fans out; BOTH legs fire (local dave + remote bob/carol).
+# ---------------------------------------------------------------------------
+test_T1_member_fanout_allowed() {
+  local out rc
+  set +e
+  out="$(fanout_as alice "" --title "team note" --body "from alice")"
+  rc=$?
+  set -e
+  [[ $rc -eq 0 ]] || smoke_fail "T1: a full fan-out with no failures must rc=0 (got $rc): $out"
+  smoke_assert_contains "$out" "\"epoch\": $EPOCH" "T1: the fan-out stamps the sender's cached epoch"
+  smoke_assert_contains "$out" "\"sender\": \"alice@$NODE_A\"" "T1: sender identity is OS-actor anchored"
+  smoke_assert_contains "$out" "\"local\": true" "T1: the local leg was used (same-node member dave)"
+  smoke_assert_contains "$out" "\"remote\": true" "T1: the remote leg was used (bob/carol)"
+}
+
+# ---------------------------------------------------------------------------
+# T2: a NON-member sender cannot fan out — refused, nothing leaves either leg.
+# ---------------------------------------------------------------------------
+test_T2_non_member_denied() {
+  local out rc
+  set +e
+  # mallory is NOT in the roster; even --as alice is ignored (OS actor wins).
+  out="$(fanout_as mallory "" --title hi --body x --as alice 2>&1)"
+  rc=$?
+  set -e
+  [[ $rc -ne 0 ]] || smoke_fail "T2: a non-member fan-out must FAIL (got rc=$rc): $out"
+  smoke_assert_contains "$out" "is not a member" "T2: a non-member sender is refused (membership proven from the roster, not the flags)"
+  local nlocal nremote
+  nlocal="$(python3 "$HELPER" count-lines "$LOCAL_CAPTURE")"
+  nremote="$(python3 "$HELPER" count-lines "$POST_CAPTURE")"
+  smoke_assert_eq "0" "$nlocal" "T2: a denied fan-out enqueues NOTHING locally"
+  smoke_assert_eq "0" "$nremote" "T2: a denied fan-out sends NOTHING remotely"
+}
+
+# ---------------------------------------------------------------------------
+# T3: the sender is EXCLUDED from recipients (no self-delivery on either leg).
+# ---------------------------------------------------------------------------
+test_T3_self_excluded() {
+  fanout_as alice "" --title t --body b >/dev/null
+  # Local targets are only same-node members EXCEPT alice → only dave.
+  local local_targets remote_targets
+  local_targets="$(python3 "$HELPER" field-each "$LOCAL_CAPTURE" target_agent | sort | tr '\n' ',')"
+  remote_targets="$(python3 "$HELPER" field-each "$POST_CAPTURE" body:target_agent | sort | tr '\n' ',')"
+  smoke_assert_eq "dave," "$local_targets" "T3: the local leg targets only same-node dave (alice excluded)"
+  smoke_assert_eq "bob,carol," "$remote_targets" "T3: the remote leg targets bob+carol (alice excluded)"
+  case ",${local_targets}${remote_targets}" in
+    *,alice,*|*",alice,") smoke_fail "T3: alice (the sender) must never be a recipient" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# T4: same-node members are delivered via the LOCAL queue leg with room
+# provenance (room id + epoch + from), through bridge-task.sh create.
+# ---------------------------------------------------------------------------
+test_T4_local_leg_delivery() {
+  fanout_as alice "" --title "local hi" --body "local body" >/dev/null
+  local n from room_in
+  n="$(python3 "$HELPER" count-lines "$LOCAL_CAPTURE")"
+  smoke_assert_eq "1" "$n" "T4: exactly one local-queue create (dave)"
+  from="$(python3 "$HELPER" field-each "$LOCAL_CAPTURE" from)"
+  smoke_assert_eq "room:$ROOM:alice" "$from" "T4: the local create is stamped with room fan-out provenance (--from room:<room>:<sender>)"
+  room_in="$(python3 "$HELPER" field-each "$LOCAL_CAPTURE" room_id)"
+  smoke_assert_eq "$ROOM" "$room_in" "T4: the local create carries the room id"
+}
+
+# ---------------------------------------------------------------------------
+# T5: remote members are delivered via the cross-node room-scoped A2A leg, and
+# the REAL receiver accepts a delivered remote hop (200, room-scoped, in queue).
+# ---------------------------------------------------------------------------
+test_T5_remote_leg_delivery() {
+  fanout_as alice "" --title "remote hi" --body "remote body" >/dev/null
+  local proto room_in epoch_in path_in
+  proto="$(python3 "$HELPER" field-each "$POST_CAPTURE" header:X-AGB-Protocol | head -1)"
+  smoke_assert_eq "a2a-enqueue-v1" "$proto" "T5: the remote leg routes over the normal enqueue protocol (no new endpoint)"
+  path_in="$(python3 "$HELPER" field-each "$POST_CAPTURE" path | head -1)"
+  smoke_assert_eq "/enqueue" "$path_in" "T5: the remote leg posts to the enqueue path"
+  room_in="$(python3 "$HELPER" field-each "$POST_CAPTURE" body:room_id | head -1)"
+  smoke_assert_eq "$ROOM" "$room_in" "T5: the remote envelope carries the room id"
+  epoch_in="$(python3 "$HELPER" field-each "$POST_CAPTURE" body:room_epoch | head -1)"
+  smoke_assert_eq "$EPOCH" "$epoch_in" "T5: the remote envelope carries the cached room epoch"
+
+  # Replay the bob-targeted hop through the REAL receiver (CFG_B trusts nodeA +
+  # allowlists bob). Pick the captured line whose target is bob (helper subcmd).
+  local bob_idx res
+  bob_idx="$(python3 "$HELPER" target-index "$POST_CAPTURE" bob)"
+  [[ -n "$bob_idx" ]] || smoke_fail "T5: no captured remote hop targeted bob"
+  res="$(deliver_remote "$bob_idx")"
+  smoke_assert_contains "$res" "status=200" "T5: the REAL receiver accepts a delivered remote room hop (200)"
+  smoke_assert_contains "$res" "delivered=True" "T5: the remote room message is DELIVERED into the queue"
+}
+
+# ---------------------------------------------------------------------------
+# T6: a partial failure (one local recipient fails) does NOT abort the rest; it
+# is reported per-recipient in the JSON, and the rc is 2 (non-zero so callers
+# notice) while the OTHER legs still delivered.
+# ---------------------------------------------------------------------------
+test_T6_partial_failure_reported() {
+  local out rc
+  set +e
+  out="$(fanout_as alice "dave" --title t --body b)"  # dave's local create fails
+  rc=$?
+  set -e
+  [[ $rc -eq 2 ]] || smoke_fail "T6: a partial failure must rc=2 (got $rc): $out"
+  smoke_assert_contains "$out" "\"failed\": [{" "T6: the failing recipient appears in failed[]"
+  smoke_assert_contains "$out" "\"agent\": \"dave\"" "T6: the failed local recipient (dave) is named"
+  smoke_assert_contains "$out" "\"leg\": \"local\"" "T6: the failure is tagged with its leg (local)"
+  # The remote recipients still delivered despite the local failure.
+  smoke_assert_contains "$out" "\"agent\": \"bob\"" "T6: bob still delivered despite dave's local failure"
+  smoke_assert_contains "$out" "\"agent\": \"carol\"" "T6: carol still delivered despite dave's local failure"
+}
+
+# ---------------------------------------------------------------------------
+# T7: NO regression. `room talk` (no --fanout) stays cross-node only (it skips
+# same-node members), and the 1:1 `a2a send --peer --to` surface still requires
+# its own args (mutual exclusivity holds).
+# ---------------------------------------------------------------------------
+test_T7_no_regression() {
+  : >"$POST_CAPTURE"; : >"$LOCAL_CAPTURE"
+  # `room talk` (no --fanout) → remote-only: bob+carol on the wire, NO local leg.
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-alice" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+      "BRIDGE_A2A_ROOMS_DB=$SENDER_DB" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$POST_HOOK" \
+      "BRIDGE_ROOMS_TEST_LOCAL_HOOK=$LOCAL_HOOK" \
+      "POST_CAPTURE=$POST_CAPTURE" "LOCAL_CAPTURE=$LOCAL_CAPTURE" \
+    python3 "$ROOMS_CLI" talk "$ROOM" --title t --body b --json >/dev/null
+  local nlocal nremote
+  nlocal="$(python3 "$HELPER" count-lines "$LOCAL_CAPTURE")"
+  nremote="$(python3 "$HELPER" count-lines "$POST_CAPTURE")"
+  smoke_assert_eq "0" "$nlocal" "T7: bare \`room talk\` does NOT use the local leg (back-compat: cross-node only)"
+  smoke_assert_eq "2" "$nremote" "T7: bare \`room talk\` still reaches both remote members (bob+carol)"
+
+  # 1:1 `a2a send --room` + `--peer` are mutually exclusive (surface intact).
+  local out rc
+  set +e
+  out="$(python3 "$A2A_CLI" send --room "$ROOM" --peer "$NODE_B" --to bob --title t --body b 2>&1)"
+  rc=$?
+  set -e
+  [[ $rc -ne 0 ]] || smoke_fail "T7: --room + --peer together must be rejected"
+  smoke_assert_contains "$out" "only one of --peer" "T7: --peer and --room are mutually exclusive"
+
+  # A 1:1 `a2a send --to` without --peer is still rejected (no silent fan-out).
+  set +e
+  out="$(python3 "$A2A_CLI" send --to bob --title t --body b 2>&1)"
+  rc=$?
+  set -e
+  [[ $rc -ne 0 ]] || smoke_fail "T7: a 1:1 send with no --peer and no --room must fail"
+  smoke_assert_contains "$out" "--peer is required" "T7: a 1:1 send still requires --peer"
+}
+
+# ---------------------------------------------------------------------------
+# T8: security — the receiver-side membership gate is UNCHANGED. A captured
+# remote hop whose envelope sender is rewritten to a non-member (re-signed so it
+# passes HMAC) is REJECTED by the receiver's fail-closed room gate. The additive
+# sender-side gate does not weaken the receiver.
+# ---------------------------------------------------------------------------
+test_T8_receiver_gate_unweakened() {
+  fanout_as alice "" --title t --body b >/dev/null
+  # find bob's captured hop, rewrite the envelope sender.agent → mallory, re-sign
+  # so the membership gate (not the HMAC gate) is what rejects it. Both via the
+  # helper (no inline heredoc — footgun #11 hygiene).
+  local bob_idx overrides res
+  bob_idx="$(python3 "$HELPER" target-index "$POST_CAPTURE" bob)"
+  [[ -n "$bob_idx" ]] || smoke_fail "T8: no captured remote hop targeted bob"
+  overrides="$(python3 "$HELPER" nonmember-overrides "$POST_CAPTURE" "$bob_idx" mallory)"
+  res="$(deliver_remote "$bob_idx" "$overrides")"
+  smoke_assert_contains "$res" "status=403" "T8: the receiver gate rejects a non-member envelope sender (403)"
+  smoke_assert_contains "$res" "sender_not_member" "T8: the refusal reason is sender_not_member (fail-closed gate intact)"
+  smoke_assert_contains "$res" "delivered=False" "T8: a non-member remote hop is NEVER delivered"
+}
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+smoke_run "T1: same-room fan-out allowed for a member (both legs)" test_T1_member_fanout_allowed
+smoke_run "T2: a NON-member sender cannot fan out (denied, nothing leaves)" test_T2_non_member_denied
+smoke_run "T3: the sender is excluded from recipients (no self-delivery)" test_T3_self_excluded
+smoke_run "T4: same-node members delivered via the LOCAL queue leg" test_T4_local_leg_delivery
+smoke_run "T5: remote members delivered via the room-scoped A2A leg (receiver 200)" test_T5_remote_leg_delivery
+smoke_run "T6: a partial failure is reported per-recipient, rest still delivered" test_T6_partial_failure_reported
+smoke_run "T7: NO regression — room talk cross-node only + 1:1 send surface intact" test_T7_no_regression
+smoke_run "T8: the receiver-side membership gate stays fail-closed (additive sender gate)" test_T8_receiver_gate_unweakened
+
+smoke_log "passed"


### PR DESCRIPTION
## What

Whole-room fan-out UX for A2A rooms — references #1594 (no `Closes`; held for the 0.16.0 stable cut).

`agent-bridge a2a send --room <room_id> --title ... [--body|--body-file] [--to <member>] [--priority] [--allow-empty-body] [--json]` fans a message out to every eligible member of a room in one command. Aliases `room send <room_id> ...` and `room talk <room_id> --fanout` share the one implementation. `--peer/--to` (1:1) and `--room` (fan-out) are mutually exclusive. **Bare `room talk` is unchanged** (cross-node only).

## Semantics

- **Membership proven from this node's local leader-MAC roster cache / authoritative `rooms.db`** (`rooms.get_roster_cache` → `_cached_members` → the `(agent,node) in member_pairs` gate), never from caller flags. A non-member sender is refused before anything leaves either leg. Self is excluded.
- **Local leg** (same-node members) → `_post_room_local` via the existing `bridge-task.sh create` boundary, stamped `--from room:<room>:<sender>` — the same durable queue path the receiver uses.
- **Remote leg** (cross-node members) → the existing `_post_room_talk` (node-link + HMAC + room epoch over `/enqueue`).
- **Partial failures** reported per-recipient; JSON: `{room_id, epoch, sender, delivered[], failed[], legs:{local,remote}}` with a `leg: local|remote` tag per recipient. rc=0 fully delivered, rc=2 on any failure.

## Security boundary (HIGH-RISK — additive only)

- The sender-side membership check is **purely additive**. The receiver is **untouched**: `git diff origin/main -- bridge-handoffd.py bridge_a2a_common.py bridge_rooms_common.py` is empty — `room_scoped_check` / HMAC / `remote_addr` / allowlist / dedupe / backpressure all stay fail-closed.
- An agent in room A cannot fan out to room B unless it is a member of B.

## Verification (orchestrator re-verified after takeover)

The dispatched fixer completed the implementation + self-verification but exited before committing/opening the PR (it was parked waiting on its internal codex review). I took over its worktree, re-verified from scratch, committed, and pushed:

- `python3 -m py_compile bridge-a2a.py bridge-rooms.py scripts/smoke/1594-rooms-fanout-helper.py` — OK.
- `bash -n` + `shellcheck` on `agent-bridge` + the 4 smoke/hook scripts + `ci-select-smoke.sh` — rc=0.
- **Receiver-untouched**: `git diff origin/main -- bridge-handoffd.py bridge_a2a_common.py bridge_rooms_common.py` = 0 lines.
- `scripts/smoke/1594-rooms-fanout.sh` (bash 5.x) — **all 8 teeth pass, real rc=0**: T1 fan-out both legs · **T2 non-member denied (nothing leaves)** · T3 self excluded · T4 local queue leg · T5 remote room-scoped A2A (receiver 200) · T6 per-recipient partial failure · T7 no-regression (`room talk` cross-node + 1:1 intact) · **T8 receiver membership gate fail-closed** (real `reject_room_membership ... security=True` audit line).
- `scripts/oss-preflight.sh` — rc=0 "preflight passed"; iso-helper + raw-pathlib baselines unchanged (two `# noqa` markers added for `os.environ`/`os.unlink` false positives rather than bumping baselines). ci-select conflict-marker count = 0. (macOS skips the Linux-only iso-helper-ratchet — GitHub CI is the authoritative gate.)
- Two pre-existing macOS-only smoke failures (`#365 isolated-agent-env`, `a2a-rooms-p1b-acl` empty-array) confirmed identical on a clean `origin/main` checkout — not introduced here.

## Out of scope / notes

- No VERSION/CHANGELOG bump. **Do not merge** — held for the operator-cued stable 0.16.0 cut after the A2A security review + a live multi-node VM test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
