### PR TITLE
a2a: reset attempts on outbox retry so a manual retry restarts backoff (#1618)

### DIFF
--- a/bridge-a2a.py
+++ b/bridge-a2a.py
@@ -5,6 +5,8 @@ Subcommands (surfaced through `agent-bridge a2a ...`):
 
   send          Stage an outbound handoff into the durable outbox.
   outbox        list | retry | drop | gc — manage the sender outbox.
+                `retry` requeues a dead/retry row to send now and resets its
+                attempt counter so it walks the backoff ladder afresh (#1618).
   inbox-dedupe  list | gc — inspect/prune the receiver dedupe ledger.
   peers         list | test <peer> — inspect configured peers.
   deliver       Drain the outbox: sign + POST each pending entry over the
@@ -532,9 +534,17 @@ def cmd_outbox(args: argparse.Namespace) -> int:
         if action == "retry":
             if not args.message_id:
                 return die("outbox retry needs <message_id>") or 1
+            # #1618: a manual retry RESTARTS the delivery effort, so it resets
+            # `attempts=0` alongside `next_attempt_ts=0` ("send now"). A dead row
+            # sits at the delivery_max_attempts ceiling (default 12); preserving
+            # the count gave it exactly ONE serve tick (attempts -> 13 >= max ->
+            # re-dead) or a single re-schedule at the backoff ceiling (12h/1d).
+            # Zeroing attempts walks the backoff ladder again from the base
+            # interval, matching the verb's intent ("send it now, keep trying").
+            # The historical attempt count is intentionally cleared.
             cur = conn.execute(
                 "UPDATE outbox SET status='pending', next_attempt_ts=0, "
-                "lease_owner=NULL, lease_expires_ts=0, updated_ts=? "
+                "attempts=0, lease_owner=NULL, lease_expires_ts=0, updated_ts=? "
                 "WHERE message_id=? AND status IN ('dead', 'retry')",
                 (a2a.now_ts(), args.message_id),
             )
@@ -870,10 +880,12 @@ def _schedule_retry(conn, message_id: str, attempts: int, cfg: dict[str, Any],
                     last_error: str, retry_after: Optional[str] = None) -> str:
     max_attempts = int(cfg.get("delivery_max_attempts", 12))
     if attempts >= max_attempts:
-        row = conn.execute(
-            "SELECT body_path FROM outbox WHERE message_id=?",
-            (message_id,),
-        ).fetchone()
+        # #1618: do NOT unlink the staged body on dead-letter. A `dead` row is an
+        # operator-retryable state (`agb a2a outbox retry`), and the prior code
+        # deleted the managed envelope here, so a manual retry of a maxattempts
+        # row re-dead-lettered as `dead(nobody)` on the next tick (body gone) —
+        # i.e. retry could never actually resend it. The body is still reclaimed
+        # by `outbox gc` (terminal rows older than max-age) and `outbox drop`.
         conn.execute(
             "UPDATE outbox SET status='dead', attempts=?, last_error=?, updated_ts=? "
             "WHERE message_id=?",
@@ -881,8 +893,6 @@ def _schedule_retry(conn, message_id: str, attempts: int, cfg: dict[str, Any],
              a2a.now_ts(), message_id),
         )
         conn.commit()
-        if row is not None:
-            _unlink_outbox_body_path(row["body_path"])
         return "dead(maxattempts)"
 
     ceiling = a2a.delivery_backoff_ceiling(cfg)
@@ -924,18 +934,18 @@ def _schedule_retry(conn, message_id: str, attempts: int, cfg: dict[str, Any],
 
 
 def _mark_dead(conn, message_id: str, reason: str) -> None:
-    row = conn.execute(
-        "SELECT body_path FROM outbox WHERE message_id=?",
-        (message_id,),
-    ).fetchone()
+    # #1618: the staged body is preserved on dead-letter (it used to be unlinked
+    # here) so `agb a2a outbox retry` can actually resend a dead row once the
+    # operator fixes the underlying cause (e.g. a recovered peer / corrected
+    # config). The body is reclaimed by `outbox gc` / `outbox drop` instead.
+    # `dead(nobody)` rows whose body was already missing simply have nothing to
+    # retain — the reschedule on the next tick will re-dead them the same way.
     conn.execute(
         "UPDATE outbox SET status='dead', last_error=?, "
         "lease_owner=NULL, lease_expires_ts=0, updated_ts=? WHERE message_id=?",
         (reason[:500], a2a.now_ts(), message_id),
     )
     conn.commit()
-    if row is not None:
-        _unlink_outbox_body_path(row["body_path"])
 
 
 def cmd_deliver(args: argparse.Namespace) -> int:
@@ -2740,7 +2750,9 @@ def build_parser() -> argparse.ArgumentParser:
                         help="resolve + validate but do not write the outbox")
     p_send.set_defaults(func=cmd_send)
 
-    p_outbox = sub.add_parser("outbox", help="manage the sender outbox")
+    p_outbox = sub.add_parser(
+        "outbox",
+        help="manage the sender outbox (retry resets the attempt counter, #1618)")
     p_outbox.add_argument("action", choices=["list", "retry", "drop", "gc"])
     p_outbox.add_argument("message_id", nargs="?", default=None)
     p_outbox.add_argument("--json", action="store_true")

--- a/docs/a2a-cross-bridge.md
+++ b/docs/a2a-cross-bridge.md
@@ -497,6 +497,15 @@ runner loops from double-sending.
 - GC: max attempts or max age → `dead`. Caps on total outbox bytes +
   per-peer pending count; over-cap, new sends fail locally with a clear
   remediation message (no silent unbounded disk growth).
+- **Manual retry restarts the ladder (#1618).** `agb a2a outbox retry <id>`
+  on a `dead`/`retry` row sets `next_attempt_ts=0` ("send now") **and resets
+  `attempts=0`**, so it walks the backoff ladder from the base interval again
+  instead of getting one shot before the ceiling / re-dead-letter. To make this
+  actually resend, dead-letter now **preserves** the staged outgoing envelope
+  (it used to unlink it, so a retried `dead` row re-dead-lettered as
+  `dead(nobody)`); the dead body is reclaimed by `outbox gc` (terminal rows past
+  max-age, default 14d) or `outbox drop` instead. Dead rows do not count toward
+  the total-byte / per-peer-pending caps.
 
 ## Diagnosis + backoff recovery (`agb a2a diagnose-stuck`, #1563 PR-8)
 

--- a/scripts/baselines/iso-helper-baseline.txt
+++ b/scripts/baselines/iso-helper-baseline.txt
@@ -142,6 +142,7 @@ scripts/smoke/1497-p2-operator-home.sh=14
 scripts/smoke/1506-isolate-normalize.sh=5
 scripts/smoke/1563-pr3-daemon-escalation.sh=1
 scripts/smoke/1563-pr4-a2a-receiver-healthz.sh=5
+scripts/smoke/1618-outbox-retry-resets-attempts-helper.py=4
 scripts/smoke/4494-integrated-dynamic-recovery.sh=4
 scripts/smoke/857-pr1-isolation-write-helper.sh=9
 scripts/smoke/857-pr6-isolation-v3-channel-dotenv-migrate.sh=25

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -134,6 +134,10 @@ add_required a2a-backpressure-openonly
 # #1575-B + #1589/B8: A2A sender retry scheduling keeps our exponential backoff
 # ceiling separate from peer Retry-After floor caps.
 add_required 1575b-a2a-backoff-ceiling
+# #1618: `agb a2a outbox retry` of a dead/retry row resets attempts=0 (alongside
+# next_attempt_ts=0) so a manual retry walks the backoff ladder from the base
+# interval instead of one-shot-then-ceiling / re-dead-letter.
+add_required 1618-outbox-retry-resets-attempts
 # #1595: A2A is transport-pluggable (Tailscale | cloudflare-warp-mesh). The
 # Cloudflare bind proof inspects REAL local interface state + WARP connected/
 # enrolled status (CIDR shape is NOT proof; fail-closed on uncertainty); the
@@ -1027,7 +1031,7 @@ select_for_path() {
       add_required queue a2a-rooms-p1b-acl
       ;;
 
-    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|lib/daemon-helpers/a2a-receiver-exit-cause.py|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/smoke/rooms-p4-2-roster-broadcast-helper.py|scripts/smoke/rooms-p4-2-post-hook.sh|scripts/smoke/rooms-p4-3-room-talk-helper.py|scripts/smoke/rooms-p4-3-post-hook.sh|scripts/smoke/1594-rooms-fanout-helper.py|scripts/smoke/1594-rooms-fanout-post-hook.sh|scripts/smoke/1594-rooms-fanout-local-hook.sh|scripts/smoke/rooms-p4-5-polish.sh|scripts/smoke/rooms-p4-5-helper.py|scripts/smoke/1563-pr8-a2a-diag-recovery-helper.py|scripts/smoke/1575b-a2a-backoff-ceiling-helper.py|scripts/smoke/1595-cloudflare-warp-mesh-helper.py|scripts/install-handoffd-systemd.sh)
+    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|lib/daemon-helpers/a2a-receiver-exit-cause.py|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/smoke/rooms-p4-2-roster-broadcast-helper.py|scripts/smoke/rooms-p4-2-post-hook.sh|scripts/smoke/rooms-p4-3-room-talk-helper.py|scripts/smoke/rooms-p4-3-post-hook.sh|scripts/smoke/1594-rooms-fanout-helper.py|scripts/smoke/1594-rooms-fanout-post-hook.sh|scripts/smoke/1594-rooms-fanout-local-hook.sh|scripts/smoke/rooms-p4-5-polish.sh|scripts/smoke/rooms-p4-5-helper.py|scripts/smoke/1563-pr8-a2a-diag-recovery-helper.py|scripts/smoke/1575b-a2a-backoff-ceiling-helper.py|scripts/smoke/1618-outbox-retry-resets-attempts-helper.py|scripts/smoke/1595-cloudflare-warp-mesh-helper.py|scripts/install-handoffd-systemd.sh)
       # Issue #1032: A2A cross-bridge task handoff. Any move to the
       # receiver daemon, sender outbox/delivery-runner, shared protocol
       # module, lifecycle helper, or the smoke helper re-runs the
@@ -1196,7 +1200,13 @@ select_for_path() {
       # hot-reload). Pull 1612-upgrade-restart-receiver whenever the receiver
       # lifecycle script / lib-a2a moves so a change to the status output shape
       # or the restart subcommand cannot silently break the upgrade-time cycle.
-      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force a2a-backpressure-openonly rooms-p4-1-cross-node-join rooms-p4-2-roster-broadcast rooms-p4-3-room-talk 1594-rooms-fanout rooms-p4-5-polish 1563-pr4-a2a-receiver-healthz 1563-pr5-fp-control-matrix 1563-pr8-a2a-diag-recovery 1575b-a2a-backoff-ceiling 1595-cloudflare-warp-mesh 1612-upgrade-restart-receiver
+      # Issue #1618: bridge-a2a.py's `outbox retry` resets attempts=0 (alongside
+      # next_attempt_ts=0) so a manual retry of a dead/retry row walks the backoff
+      # ladder from the base interval instead of one-shot-then-ceiling /
+      # re-dead-letter. 1618-outbox-retry-resets-attempts drives the REAL
+      # cmd_outbox retry path + _schedule_retry; pull it on every bridge-a2a.py
+      # move so the attempt-reset cannot regress to the preserve-attempts footgun.
+      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force a2a-backpressure-openonly rooms-p4-1-cross-node-join rooms-p4-2-roster-broadcast rooms-p4-3-room-talk 1594-rooms-fanout rooms-p4-5-polish 1563-pr4-a2a-receiver-healthz 1563-pr5-fp-control-matrix 1563-pr8-a2a-diag-recovery 1575b-a2a-backoff-ceiling 1618-outbox-retry-resets-attempts 1595-cloudflare-warp-mesh 1612-upgrade-restart-receiver
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)
@@ -3011,6 +3021,15 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # already pulls it via the full static suite; this arm keeps the
       # selection focused when only these two files change).
       add_required 1611-migrate-orphan-skip
+      ;;
+
+    scripts/smoke/1618-outbox-retry-resets-attempts.sh|scripts/smoke/1618-outbox-retry-resets-attempts-helper.py)
+      # Issue #1618: editing the outbox-retry-reset smoke or its helper re-runs
+      # the smoke directly (the scripts/smoke/* catch-all already pulls it via
+      # the full static suite; this arm keeps the selection focused when only
+      # these two files change). The helper is ALSO listed in the bridge-a2a.py
+      # arm above so a sender change selects this smoke.
+      add_required 1618-outbox-retry-resets-attempts
       ;;
 
     bridge-release.py)

