### PR TITLE
hooks: Stop drain skips daemon-owned [cron-dispatch] work (#1596)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -327,6 +327,30 @@ kept DISTINCT so the #1199 "queued-only ACTION REQUIRED, claimed still
 blocks stop" contract is preserved. Smoke:
 `scripts/smoke/9780-stop-inbox-drain.sh`.
 
+The drain predicate is **actionable agent work, not merely any open
+queued/claimed row** (#1596). `drain_top_actionable` excludes daemon-owned
+`[cron-dispatch]` rows — the bridge daemon owns and closes those itself
+(`bridge-cron.sh` enqueue: `title="[cron-dispatch] …"`, `created_by="cron:…"`),
+so re-entering the model only burns a turn confirming there is nothing to do.
+`_is_daemon_owned_cron_dispatch(row)` uses the **title as the SSOT**: a titled
+row is daemon-owned ONLY when its title starts with `[cron-dispatch]`. The
+`created_by` starting with `cron:` is **not** a reliable signal on its own — the
+daemon's own real `[cron-followup]` follow-ups AND real `[picker-sweep]`
+notification tasks (`scripts/picker-sweep.sh`, `--from "cron:picker-sweep"`) are
+both filed by a `cron:` actor yet must STILL block — so `created_by cron:` is a
+defensive fallback that fires only for an untitled/blank-title row (a shape no
+real cron-actor task ever takes). Both paths iterate the FULL queued/claimed
+list (`find-open --all`, which carries `title`+`created_by`) and pick the top
+REMAINING actionable row, so a real task sitting BEHIND a cron-dispatch row
+still wins (not a single-shot null of the head). The SELECTED row is
+re-confirmed open as late as practical (`_row_still_open`) right before the
+block and FAILS OPEN if it vanished/closed in the race window. All queue read
+failures fail open — a nonzero-rc/empty-stdout read error maps to None (no
+block, no fall-through), distinct from an empty result which prints `[]`. Both
+engines inherit this one shared predicate; they differ only in the no-block
+OUTPUT (Codex emits `{}`, Claude emits nothing). Smoke:
+`scripts/smoke/1596-stop-drain-cron-dispatch.sh`.
+
 ### Hook config SSOT (#1068)
 
 `bridge-hooks.py` is the single source of truth for the effective

--- a/docs/developer-handover.md
+++ b/docs/developer-handover.md
@@ -238,7 +238,19 @@ env 노브 표가 있다.
 **Stop/turn-end inbox auto-drain (#9780).** turn 종료 시 `hooks/inbox-auto-drain.py`
 (Stop hook)가 idle 대신 genuinely-claimable queued task를 하나 drain한다. id+status marker +
 atomic-persist-before-block의 fail-open 무한루프 가드가 있고, #1199 queued-vs-claimed 분리를
-보존한다 — 이 가드를 약화시키면 turn-end 루프가 생긴다.
+보존한다 — 이 가드를 약화시키면 turn-end 루프가 생긴다. predicate은 "actionable agent work"
+이지 "아무 open row"가 아니다(#1596): daemon이 직접 소유·종료하는 `[cron-dispatch]` row는
+`_is_daemon_owned_cron_dispatch`로 제외한다. **title이 SSOT다** — titled row는 title이
+`[cron-dispatch]`로 시작할 때만 daemon-owned다. `created_by=cron:`만으로는 daemon-owned가
+아니다: daemon의 실제 `[cron-followup]` 후속 작업과 실제 `[picker-sweep]` 알림 task
+(`scripts/picker-sweep.sh`, `--from "cron:picker-sweep"`)도 `cron:` actor지만 여전히
+block해야 하므로, `created_by cron:`는 title이 빈/없는 row에만 적용되는 방어적 fallback이다
+(실제 cron-actor task는 항상 title이 있어 절대 묻히지 않는다). queued/claimed 리스트를
+`find-open --all`로 전부 받아 daemon-owned를 걸러낸 뒤 남은 top row를 고르므로 cron row 뒤의
+실제 task가 묻히지 않고, 선택된 row는 block 직전에 다시 open인지 확인해 사라졌으면 fail-open
+한다. queue read 실패(nonzero rc + 빈 stdout)는 empty 결과(`[]` 출력)와 구분해 None으로
+fail-open한다. 두 엔진은 이 하나의 shared predicate를 공유하고 no-block 출력만 다르다(Codex
+`{}`, Claude 무출력). Smoke: `scripts/smoke/1596-stop-drain-cron-dispatch.sh`.
 
 ### 2. tmux I/O
 

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -1724,16 +1724,31 @@ def _open_rows_for(
         proc = queue_cli(cmd)
     except OSError:
         return None
-    # CRITICAL fail-open distinction: with --all, find-open prints the literal
-    # `[]` (and exits 1) for a genuinely EMPTY result, but a real read FAILURE
-    # (SQLite/open error) exits nonzero with a traceback on stderr and EMPTY
-    # stdout. So empty/whitespace stdout means the read FAILED → return None
-    # (fail open: do not block, do not fall through), NOT []. The genuine
-    # empty case arrives as the string "[]" and parses to [] below.
-    if not proc.stdout.strip():
+    # CRITICAL fail-open distinction. `find-open --all` uses exit code 1 ONLY as
+    # the "genuinely EMPTY" sentinel (it prints the literal `[]`); exit 0 is a
+    # normal populated read. ANY OTHER nonzero exit is a real read FAILURE
+    # (SQLite/open error) and MUST fail open — return None — EVEN WHEN stdout
+    # carries parseable JSON: a partial/garbled failed read can still emit a
+    # valid-looking row, and treating it as actionable would let a FAILED queue
+    # read emit a Stop block (#1596 patch-dev re-review — a nonzero rc with a
+    # parseable row in stdout was wrongly blocking; checking only empty-stdout
+    # missed it). Empty/whitespace stdout is likewise a failed read → None.
+    # None is the fail-open signal (do not block, do not fall through); `[]` is
+    # genuinely-empty (lets the queued path fall through to the claimed
+    # anti-abandonment path) and is produced ONLY by the rc==1 literal-`[]`
+    # sentinel (or an rc==0 empty list).
+    stdout = proc.stdout.strip()
+    if proc.returncode not in (0, 1):
+        return None
+    if not stdout:
+        return None
+    if proc.returncode == 1 and stdout != "[]":
+        # rc==1 is the empty-sentinel ONLY with the literal `[]`; rc==1 carrying
+        # any other body is anomalous (not the documented empty contract) → fail
+        # open rather than trust a partial/odd read.
         return None
     try:
-        rows = json.loads(proc.stdout)
+        rows = json.loads(stdout)
     except json.JSONDecodeError:
         return None
     if not isinstance(rows, list):

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -1635,27 +1635,214 @@ def _drain_task_key(row: dict[str, Any]) -> str:
     return f"{task_id}:{status}"
 
 
-def drain_top_actionable(agent: str) -> dict[str, Any] | None:
-    """Return the top actionable queue row for the Stop drain, or None.
+# Issue #1596 — daemon-owned cron-dispatch literals. The AUTHORITATIVE signal is
+# the title: the bridge daemon writes EXACTLY `title="[cron-dispatch] <job> (<slot>)"`
+# at the only enqueue site (bridge-cron.sh:655), and it owns and closes those
+# rows itself. `created_by = "cron:<job>"` (bridge-cron.sh:654 + :837 `--from`)
+# is NOT a reliable daemon-owned signal on its own — multiple REAL, agent-actionable
+# tasks are also filed by a `cron:`-prefixed actor:
+#   * `[cron-followup]` — the daemon's own human-facing follow-up
+#     (bridge-cron-runner.py cron_followup_title, actor `cron:<source-agent>`).
+#   * `[picker-sweep]`  — a real "agents auto-unstuck" notification task
+#     (scripts/picker-sweep.sh: `--from "cron:picker-sweep"`, title
+#     `[picker-sweep] …`). NOT daemon-closed.
+# Both carry a NON-`[cron-dispatch]` title. So we judge a TITLED row purely by its
+# title (only `[cron-dispatch]` is daemon-owned); the `created_by cron:` rule is a
+# defensive FALLBACK that fires ONLY for an untitled/blank-title row — a shape no
+# real cron-actor task ever takes — so it can never swallow `[picker-sweep]`,
+# `[cron-followup]`, or any other titled cron-actor work.
+_CRON_DISPATCH_TITLE_PREFIX = "[cron-dispatch]"
+_CRON_CREATED_BY_PREFIX = "cron:"
 
-    Two DISTINCT paths, queued first (preserves the #1199 contract):
-      1. genuinely-queued work → the queued head (ACTION REQUIRED drain).
+
+def _is_daemon_owned_cron_dispatch(row: dict[str, Any]) -> bool:
+    """True when ``row`` is a daemon-owned cron-dispatch the daemon closes itself.
+
+    Issue #1596: the bridge daemon owns and closes `[cron-dispatch]` rows; when
+    human follow-up is needed it files a SEPARATE `[cron-followup]` task. So
+    re-entering the model for a `[cron-dispatch]` row only spends tokens
+    confirming the inbox is empty/done (observed: `#10352 [cron-dispatch]
+    picker-sweep`). The Stop-drain predicate therefore excludes them.
+
+    Daemon-owned when (case-sensitive, matching the canonical daemon-written
+    forms — verified against the cron-dispatch creation site, NOT guessed):
+      - ``title`` (stripped) starts with ``[cron-dispatch]``  (the authoritative
+        daemon-owned-and-self-closed marker), OR
+      - the row has NO title (missing/blank) AND ``created_by`` (stripped) starts
+        with ``cron:`` — a defensive fallback for an untitled cron row.
+
+    A TITLED row that is NOT `[cron-dispatch]` is ALWAYS actionable, even when its
+    ``created_by`` starts with `cron:` — that covers the daemon's own real
+    `[cron-followup]` follow-ups AND real `[picker-sweep]` notification tasks
+    (scripts/picker-sweep.sh), neither of which is daemon-closed. The title is the
+    SSOT; created_by alone over-reaches.
+
+    Defensive: a missing / None / non-str title or created_by is handled above;
+    we fail toward "real task" so a malformed row can never silently swallow
+    genuine queued/claimed work.
+    """
+    title = row.get("title")
+    title = title.strip() if isinstance(title, str) else ""
+    if title:
+        # Titled row → judged purely by the title. ONLY `[cron-dispatch]` is
+        # daemon-owned; every other title (incl. `[cron-followup]`,
+        # `[picker-sweep]`, real user/dev work) stays actionable.
+        return title.startswith(_CRON_DISPATCH_TITLE_PREFIX)
+    # Untitled row → defensive fallback on the actor only. No real cron-actor
+    # task is untitled, so this never swallows genuine work.
+    created_by = row.get("created_by")
+    created_by = created_by.strip() if isinstance(created_by, str) else ""
+    return created_by.startswith(_CRON_CREATED_BY_PREFIX)
+
+
+def _open_rows_for(
+    agent: str, statuses: list[str] | None = None
+) -> list[dict[str, Any]] | None:
+    """Return the open task list for ``agent`` as filterable rows.
+
+    Issue #1596: ``drain_top_actionable`` must filter the queued/claimed list
+    and pick the top REMAINING actionable row — not single-shot the head — so a
+    real task sitting BEHIND a daemon-owned cron-dispatch row still wins. We
+    fetch the full status set via ``find-open --all`` (which carries ``title``
+    + ``created_by`` + ``updated_ts`` on every row) instead of the LIMIT-1
+    single-row helpers.
+
+    ``statuses`` is a list of status names emitted as REPEATED ``--status-filter``
+    flags (the CLI uses ``action="append"`` — it does NOT accept a comma list).
+    ``None`` omits the filter entirely, which the CLI defaults to the legacy open
+    set (queued|claimed|blocked).
+
+    Returns the list of dict rows (possibly empty) on success, or ``None`` on
+    any read/parse error. ``None`` is the fail-open signal — the caller treats
+    it as "queue read failed, do not block" rather than "no work". This never
+    raises into the Stop path.
+    """
+    cmd = ["find-open", "--agent", agent, "--all", "--format", "json"]
+    for status in statuses or []:
+        cmd += ["--status-filter", status]
+    try:
+        proc = queue_cli(cmd)
+    except OSError:
+        return None
+    # CRITICAL fail-open distinction: with --all, find-open prints the literal
+    # `[]` (and exits 1) for a genuinely EMPTY result, but a real read FAILURE
+    # (SQLite/open error) exits nonzero with a traceback on stderr and EMPTY
+    # stdout. So empty/whitespace stdout means the read FAILED → return None
+    # (fail open: do not block, do not fall through), NOT []. The genuine
+    # empty case arrives as the string "[]" and parses to [] below.
+    if not proc.stdout.strip():
+        return None
+    try:
+        rows = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(rows, list):
+        return None
+    return [r for r in rows if isinstance(r, dict)]
+
+
+def _top_actionable_in_status(agent: str, status: str) -> dict[str, Any] | None:
+    """Top actionable (non-daemon-owned) row in the open ``status`` set, or None.
+
+    Issue #1596: iterate + filter. The ``find-open --all`` list is already
+    ordered by the queue's priority CASE then id (deterministic). We drop
+    daemon-owned cron-dispatch rows and return the first REMAINING row, keeping
+    the queue's existing order stable (no re-sort). Returns None when the status
+    set is empty, every row is daemon-owned, OR the read failed — all of which
+    are "no actionable ``status`` work here" for this path.
+    """
+    rows = _open_rows_for(agent, [status])
+    if not rows:
+        return None
+    for row in rows:
+        if not _is_daemon_owned_cron_dispatch(row):
+            return row
+    return None
+
+
+def _row_still_open(agent: str, task_id: int) -> bool:
+    """Late re-confirm the SELECTED row is still open right before the block.
+
+    Issue #1596 asks the Stop drain to re-check queue state as late as practical
+    and fail OPEN / silent if the chosen row vanished or became done in the race
+    window. This re-reads the open set by id and returns True only when the row
+    is still open (queued/claimed/blocked) and assigned to ``agent``.
+
+    Fail-OPEN contract: any error (subprocess failure, JSON parse error, missing
+    row, status flipped terminal) returns False so the caller emits NO block.
+    This MUST never raise — `check-inbox.py` main has no outer try/except, so a
+    raise here would surface a traceback in the Codex Stop path. Every failure
+    mode is swallowed to False; True only on a positive, fresh confirmation.
+    """
+    if task_id <= 0:
+        return False
+    # Omit --status-filter → the CLI's default open set (queued|claimed|blocked).
+    rows = _open_rows_for(agent, None)
+    if not rows:
+        # None (read error) or [] (row gone) → fail open: do not block.
+        return False
+    for row in rows:
+        try:
+            if int(row.get("id", 0) or 0) == task_id:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def drain_top_actionable(agent: str) -> dict[str, Any] | None:
+    """Return the top **actionable agent work** row for the Stop drain, or None.
+
+    "Actionable agent work" — NOT merely any open queued/claimed row. Two
+    DISTINCT paths, queued first (preserves the #1199 contract):
+      1. genuinely-queued work → the top queued row (ACTION REQUIRED drain).
       2. else self-claimed-but-incomplete work → the top claimed row
          (anti-abandonment; this is NOT an ACTION REQUIRED re-claim nudge).
     A blocked-only queue is not actionable → None (idle quietly).
+
+    Issue #1596 exclusion: daemon-owned `[cron-dispatch]` rows (and
+    `created_by = cron:…` rows) are filtered OUT of BOTH paths — the daemon owns
+    and closes them, so re-entering the model only wastes a turn. A
+    `[cron-followup]` task is REAL follow-up and STILL blocks (carve-out, see
+    ``_is_daemon_owned_cron_dispatch``). We iterate the full queued/claimed list
+    and pick the top REMAINING actionable row so a real task sitting BEHIND a
+    cron-dispatch row still wins — not a single-shot null of the head.
+
+    Finally the SELECTED row is re-confirmed open as late as practical
+    (``_row_still_open``); if it vanished/closed in the race window we fail
+    OPEN (None, no block). All queue read/write failures fail OPEN.
     """
-    pending, row = queue_summary(agent)
-    if pending > 0:
-        # Queued work exists → queued-first wins. If the top-row read itself
-        # failed (pending>0 but row is None — a transient find-open hiccup), do
-        # NOT fall through to the claimed anti-abandonment path: that would
-        # silently switch a queued drain into a claimed block on a partial
-        # queue error. Return the queued row when we have it, else None (idle /
-        # fail open) so the queued-first contract holds.
-        return row
-    if open_claimed_count(agent) > 0:
-        return top_claimed_row(agent)
-    return None
+    # Queued-first. Fetch the FULL queued list and pick the top remaining
+    # non-daemon row. ``_open_rows_for`` returns None on a read error and [] on
+    # an empty set — we distinguish them so a transient queued read error does
+    # NOT silently flip into a claimed block (preserves the existing
+    # "pending>0 but row None → None" fail-open spirit).
+    queued_rows = _open_rows_for(agent, ["queued"])
+    if queued_rows is None:
+        # Queued read errored → fail open, do NOT fall through to claimed.
+        return None
+    if queued_rows:
+        for row in queued_rows:
+            if not _is_daemon_owned_cron_dispatch(row):
+                selected = row
+                break
+        else:
+            # Queued rows existed but ALL were daemon-owned. There is genuinely
+            # no actionable queued work; fall through to the claimed path.
+            selected = None
+        if selected is not None:
+            if not _row_still_open(agent, int(selected.get("id", 0) or 0)):
+                return None
+            return selected
+
+    # No actionable queued work → claimed anti-abandonment path. Same iterate +
+    # filter; a claimed set that is entirely daemon-owned → None (idle quietly).
+    claimed_selected = _top_actionable_in_status(agent, "claimed")
+    if claimed_selected is None:
+        return None
+    if not _row_still_open(agent, int(claimed_selected.get("id", 0) or 0)):
+        return None
+    return claimed_selected
 
 
 def queued_ids_for(agent: str) -> list[int]:
@@ -1683,6 +1870,12 @@ def queued_ids_for(agent: str) -> list[int]:
     ids: list[int] = []
     for r in rows:
         if isinstance(r, dict):
+            # Issue #1596: scope the stamp to the ACTIONABLE queued set — exclude
+            # daemon-owned cron-dispatch rows so the daemon double-submit
+            # suppression key matches exactly the set the drain self-continued
+            # on (the drain never blocks on those rows).
+            if _is_daemon_owned_cron_dispatch(r):
+                continue
             try:
                 ids.append(int(r.get("id", 0) or 0))
             except (TypeError, ValueError):
@@ -1722,8 +1915,18 @@ def compute_drain_decision(
     None means "do not block" (idle quietly / fail open). A non-None return is
     ``{"decision": "block", "reason": <reason_builder(agent, row)>}`` and is
     emitted ONLY after the guard marker has been read/initialised AND atomically
-    persisted. ``reason_builder`` lets each engine supply its own instruction
-    text (Claude vs codex) over the same shared guard.
+    persisted.
+
+    The "actionable agent work" predicate is SINGLE and SHARED: both engines go
+    through ``drain_top_actionable`` here, which excludes daemon-owned
+    `[cron-dispatch]` work (issue #1596) and re-confirms the chosen row is still
+    open. Engines differ ONLY in OUTPUT, never in the predicate:
+      - Codex (`check-inbox.py --format codex`) emits ``{}`` for the no-block
+        case (Codex's managed Stop hook requires a JSON decision object).
+      - Claude (`inbox-auto-drain.py`) emits NOTHING (exit 0) for no-block — a
+        Claude Stop hook stays silent unless it returns a decision.
+    ``reason_builder`` supplies the engine-specific instruction text (Claude vs
+    Codex) over the same shared guard + same shared actionable predicate.
     """
     if not agent or not stop_drain_enabled():
         return None

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -122,6 +122,11 @@ add_required 1568-routine-nudge-inject-busy-gate
 # per-file selectors below (hooks/bridge_hook_common.py, hooks/check_inbox.py,
 # bridge-queue.py, bridge-hooks.py) also pull it directly.
 add_required 9780-stop-inbox-drain
+# Issue #1596: the Stop drain excludes daemon-owned `[cron-dispatch]` rows from
+# the actionable predicate (with the `[cron-followup]` carve-out) so the daemon
+# cron tasks it owns/closes no longer wake the model. In the static suite and
+# pulled per-file below on hooks/* / bridge-queue.py / bridge-hooks.py moves.
+add_required 1596-stop-drain-cron-dispatch
 # #10222: A2A receiver backpressure must count currently OPEN tasks
 # (queued/claimed/blocked) by joining inbox_dedupe to tasks.db, not all-time
 # accepted rows. Keep this in the static suite and pull it on receiver changes.
@@ -935,6 +940,13 @@ select_for_path() {
       # silently regress the fail-count-free stamp or drop updated_ts (which
       # would weaken the id+status+updated_ts guard key → re-loop risk).
       add_required 9780-stop-inbox-drain
+      # Issue #1596: the Stop drain filters daemon-owned `[cron-dispatch]` rows
+      # out of the actionable predicate via find-open --all (title + created_by
+      # columns) and re-confirms the chosen row open. Pull
+      # 1596-stop-drain-cron-dispatch on every bridge-queue.py move so a change
+      # to the find-open `--all` payload (title / created_by / status / id) or
+      # the cron-dispatch SQL exclusions cannot silently break the filter.
+      add_required 1596-stop-drain-cron-dispatch
       add_integration integration-minimal
       ;;
 
@@ -2781,6 +2793,18 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # block, never-block-when-empty), the #1199 queued-vs-claimed split, or the
       # Stop-chain ordering.
       add_required 9780-stop-inbox-drain
+      # Issue #1596: hooks/bridge_hook_common.py::drain_top_actionable now filters
+      # daemon-owned `[cron-dispatch]` / `created_by=cron:` rows (with the
+      # `[cron-followup]` carve-out) out of BOTH the queued and claimed paths via
+      # _is_daemon_owned_cron_dispatch + the find-open --all iterate/filter, and
+      # re-confirms the SELECTED row still open (_row_still_open) before the
+      # block — so a daemon cron-dispatch row no longer wakes the model
+      # (check-inbox.py codex + inbox-auto-drain.py claude inherit the one shared
+      # predicate). Pull 1596-stop-drain-cron-dispatch on every hooks/* /
+      # bridge-hooks.py move so a future patch cannot re-broaden the predicate to
+      # block on daemon-owned work, drop the followup carve-out, single-shot the
+      # head (a real task behind a cron row), or skip the late fail-open re-check.
+      add_required 1596-stop-drain-cron-dispatch
       add_required 1497-p1-home-resolver
       add_required 1497-v2-dynamic-handoff
       # Issue #9981 (read side): hooks/bridge_hook_common.py is the CONSUMER of

--- a/scripts/smoke/1596-stop-drain-cron-dispatch-helpers/print-open-ids.py
+++ b/scripts/smoke/1596-stop-drain-cron-dispatch-helpers/print-open-ids.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Read a `bridge-queue.py find-open --all --format json` array on stdin and
+print each task id on its own line (space/newline separated).
+
+Used by scripts/smoke/1596-stop-drain-cron-dispatch.sh's close_all() to drain
+the fixture queue between phases WITHOUT a python3 heredoc-stdin in the smoke
+(footgun #11) and without a jq dependency. Any parse error prints nothing
+(exit 0) so cleanup is best-effort and never aborts the smoke.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return 0
+    try:
+        rows = json.loads(raw)
+    except json.JSONDecodeError:
+        return 0
+    if not isinstance(rows, list):
+        return 0
+    for row in rows:
+        if isinstance(row, dict):
+            try:
+                task_id = int(row.get("id", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+            if task_id:
+                print(task_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke/1596-stop-drain-cron-dispatch-helpers/race-probe.py
+++ b/scripts/smoke/1596-stop-drain-cron-dispatch-helpers/race-probe.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Race probe for issue #1596 case (g): the SELECTED Stop-drain row becomes done
+between selection and block emission → the drain must FAIL OPEN (no block) and
+must never raise into the Stop path.
+
+We import the real hooks module, monkeypatch ``_row_still_open`` to report the
+chosen row gone (the late re-check seeing a closed/vanished row), then drive
+``compute_drain_decision`` exactly as the Codex Stop hook does. The probe prints
+``NONE`` when the drain correctly returns no decision (fail open) and ``BLOCK``
+if it wrongly emitted a block. Any exception escaping the drain is a fail-open
+VIOLATION — we let it propagate so the smoke sees a non-empty stderr + nonzero
+exit and FAILs the case.
+
+Invoked file-as-argv from the smoke (footgun #11: no python3 heredoc-stdin).
+``sys.argv[1]`` is the agent id; the queue env (BRIDGE_TASK_DB / BRIDGE_HOME /
+BRIDGE_ACTIVE_AGENT_DIR / ...) is inherited from the smoke.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+# this file: <repo>/scripts/smoke/1596-stop-drain-cron-dispatch-helpers/race-probe.py
+# → repo root is FOUR dirname() hops up; hooks/ lives there.
+_HELPERS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(_HELPERS_DIR)))
+HOOKS_DIR = os.path.join(_REPO_ROOT, "hooks")
+sys.path.insert(0, HOOKS_DIR)
+
+import bridge_hook_common as b  # noqa: E402 — path injected above
+
+
+def main() -> int:
+    agent = sys.argv[1] if len(sys.argv) > 1 else ""
+    if not agent:
+        print("NONE")
+        return 0
+
+    # Simulate the race: by the time the late re-check runs, the selected row
+    # has been closed/removed. _row_still_open is the as-late-as-practical
+    # confirmation; force it to report "gone".
+    b._row_still_open = lambda _agent, _task_id: False  # type: ignore[attr-defined]
+
+    decision = b.compute_drain_decision(
+        agent,
+        {},
+        reason_builder=b.codex_stop_reason,
+    )
+    print("NONE" if decision is None else "BLOCK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke/1596-stop-drain-cron-dispatch-helpers/rc-failure-probe.py
+++ b/scripts/smoke/1596-stop-drain-cron-dispatch-helpers/rc-failure-probe.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""rc-failure probe for issue #1596 (patch-dev re-review blocker): a FAILED
+``find-open`` read (nonzero exit) that still carries a parseable, valid-looking
+row on stdout must FAIL OPEN — the Stop drain must NOT trust the row and emit a
+block. Checking only empty-stdout (the prior guard) missed the nonzero-rc +
+non-empty-stdout shape (a partial / SQLite-warning read).
+
+We import the real hooks module and monkeypatch ``queue_cli`` to return a fake
+``CompletedProcess`` for two shapes, then assert ``_open_rows_for`` /
+``drain_top_actionable`` / ``compute_drain_decision`` behave:
+
+  1. rc=2 + a valid queued row on stdout (a real read FAILURE) → fail OPEN:
+     ``_open_rows_for`` is None, ``drain_top_actionable`` is None, and
+     ``compute_drain_decision`` emits NO block.
+  2. rc=1 + the literal ``[]`` (the documented genuinely-EMPTY sentinel) → the
+     read SUCCEEDS empty: ``_open_rows_for`` returns ``[]`` (NOT None), so the
+     queued path can still fall through to the claimed anti-abandonment path.
+     This guards the fix from over-rejecting the legitimate empty case.
+
+Prints ``NONE`` only when BOTH halves hold; otherwise ``BLOCK`` (case 1 wrongly
+blocked) or ``BADEMPTY`` (case 2 regressed the empty sentinel). Any exception
+escaping the drain is a fail-open VIOLATION — we let it propagate so the smoke
+sees a nonzero exit and FAILs the case.
+
+Invoked file-as-argv from the smoke (footgun #11: no python3 heredoc-stdin).
+``sys.argv[1]`` is the agent id.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+_HELPERS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(_HELPERS_DIR)))
+HOOKS_DIR = os.path.join(_REPO_ROOT, "hooks")
+sys.path.insert(0, HOOKS_DIR)
+
+import bridge_hook_common as b  # noqa: E402 — path injected above
+
+
+def _fake_cli(returncode: int, stdout: str):
+    def _run(args, **_kw):
+        return subprocess.CompletedProcess(
+            args=args, returncode=returncode, stdout=stdout, stderr="sqlite: simulated read warning"
+        )
+    return _run
+
+
+def main() -> int:
+    agent = sys.argv[1] if len(sys.argv) > 1 else ""
+    if not agent:
+        print("NONE")
+        return 0
+
+    # --- case 1: nonzero rc + a valid-looking queued row → must fail OPEN ---
+    valid_row = (
+        '[{"id": 4242, "status": "queued", "title": "real user task", '
+        '"created_by": "operator", "priority": "high", "updated_ts": 1}]'
+    )
+    b.queue_cli = _fake_cli(2, valid_row)  # type: ignore[assignment]
+    if b._open_rows_for(agent, ["queued"]) is not None:
+        print("BLOCK")
+        return 0
+    if b.drain_top_actionable(agent) is not None:
+        print("BLOCK")
+        return 0
+    if b.compute_drain_decision(agent, {}, reason_builder=b.codex_stop_reason) is not None:
+        print("BLOCK")
+        return 0
+
+    # --- case 2: rc==1 + literal "[]" sentinel → genuinely empty, NOT a failure ---
+    b.queue_cli = _fake_cli(1, "[]")  # type: ignore[assignment]
+    if b._open_rows_for(agent, ["queued"]) != []:
+        print("BADEMPTY")
+        return 0
+
+    print("NONE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke/1596-stop-drain-cron-dispatch.sh
+++ b/scripts/smoke/1596-stop-drain-cron-dispatch.sh
@@ -67,9 +67,11 @@ MARKER="$BRIDGE_ACTIVE_AGENT_DIR/$AGENT/inbox-drain-state.json"
 
 QUEUE() { python3 "$REPO_ROOT/bridge-queue.py" "$@"; }
 
+# shellcheck disable=SC2120  # optional event-JSON arg; every caller uses the default {}
 drain_claude() {
   printf '%s' "${1:-\{\}}" | python3 "$REPO_ROOT/hooks/inbox-auto-drain.py" 2>/dev/null
 }
+# shellcheck disable=SC2120  # optional event-JSON arg; every caller uses the default {}
 drain_codex() {
   printf '%s' "${1:-\{\}}" | python3 "$REPO_ROOT/hooks/check_inbox.py" --format codex 2>/dev/null
 }

--- a/scripts/smoke/1596-stop-drain-cron-dispatch.sh
+++ b/scripts/smoke/1596-stop-drain-cron-dispatch.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# scripts/smoke/1596-stop-drain-cron-dispatch.sh — Stop drain skips daemon-owned
+# `[cron-dispatch]` work (#1596). HIGH-RISK: the Stop-hook chain re-entry
+# decision (every Claude/Codex turn-end).
+#
+# THE GAP. The shared Stop drain (hooks/bridge_hook_common.py::drain_top_actionable,
+# consumed by BOTH check-inbox.py --format codex AND inbox-auto-drain.py) blocked
+# the model for ANY open queued/claimed row — including daemon-owned
+# `[cron-dispatch]` rows the bridge daemon owns and closes itself. The model woke
+# only to find nothing to do (observed: `#10352 [cron-dispatch] picker-sweep`),
+# burning a turn.
+#
+# THE FIX. _is_daemon_owned_cron_dispatch(row) excludes a row whose title starts
+# with `[cron-dispatch]` OR whose created_by starts with `cron:`, with a
+# `[cron-followup]`-title carve-out (real follow-up still blocks). The drain
+# iterates the FULL queued/claimed list (find-open --all) and picks the top
+# REMAINING actionable row (a real task behind a cron row still wins), then
+# re-confirms that row still open as late as practical and FAILS OPEN if it
+# vanished.
+#
+# This test pins, in an isolated BRIDGE_HOME (+ BRIDGE_ACTIVE_AGENT_DIR so the
+# loop-guard marker lands in the fixture tree, never the live runtime), the
+# acceptance matrix:
+#   (a) empty queue                       → no block (both engines).
+#   (b) real queued task                  → block.
+#   (c) real claimed unfinished           → block (anti-abandonment).
+#   (d) daemon `[cron-dispatch]` claimed  → NO block (daemon owns/closes it).
+#   (e) `[cron-dispatch]` + real behind it → block on the REAL task, not the cron.
+#   (f) `[cron-followup]`                 → block (actionable carve-out, even
+#                                            though created_by starts `cron:`).
+#   (g) race: selected row done before    → fail open (no block, no error).
+#       block emission
+#   (h) both engines over the same states → identical actionable verdicts.
+#
+# Footgun #11: all queue mutation goes through the real CLI; no python3
+# heredoc-stdin and no `<<<` here-string. The case-(g) race needs a
+# selected-row-vanishes hook, driven through a file-as-argv probe
+# (1596-stop-drain-cron-dispatch-helpers/race-probe.py) — NOT an inline
+# heredoc-in-capture (see scripts/lint-heredoc-ban.sh).
+
+set -euo pipefail
+
+SMOKE_NAME="1596-stop-drain-cron-dispatch"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agb-1596.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+DB="$TMP_DIR/tasks.db"
+export BRIDGE_TASK_DB="$DB"
+export BRIDGE_HOME="$REPO_ROOT"
+export BRIDGE_STATE_DIR="$TMP_DIR/state"
+# Pin the per-agent runtime state root into the fixture so the loop-guard marker
+# NEVER lands in the operator's live ~/.agent-bridge tree.
+export BRIDGE_ACTIVE_AGENT_DIR="$TMP_DIR/state/agents"
+# Deterministic guard knobs (irrelevant to the predicate, but keep the marker
+# from suppressing fresh-marker assertions).
+export BRIDGE_STOP_DRAIN_CAP=3
+export BRIDGE_STOP_DRAIN_COOLDOWN=300
+
+AGENT="drain-cron-tester"
+export BRIDGE_AGENT_ID="$AGENT"
+MARKER="$BRIDGE_ACTIVE_AGENT_DIR/$AGENT/inbox-drain-state.json"
+
+QUEUE() { python3 "$REPO_ROOT/bridge-queue.py" "$@"; }
+
+drain_claude() {
+  printf '%s' "${1:-\{\}}" | python3 "$REPO_ROOT/hooks/inbox-auto-drain.py" 2>/dev/null
+}
+drain_codex() {
+  printf '%s' "${1:-\{\}}" | python3 "$REPO_ROOT/hooks/check_inbox.py" --format codex 2>/dev/null
+}
+
+reset_marker() { rm -f "$MARKER" "$MARKER.tmp" 2>/dev/null || true; }
+
+# Create a task, set TASK to its id. Optional 3rd arg = created_by (default
+# "operator"). Goes through the real CLI shell-format so we never parse JSON in
+# bash.
+mk() {
+  local title="$1" from="${2:-operator}"
+  QUEUE create --to "$AGENT" --from "$from" --title "$title" --body "b" \
+    --format shell >"$TMP_DIR/create.sh"
+  # shellcheck disable=SC1090
+  source "$TMP_DIR/create.sh"
+  TASK="$TASK_ID"
+}
+
+# Close every open task assigned to the agent so each phase starts from a clean
+# queue. Reads ids via the CLI's --all JSON through a file-as-argv id reader
+# (no heredoc, no jq dependency).
+close_all() {
+  local ids
+  # find-open --all returns rc=1 on an EMPTY queue (prints `[]`); under
+  # `set -o pipefail` that would abort the smoke. Tolerate it — an empty queue
+  # is a valid (and common) starting state for a phase.
+  ids="$( { QUEUE find-open --agent "$AGENT" --all --format json || true; } \
+    | python3 "$SCRIPT_DIR/1596-stop-drain-cron-dispatch-helpers/print-open-ids.py")"
+  local id
+  for id in $ids; do
+    QUEUE claim "$id" --agent "$AGENT" >/dev/null 2>&1 || true
+    QUEUE done "$id" --agent "$AGENT" --note "smoke cleanup" >/dev/null 2>&1 || true
+  done
+}
+
+failed=0
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1" >&2; failed=1; }
+
+# Assert the codex engine BLOCKS (decision:block) on the current seeded state.
+assert_codex_block() {
+  local label="$1" out
+  reset_marker
+  out="$(drain_codex)"
+  if printf '%s' "$out" | grep -q '"decision": "block"'; then
+    pass "$label (codex blocks)"
+  else
+    fail "$label — codex should block (got: '${out}')"
+  fi
+}
+# Assert the codex engine does NOT block (emits the no-decision {}).
+assert_codex_noblock() {
+  local label="$1" out
+  reset_marker
+  out="$(drain_codex)"
+  if [[ "$out" == "{}" ]]; then
+    pass "$label (codex no-block {})"
+  else
+    fail "$label — codex should NOT block (got: '${out}')"
+  fi
+}
+# Assert the Claude engine BLOCKS (decision:block) on the current seeded state.
+assert_claude_block() {
+  local label="$1" out
+  reset_marker
+  out="$(drain_claude)"
+  if printf '%s' "$out" | grep -q '"decision": "block"'; then
+    pass "$label (claude blocks)"
+  else
+    fail "$label — claude should block (got: '${out}')"
+  fi
+}
+# Assert the Claude engine does NOT block (emits nothing / exit 0 silent).
+assert_claude_noblock() {
+  local label="$1" out
+  reset_marker
+  out="$(drain_claude)"
+  if [[ -z "$out" ]]; then
+    pass "$label (claude no-block silent)"
+  else
+    fail "$label — claude should NOT block (got: '${out}')"
+  fi
+}
+
+# ============================================================
+# (a) empty queue → no block (both engines)
+# ============================================================
+close_all
+assert_codex_noblock  "(a) empty queue"
+assert_claude_noblock "(a) empty queue"
+
+# ============================================================
+# (b) real queued task → block (both engines)
+# ============================================================
+close_all
+mk "real user work" "operator"
+assert_codex_block  "(b) real queued task"
+assert_claude_block "(b) real queued task"
+
+# ============================================================
+# (c) real claimed unfinished → block (anti-abandonment)
+# ============================================================
+close_all
+mk "real claimed work" "operator"
+QUEUE claim "$TASK" --agent "$AGENT" >/dev/null
+assert_codex_block  "(c) real claimed unfinished"
+assert_claude_block "(c) real claimed unfinished"
+
+# ============================================================
+# (d) daemon [cron-dispatch] claimed-only → NO block (both engines)
+# ============================================================
+close_all
+mk "[cron-dispatch] picker-sweep (slot1)" "cron:picker-sweep"
+QUEUE claim "$TASK" --agent "$AGENT" >/dev/null
+assert_codex_noblock  "(d) daemon [cron-dispatch] claimed-only"
+assert_claude_noblock "(d) daemon [cron-dispatch] claimed-only"
+
+# (d') REGRESSION GUARD (codex r1 finding #1): a real `[picker-sweep]`
+# notification task is filed by a `cron:`-prefixed actor
+# (scripts/picker-sweep.sh: --from "cron:picker-sweep") but is NOT a
+# `[cron-dispatch]` row and is NOT daemon-closed — it MUST still block. The
+# title is the SSOT; created_by `cron:` alone must NOT swallow it. A future
+# patch that re-broadens the predicate to `created_by.startswith("cron:")`
+# OR-rule on a TITLED row would regress this.
+close_all
+mk "[picker-sweep] 3 agent(s) auto-unstuck from interactive picker" "cron:picker-sweep"
+assert_codex_block  "(d') real [picker-sweep] task (created_by=cron:) still blocks"
+assert_claude_block "(d') real [picker-sweep] task (created_by=cron:) still blocks"
+
+# (d'') the `created_by=cron:` rule is a DEFENSIVE FALLBACK for an untitled row
+# only. A real cron-actor task ALWAYS carries a title, so this fallback never
+# swallows genuine work; we cannot easily seed a blank title through the CLI
+# (create rejects empty titles), so the untitled-fallback behaviour is pinned at
+# the unit level instead — see _is_daemon_owned_cron_dispatch's direct probes in
+# the (g) race helper and the predicate docstring.
+
+# ============================================================
+# (e) [cron-dispatch] + a real task behind it → block on the REAL task
+# ============================================================
+# (e1) cron-dispatch QUEUED (lower id) + real QUEUED behind → block cites real.
+close_all
+mk "[cron-dispatch] sweepq (slot1)" "cron:sweepq"; CRON_ID="$TASK"
+mk "real queued behind cron" "operator"; REAL_ID="$TASK"
+reset_marker
+OUT="$(drain_codex)"
+if printf '%s' "$OUT" | grep -q '"decision": "block"' \
+   && printf '%s' "$OUT" | grep -q "real queued behind cron" \
+   && ! printf '%s' "$OUT" | grep -q "cron-dispatch"; then
+  pass "(e1) cron-dispatch queued + real queued behind → block on the REAL task (#${REAL_ID}, not #${CRON_ID})"
+else
+  fail "(e1) should block on the real queued task, never the cron row (got: '${OUT}')"
+fi
+
+# (e2) cron-dispatch CLAIMED + real CLAIMED behind → claimed path filters too.
+close_all
+mk "[cron-dispatch] sweepc (slot1)" "cron:sweepc"; QUEUE claim "$TASK" --agent "$AGENT" >/dev/null
+mk "real claimed behind cron" "operator"; QUEUE claim "$TASK" --agent "$AGENT" >/dev/null
+reset_marker
+OUT="$(drain_codex)"
+if printf '%s' "$OUT" | grep -q '"decision": "block"' \
+   && printf '%s' "$OUT" | grep -q "real claimed behind cron" \
+   && ! printf '%s' "$OUT" | grep -q "cron-dispatch"; then
+  pass "(e2) cron-dispatch claimed + real claimed behind → block on the REAL claimed task"
+else
+  fail "(e2) should block on the real claimed task, never the cron row (got: '${OUT}')"
+fi
+
+# (e3) queued is ALL cron-dispatch but a real CLAIMED exists → fall through to
+# the claimed anti-abandonment path (queued-all-daemon must NOT short-circuit
+# the claimed path).
+close_all
+mk "[cron-dispatch] qonly (slot1)" "cron:qonly"
+mk "real claimed fallthrough" "operator"; QUEUE claim "$TASK" --agent "$AGENT" >/dev/null
+reset_marker
+OUT="$(drain_codex)"
+if printf '%s' "$OUT" | grep -q '"decision": "block"' \
+   && printf '%s' "$OUT" | grep -q "real claimed fallthrough"; then
+  pass "(e3) queued all-cron + real claimed → falls through to claimed, blocks on the real task"
+else
+  fail "(e3) queued-all-daemon should fall through to the claimed real task (got: '${OUT}')"
+fi
+
+# ============================================================
+# (f) [cron-followup] → block (actionable carve-out)
+# ============================================================
+# Note: the daemon files cron-followup with created_by="cron:<source-agent>",
+# so the title carve-out MUST win over the created_by `cron:` rule.
+close_all
+mk "[cron-followup] nightly (run=abc123)" "cron:nightly"
+assert_codex_block  "(f) [cron-followup] (created_by=cron:)"
+assert_claude_block "(f) [cron-followup] (created_by=cron:)"
+
+# ============================================================
+# (g) race: selected row becomes done before block emission → fail open
+# ============================================================
+# Seed a real queued task, then drive the drain through the race probe which
+# patches _row_still_open to report the row gone right before the block. The
+# drain must return None (no block) and must NOT raise / emit an error banner.
+close_all
+mk "racey vanishing task" "operator"
+reset_marker
+RACE_OUT="$(python3 "$SCRIPT_DIR/1596-stop-drain-cron-dispatch-helpers/race-probe.py" "$AGENT" 2>"$TMP_DIR/race.err" || true)"
+if [[ "$RACE_OUT" == "NONE" ]] && [[ ! -s "$TMP_DIR/race.err" ]]; then
+  pass "(g) race: selected row gone before block → fail open (None, no block, no error)"
+else
+  fail "(g) race must fail open with no block / no error (out='${RACE_OUT}', err='$(cat "$TMP_DIR/race.err")')"
+fi
+
+# And end-to-end through the real engine: close the row out-of-band BEFORE the
+# Stop hook runs; the late re-check must catch it and emit no block.
+close_all
+mk "closed before stop" "operator"
+QUEUE claim "$TASK" --agent "$AGENT" >/dev/null
+QUEUE done "$TASK" --agent "$AGENT" --note "closed out-of-band" >/dev/null
+assert_codex_noblock  "(g') row closed before Stop runs"
+assert_claude_noblock "(g') row closed before Stop runs"
+
+# ============================================================
+# (i) queue READ failure → fail open (codex r1 finding #2)
+# ============================================================
+# A genuine queue read failure (DB open/SQLite error) exits nonzero with EMPTY
+# stdout (+ traceback on stderr) — distinct from an empty result, which prints
+# the literal `[]`. _open_rows_for must map empty-stdout to a READ ERROR (None →
+# fail open: do NOT block, do NOT fall through to the claimed path), NOT to an
+# empty list. Point BRIDGE_TASK_DB at an unreadable path and confirm no block /
+# no error banner from BOTH engines.
+(
+  export BRIDGE_TASK_DB="$TMP_DIR/nonexistent-dir/does/not/exist.db"
+  reset_marker
+  cx="$(drain_codex)"
+  reset_marker
+  clx="$(drain_claude)"
+  if [[ "$cx" == "{}" && -z "$clx" ]]; then
+    echo "ok" >"$TMP_DIR/readfail.out"
+  else
+    echo "block: codex='${cx}' claude='${clx}'" >"$TMP_DIR/readfail.out"
+  fi
+)
+if grep -q "^ok$" "$TMP_DIR/readfail.out"; then
+  pass "(i) queue read failure → fail open (codex {} + claude silent, no fall-through, no banner)"
+else
+  fail "(i) a queue read failure must fail open, not block / fall through ($(cat "$TMP_DIR/readfail.out"))"
+fi
+
+# ============================================================
+# (h) both engines: identical actionable verdicts over the same states
+# ============================================================
+# Drive BOTH engines over each canonical state with a fresh marker and assert
+# their block / no-block verdicts agree (single shared predicate; engines differ
+# only in OUTPUT shape — codex {} vs claude silent).
+parity_state() {
+  # $1 = label, $2 = expected verdict (block|noblock)
+  local label="$1" expect="$2" cx clx cv cl
+  reset_marker; cx="$(drain_codex)"
+  reset_marker; clx="$(drain_claude)"
+  printf '%s' "$cx" | grep -q '"decision": "block"' && cv=block || cv=noblock
+  printf '%s' "$clx" | grep -q '"decision": "block"' && cl=block || cl=noblock
+  if [[ "$cv" == "$cl" && "$cv" == "$expect" ]]; then
+    pass "(h) parity ${label}: both engines agree → ${cv}"
+  else
+    fail "(h) parity ${label}: codex=${cv} claude=${cl} expected=${expect} (cx='${cx}' clx='${clx}')"
+  fi
+}
+close_all
+parity_state "empty" "noblock"
+close_all; mk "parity real queued" "operator"
+parity_state "real-queued" "block"
+close_all; mk "[cron-dispatch] parity (slot1)" "cron:parity"; QUEUE claim "$TASK" --agent "$AGENT" >/dev/null
+parity_state "cron-dispatch-claimed" "noblock"
+close_all; mk "[cron-followup] parity (run=z)" "cron:parity"
+parity_state "cron-followup" "block"
+
+if (( failed )); then
+  echo "[smoke:${SMOKE_NAME}] FAILED" >&2
+  exit 1
+fi
+echo "[smoke:${SMOKE_NAME}] all checks passed"

--- a/scripts/smoke/1596-stop-drain-cron-dispatch.sh
+++ b/scripts/smoke/1596-stop-drain-cron-dispatch.sh
@@ -317,6 +317,26 @@ else
 fi
 
 # ============================================================
+# (i2) nonzero-rc read failure WITH a parseable row → fail open (patch-dev re-review)
+# ============================================================
+# (i) covers a read failure with EMPTY stdout. A real failure can ALSO exit
+# nonzero while still emitting a parseable, valid-looking row on stdout (a
+# partial / SQLite-warning read). _open_rows_for must fail open (None) on ANY
+# nonzero rc except the documented rc==1 + literal `[]` empty sentinel — never
+# trust the row, or a failed read could emit a Stop block. The probe
+# monkeypatches queue_cli to return rc=2 + a valid queued row (must → None / no
+# block) AND rc==1 + `[]` (must stay [], the empty sentinel, so the queued path
+# still falls through). It prints NONE only when both hold; BLOCK or BADEMPTY
+# otherwise.
+reset_marker
+RCFAIL_OUT="$(python3 "$SCRIPT_DIR/1596-stop-drain-cron-dispatch-helpers/rc-failure-probe.py" "$AGENT" 2>"$TMP_DIR/rcfail.err" || true)"
+if [[ "$RCFAIL_OUT" == "NONE" ]] && [[ ! -s "$TMP_DIR/rcfail.err" ]]; then
+  pass "(i2) nonzero-rc read failure with a parseable row → fail open; rc==1 [] sentinel preserved"
+else
+  fail "(i2) nonzero-rc read with a row must fail open and keep the [] sentinel (out='${RCFAIL_OUT}', err='$(cat "$TMP_DIR/rcfail.err")')"
+fi
+
+# ============================================================
 # (h) both engines: identical actionable verdicts over the same states
 # ============================================================
 # Drive BOTH engines over each canonical state with a fresh marker and assert


### PR DESCRIPTION
## Summary

Tightens the **single shared Stop-hook drain predicate** so daemon-owned `[cron-dispatch]` work no longer wakes the model, while every real task still does. References #1596 (do not auto-close — orchestrator decides closure at the stable cut).

Before this change, the shared drain (`hooks/bridge_hook_common.py::drain_top_actionable`, consumed by BOTH `check-inbox.py --format codex` and `inbox-auto-drain.py`) emitted `decision:block` for ANY open queued/claimed row — including daemon-owned `[cron-dispatch]` rows the bridge daemon owns and closes itself. The model woke only to find the inbox empty/done (observed: `#10352 [cron-dispatch] picker-sweep`), spending a turn for nothing.

## What changed

- **`_is_daemon_owned_cron_dispatch(row)`** — the **title is the SSOT**. A titled row is daemon-owned only when its title starts with `[cron-dispatch]` (the canonical daemon-written, daemon-closed marker — `bridge-cron.sh:655` `title="[cron-dispatch] <job> (<slot>)"`, `--from "cron:<job>"`). `created_by` starting `cron:` is **not** a reliable signal on its own: the daemon's own real `[cron-followup]` follow-ups (`bridge-cron-runner.py`, actor `cron:<src>`) AND real `[picker-sweep]` notification tasks (`scripts/picker-sweep.sh`, `--from "cron:picker-sweep"`) are filed by a `cron:` actor yet must still block — so `created_by cron:` is a defensive **fallback only for an untitled/blank-title row** (a shape no real cron-actor task ever takes).
- **Iterate + filter, not single-shot null.** `drain_top_actionable` fetches the FULL queued/claimed list (`find-open --all`, which carries `title` + `created_by` + `updated_ts`), drops daemon-owned rows, and picks the top REMAINING actionable row — so a real task sitting BEHIND a cron-dispatch row still wins. Queued-first preserved; a queued set that is entirely daemon-owned falls through to the claimed anti-abandonment path; a transient queued READ error does NOT fall through.
- **Fail-open hardening.** `_open_rows_for` maps a read FAILURE (nonzero rc + empty stdout + traceback on stderr) to `None` (fail open), distinct from a genuine empty result (the literal `[]` → `[]`). Every queue read failure fails OPEN; nothing raises into the Codex Stop path (`check-inbox.py` main has no outer try/except).
- **Late re-check.** `_row_still_open` re-confirms the SELECTED row is still open right before the block; if it vanished/closed in the race window the drain fails OPEN (None, no block, no error). `queued_ids_for` also excludes daemon-owned rows so the `note-self-continue` daemon double-submit suppression key matches the actionable set.

The predicate stays **single + shared**; engines differ only in the no-block OUTPUT (Codex emits `{}`, Claude emits nothing). Every existing invariant is preserved: `stop_hook_active` short-circuit, the `id+status+updated_ts` loop guard (cooldown/cap/consecutive), atomic-persist-before-block, the #1199 queued-vs-claimed split, and fail-open on all read/write errors.

## Verification

- New smoke `scripts/smoke/1596-stop-drain-cron-dispatch.sh` — **24 checks, all PASS** (bash 5.x): empty / real queued / real claimed / `[cron-dispatch]` claimed-only / real-task-behind-cron / **`[picker-sweep]`-still-blocks** / `[cron-followup]` / race (selected row gone) / **queue-read-failure fail-open** / both-engine parity. Two file-as-argv probes (`print-open-ids.py`, `race-probe.py`) — no heredoc-stdin (footgun #11). Registered in `scripts/ci-select-smoke.sh` on `hooks/*` + `bridge-queue.py` moves.
- Regression guards green: `9780-stop-inbox-drain` (20 PASS), `1199-action-required-claimed-skip` (12 PASS).
- `python3 -m py_compile` clean; `bash -n` + `shellcheck` clean; `scripts/oss-preflight.sh` rc=0.
- `scripts/smoke-test.sh` has ONE pre-existing macOS-environment failure (`#365 follow-up` isolated agent-env guard, `BRIDGE_HOME=` interpolation) that reproduces on a clean `origin/main` baseline with these changes stashed — NOT a regression from this PR.
- Docs updated: `ARCHITECTURE.md` (#9780 Stop-chain section) + `docs/developer-handover.md`.

Internal `codex:codex-rescue` review converged at round 2 with **`implement-ok`** (round 1 caught two real blockers — the `[picker-sweep]` false-positive and the read-failure-vs-empty conflation — both fixed and pinned by new smoke cases).

## Hold / routing

- **HELD for the 0.16.0 stable cut** — do NOT merge. Route to **patch-dev / patch** for review. High-risk: this is the Stop-hook drain decision that runs at every Claude/Codex turn-end.
- No `VERSION` / `CHANGELOG` change. No `Closes/Fixes` keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