--- a/scripts/smoke/1618-outbox-retry-resets-attempts-helper.py
+++ b/scripts/smoke/1618-outbox-retry-resets-attempts-helper.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Helper for scripts/smoke/1618-outbox-retry-resets-attempts.sh (#1618).
+
+Exercises the REAL source symbols, not a reimplementation:
+
+  - bridge-a2a.py:cmd_outbox  (action="retry") — the manual-requeue path
+  - bridge-a2a.py:_schedule_retry — the serve-tick reschedule
+  - bridge_a2a_common._OUTBOX_SCHEMA / backoff_seconds / delivery_backoff_ceiling
+
+Root cause under test (#1618): `outbox retry` of a dead row already set
+next_attempt_ts=0 ("send now"); the bug was that it PRESERVED `attempts`, so a
+dead row at the delivery_max_attempts ceiling got exactly one serve tick before
+re-dead-lettering / a ceiling-length backoff. The fix resets attempts=0 so a
+manual retry walks the backoff ladder from the base interval again.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+from typing import Any
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, REPO_ROOT)
+
+import bridge_a2a_common as a2a  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "bridge_a2a_cli", os.path.join(REPO_ROOT, "bridge-a2a.py"))
+_cli = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_cli)
+
+MESSAGE_ID = "m-1618"
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _seed(db_path: str, status: str, attempts: int) -> None:
+    """Create a one-row outbox at the given status/attempts (ceiling-pinned)."""
+    conn = _connect(db_path)
+    conn.executescript(a2a._OUTBOX_SCHEMA)
+    now = a2a.now_ts()
+    # A previously dead-lettered row: a future-dated next_attempt_ts (a real
+    # ceiling-length backoff) so the smoke can prove retry resets BOTH the
+    # schedule (->0) and the counter (->0).
+    conn.execute(
+        "INSERT INTO outbox (message_id, peer, target_agent, priority, title, "
+        "body_path, body_sha256, status, attempts, next_attempt_ts, "
+        "lease_owner, lease_expires_ts, last_error, created_ts, updated_ts) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (MESSAGE_ID, "peer-x", "agent-y", "normal", "t", "/dev/null", "",
+         status, attempts, now + 86400, "stale-runner", now + 30,
+         "max attempts (12): transport: simulated", now, now),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _row(db_path: str) -> dict[str, Any]:
+    conn = _connect(db_path)
+    try:
+        r = conn.execute(
+            "SELECT status, attempts, next_attempt_ts, lease_owner, "
+            "lease_expires_ts FROM outbox WHERE message_id=?",
+            (MESSAGE_ID,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return dict(r) if r is not None else {}
+
+
+def cmd_retry(args: argparse.Namespace) -> int:
+    """Seed a dead row at attempts, run the REAL `outbox retry`, dump the row."""
+    _seed(args.db, args.status, args.attempts)
+    os.environ["BRIDGE_A2A_OUTBOX_DB"] = args.db
+    ns = argparse.Namespace(action="retry", message_id=MESSAGE_ID,
+                            json=False, max_age=None)
+    # cmd_outbox prints "requeued <id>" to stdout; keep our JSON the only thing
+    # on stdout by diverting the CLI's own print() to stderr.
+    with contextlib.redirect_stdout(sys.stderr):
+        rc = _cli.cmd_outbox(ns)
+    out = _row(args.db)
+    out["rc"] = rc
+    print(json.dumps(out))
+    return 0
+
+
+def cmd_retry_missing(args: argparse.Namespace) -> int:
+    """A retry of an ACKED row must not match the dead/retry filter (rc!=0)."""
+    _seed(args.db, "acked", 3)
+    os.environ["BRIDGE_A2A_OUTBOX_DB"] = args.db
+    ns = argparse.Namespace(action="retry", message_id=MESSAGE_ID,
+                            json=False, max_age=None)
+    with contextlib.redirect_stdout(sys.stderr):
+        rc = _cli.cmd_outbox(ns)
+    out = _row(args.db)
+    out["rc"] = rc
+    print(json.dumps(out))
+    return 0
+
+
+def _seed_with_managed_body(db_path: str, body_dir: str) -> str:
+    """Seed a 'sending' row whose body_path is a REAL managed envelope under
+    outgoing_dir(), so a dead-letter transition exercises the unlink guard."""
+    os.makedirs(body_dir, exist_ok=True)
+    body_path = os.path.join(body_dir, "m-1618.json")
+    with open(body_path, "w", encoding="utf-8") as fh:
+        fh.write('{"envelope": "stub"}')
+    conn = _connect(db_path)
+    conn.executescript(a2a._OUTBOX_SCHEMA)
+    now = a2a.now_ts()
+    # One attempt below the ceiling so the next _schedule_retry tick dead-letters.
+    conn.execute(
+        "INSERT INTO outbox (message_id, peer, target_agent, priority, title, "
+        "body_path, body_sha256, status, attempts, next_attempt_ts, "
+        "created_ts, updated_ts) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        (MESSAGE_ID, "peer-x", "agent-y", "normal", "t", body_path, "",
+         "sending", 11, 0, now, now),
+    )
+    conn.commit()
+    conn.close()
+    return body_path
+
+
+def cmd_dead_letter_body(args: argparse.Namespace) -> int:
+    """Drive a REAL max-attempts dead-letter, then a manual retry, and prove the
+    staged body survives so the retried row is actually sendable (#1618)."""
+    # outgoing_dir() = state_dir()/handoff/outgoing; pin state under the temp db.
+    state_dir = os.path.dirname(os.path.abspath(args.db))
+    os.environ["BRIDGE_STATE_DIR"] = state_dir
+    body_dir = str(a2a.outgoing_dir())
+    body_path = _seed_with_managed_body(args.db, body_dir)
+
+    # Sanity: the body is inside the managed root the unlink guard enforces.
+    in_managed = False
+    try:
+        import pathlib
+        pathlib.Path(body_path).resolve().relative_to(
+            a2a.outgoing_dir().resolve())
+        in_managed = True
+    except ValueError:
+        in_managed = False
+
+    conn = _connect(args.db)
+    # attempts already 11; the serve tick makes it 12 >= max(12) -> dead-letter.
+    try:
+        outcome = _cli._schedule_retry(
+            conn, MESSAGE_ID, 12, {}, last_error="transport: simulated")
+    finally:
+        conn.close()
+    body_after_dead = os.path.isfile(body_path)
+
+    # Now the operator retries the dead row.
+    os.environ["BRIDGE_A2A_OUTBOX_DB"] = args.db
+    ns = argparse.Namespace(action="retry", message_id=MESSAGE_ID,
+                            json=False, max_age=None)
+    with contextlib.redirect_stdout(sys.stderr):
+        rc = _cli.cmd_outbox(ns)
+    row = _row(args.db)
+    body_after_retry = os.path.isfile(body_path)
+    print(json.dumps({
+        "in_managed": in_managed,
+        "dead_outcome": outcome,
+        "body_after_dead": body_after_dead,
+        "retry_rc": rc,
+        "status": row.get("status"),
+        "attempts": row.get("attempts"),
+        "body_after_retry": body_after_retry,
+    }))
+    return 0
+
+
+def cmd_reschedule(args: argparse.Namespace) -> int:
+    """After a reset (attempts=0), one failed serve tick must reschedule at the
+    BASE interval, not the ceiling, and must NOT immediately re-dead-letter."""
+    _seed(args.db, "pending", 0)
+    conn = _connect(args.db)
+    fixed_now = 2_000_000_000
+    old_now = a2a.now_ts
+    a2a.now_ts = lambda: fixed_now
+    try:
+        # Mirror the serve-tick increment (bridge-a2a.py:786): a post-reset row
+        # at attempts=0 becomes attempts=1 for the first new send.
+        outcome = _cli._schedule_retry(
+            conn, MESSAGE_ID, 1, {}, last_error="transport: simulated")
+        r = conn.execute(
+            "SELECT status, attempts, next_attempt_ts FROM outbox "
+            "WHERE message_id=?", (MESSAGE_ID,)).fetchone()
+    finally:
+        a2a.now_ts = old_now
+        conn.close()
+    print(json.dumps({
+        "outcome": outcome,
+        "status": r["status"],
+        "attempts": int(r["attempts"]),
+        "delay": int(r["next_attempt_ts"]) - fixed_now,
+    }))
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="1618-outbox-retry-resets-attempts-helper")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_retry = sub.add_parser("retry")
+    p_retry.add_argument("db")
+    p_retry.add_argument("--status", default="dead")
+    p_retry.add_argument("--attempts", type=int, default=12)
+    p_retry.set_defaults(func=cmd_retry)
+
+    p_missing = sub.add_parser("retry-missing")
+    p_missing.add_argument("db")
+    p_missing.set_defaults(func=cmd_retry_missing)
+
+    p_resched = sub.add_parser("reschedule")
+    p_resched.add_argument("db")
+    p_resched.set_defaults(func=cmd_reschedule)
+
+    p_body = sub.add_parser("dead-letter-body")
+    p_body.add_argument("db")
+    p_body.set_defaults(func=cmd_dead_letter_body)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/smoke/1618-outbox-retry-resets-attempts.sh
+++ b/scripts/smoke/1618-outbox-retry-resets-attempts.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# scripts/smoke/1618-outbox-retry-resets-attempts.sh — A2A outbox `retry`
+# resets the attempt counter (#1618).
+#
+# Root cause: `agb a2a outbox retry <id>` of a DEAD row already set
+# next_attempt_ts=0 ("send now"); the footgun was that it PRESERVED `attempts`.
+# A dead row sits at delivery_max_attempts (default 12), so the next serve tick
+# took it to 13 (>= max) and it re-dead-lettered — or rescheduled a single time
+# at the backoff CEILING (12h/1d). Effectively one shot. The fix resets
+# `attempts=0` so a manual retry walks the backoff ladder from the base interval
+# again. This smoke pins:
+#   #1 retry of a dead row -> status='pending', next_attempt_ts=0, attempts=0
+#      (and the lease is cleared).
+#   #2 retry of a backoff-waiting 'retry' row resets attempts the same way.
+#   #3 retry of a non-eligible row (acked) is a no-op (rc!=0, attempts intact).
+#   #4 after the reset, one failed serve tick reschedules at the BASE interval
+#      (small, <= ceiling+jitter), status='retry', and does NOT re-dead-letter.
+#   #5 end-to-end: a REAL max-attempts dead-letter PRESERVES the staged body
+#      (it used to be unlinked), so the manual retry leaves a sendable row
+#      instead of re-dead-lettering as `dead(nobody)` on the next tick.
+
+set -euo pipefail
+
+SMOKE_NAME="1618-outbox-retry-resets-attempts"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+HELPER="$SCRIPT_DIR/1618-outbox-retry-resets-attempts-helper.py"
+WORK=""
+
+cleanup() { [[ -n "$WORK" && -d "$WORK" ]] && rm -rf "$WORK"; }
+trap cleanup EXIT
+
+smoke_require_cmd python3
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/${SMOKE_NAME}.XXXXXX")"
+
+field() {
+  printf '%s' "$1" | python3 -c "import sys,json; print(json.load(sys.stdin)[sys.argv[1]])" "$2"
+}
+
+smoke_log "check #1: retry of a dead row (attempts=12) resets attempts to 0"
+out="$(python3 "$HELPER" retry "$WORK/dead.db" --status dead --attempts 12)"
+smoke_assert_eq "$(field "$out" rc)" "0" "#1 retry rc==0"
+smoke_assert_eq "$(field "$out" status)" "pending" "#1 status -> pending"
+smoke_assert_eq "$(field "$out" attempts)" "0" "#1 TOOTH: attempts reset to 0"
+smoke_assert_eq "$(field "$out" next_attempt_ts)" "0" "#1 next_attempt_ts -> 0 (send now)"
+smoke_assert_eq "$(field "$out" lease_owner)" "None" "#1 lease_owner cleared"
+smoke_assert_eq "$(field "$out" lease_expires_ts)" "0" "#1 lease_expires_ts cleared"
+
+smoke_log "check #2: retry of a backoff-waiting 'retry' row also resets attempts"
+out="$(python3 "$HELPER" retry "$WORK/retry.db" --status retry --attempts 8)"
+smoke_assert_eq "$(field "$out" rc)" "0" "#2 retry rc==0"
+smoke_assert_eq "$(field "$out" status)" "pending" "#2 status -> pending"
+smoke_assert_eq "$(field "$out" attempts)" "0" "#2 attempts reset to 0"
+smoke_assert_eq "$(field "$out" next_attempt_ts)" "0" "#2 next_attempt_ts -> 0"
+
+smoke_log "check #3: retry of a non-eligible (acked) row is a no-op"
+out="$(python3 "$HELPER" retry-missing "$WORK/acked.db")"
+[[ "$(field "$out" rc)" != "0" ]] \
+  || smoke_fail "#3 TOOTH: retry of an acked row should fail (rc!=0), got rc=$(field "$out" rc)"
+smoke_assert_eq "$(field "$out" status)" "acked" "#3 status untouched"
+smoke_assert_eq "$(field "$out" attempts)" "3" "#3 attempts untouched (filter excludes acked)"
+
+smoke_log "check #4: after the reset, one failed send reschedules at the base interval"
+out="$(python3 "$HELPER" reschedule "$WORK/resched.db")"
+smoke_assert_eq "$(field "$out" status)" "retry" "#4 reschedule -> retry (not dead)"
+smoke_assert_eq "$(field "$out" attempts)" "1" "#4 first new attempt -> 1"
+delay="$(field "$out" delay)"
+# base step is 15s, with full-jitter half-window the first delay lands in
+# [8,15]; the key TOOTH is it is NOT a ceiling-length backoff (12h/1d).
+[[ "$delay" -ge 1 && "$delay" -le 15 ]] \
+  || smoke_fail "#4 TOOTH: delay $delay not the base interval (one-shot-then-ceiling regressed?)"
+
+smoke_log "check #5: dead-letter preserves the body so a manual retry is sendable"
+out="$(python3 "$HELPER" dead-letter-body "$WORK/body.db")"
+smoke_assert_eq "$(field "$out" in_managed)" "True" "#5 fixture body is under the managed outgoing root"
+smoke_assert_eq "$(field "$out" dead_outcome)" "dead(maxattempts)" "#5 max-attempts dead-letter taken"
+smoke_assert_eq "$(field "$out" body_after_dead)" "True" "#5 TOOTH: body survives dead-letter (was unlinked pre-#1618)"
+smoke_assert_eq "$(field "$out" retry_rc)" "0" "#5 retry rc==0"
+smoke_assert_eq "$(field "$out" status)" "pending" "#5 retry -> pending"
+smoke_assert_eq "$(field "$out" attempts)" "0" "#5 retry resets attempts"
+smoke_assert_eq "$(field "$out" body_after_retry)" "True" "#5 TOOTH: retried row has a sendable body (no dead(nobody))"
+
+smoke_log "all #1618 retry-reset teeth passed"

--- a/scripts/smoke/a2a-backpressure-openonly.sh
+++ b/scripts/smoke/a2a-backpressure-openonly.sh
@@ -445,8 +445,10 @@ finally:
     left.close()
     right.close()
 
-# B5/B8: terminal outbox transitions unlink outgoing envelopes, gc unlinks
-# deleted terminal rows, and Retry-After remains a floor after jitter.
+# B5/B8: the acked transition unlinks the outgoing envelope; dead-letter now
+# PRESERVES it (#1618: a `dead` row is operator-retryable, so the body must
+# survive for `agb a2a outbox retry`); gc unlinks deleted terminal rows
+# (acked AND dead); and Retry-After remains a floor after jitter.
 outbox = a2a.open_outbox()
 cfg = {
     "bridge_id": "local",
@@ -494,8 +496,20 @@ a2a.outbox_insert(
     body_bytes=2,
 )
 bridge_a2a._mark_dead(outbox, "dead-msg", "unit dead")
+# #1618: dead-letter must PRESERVE the staged body so a manual `outbox retry`
+# can actually resend the row (the prior code unlinked it here, so retry
+# re-dead-lettered as dead(nobody)). gc/drop reclaim the dead body instead.
+if not dead_path.exists():
+    raise AssertionError("dead outbox body was unlinked (must be preserved for retry, #1618)")
+# And gc must still reclaim the dead row's body once it ages past the cutoff.
+outbox.execute(
+    "UPDATE outbox SET updated_ts=? WHERE message_id='dead-msg'",
+    (now - 100,),
+)
+outbox.commit()
+bridge_a2a.cmd_outbox(argparse.Namespace(action="gc", message_id=None, json=False, max_age=1))
 if dead_path.exists():
-    raise AssertionError("dead outbox body was not unlinked")
+    raise AssertionError("outbox gc did not reclaim the aged dead body")
 
 gc_path = a2a.outgoing_dir() / "gc.json"
 gc_path.write_text("{}", encoding="utf-8")


### PR DESCRIPTION
## Issue

Closes the footgun in #1618. `agb a2a outbox retry <id>` of a **dead** message (attempts at the `delivery_max_attempts` ceiling, default 12) gave the message only **one** immediate attempt before it re-dead-lettered / hit the backoff ceiling — so a manual "send it now" didn't actually get a fighting chance. The operator saw retried messages showing `due 12h/1d` right after a path recovery.

> Non-keyword reference only (`#1618`) — no `closes` keyword, intentionally.

## Root cause

- `outbox retry` already set `next_attempt_ts=0` ("send now") + `status='pending'` and cleared the lease — that was never the bug.
- It **preserved `attempts`**. A dead row sits at the ceiling (12), so the next serve tick took it to 13 (`>= max` → re-`dead`), or rescheduled a single time at the backoff ceiling (12h/1d). One shot.
- Compounding: **every dead-letter path unlinked the staged outgoing envelope**, so even after an attempts reset a retried `dead(maxattempts)` row re-dead-lettered as `dead(nobody)` on the next tick (body gone) — retry could never actually resend it. (Caught in pair review, round 1.)

## Fix

1. `cmd_outbox` retry UPDATE also resets `attempts=0` (alongside the existing `next_attempt_ts=0`), so a manual retry walks the backoff ladder from the base interval again. Status filter (`'dead','retry'`), zero-row guard, and `requeued` print unchanged.
2. Dead-letter now **preserves** the staged body — both the max-attempts branch in `_schedule_retry` and `_mark_dead`. A `dead` row is an operator-retryable state. The `acked` success path still unlinks (a delivered message never needs resending), and dead bodies are reclaimed by `outbox gc` (terminal rows past max-age, default 14d) and `outbox drop`. Dead rows don't count toward the byte / per-peer-pending caps, so accounting is unaffected.
3. Help text + `docs/a2a-cross-bridge.md` document the new manual-retry semantics.

## Tests

- New `scripts/smoke/1618-outbox-retry-resets-attempts.sh` (+ helper) drives the **real** `cmd_outbox` retry path + `_schedule_retry` (not a reimplementation):
  - #1/#2 retry of a `dead`/`retry` row → `pending`, `attempts=0`, `next_attempt_ts=0`, lease cleared.
  - #3 retry of an `acked` row is a no-op (`rc!=0`, attempts intact).
  - #4 post-reset, one failed serve tick reschedules at the **base interval** (not the ceiling), `status='retry'`, not re-dead-lettered.
  - #5 end-to-end: a real max-attempts dead-letter **preserves** the managed body so the manual retry leaves a sendable row.
  - Negative-controlled: #1 fails on the un-patched attempts (stays 12); #5 fails on the un-patched unlink — confirmed true regression gates.
- Registered in `scripts/ci-select-smoke.sh` (static suite + `bridge-a2a.py` selector arm + self-trigger arm).
- Updated `scripts/smoke/a2a-backpressure-openonly.sh` B5/B8: the stale `dead outbox body was not unlinked` assertion now asserts the preserve-on-dead contract + aged-dead `gc` reclaim.

## Verification (Homebrew bash 5.3.9, macOS)

- `python3 -c "import ast; ast.parse(...)"` on `bridge-a2a.py` + helper — OK
- `bash -n` + `shellcheck` on the changed shell — OK
- Smokes pass: `1618-outbox-retry-resets-attempts` (5 checks), `a2a-backpressure-openonly`, `1575b-a2a-backoff-ceiling`, `a2a-cross-bridge`
- `bash scripts/ci-select-smoke.sh --suite required --changed-file bridge-a2a.py | grep -qx scripts/smoke/1618-outbox-retry-resets-attempts.sh` — PASS
- `scripts/smoke-test.sh` has one **pre-existing** failure (#365 isolated-agent-env guard in `lib/bridge-agents.sh`) confirmed failing identically on the base commit with this branch's changes stashed — not a regression here.
- Internal `codex:codex-rescue` pair review: round 1 `needs-more` (body-unlink gap), round 2 `implement-ok`.

No VERSION/CHANGELOG bump (operator cues v0.16.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
