### PR TITLE
fix(runtime): shared-mode agents use operator HOME (keep CLAUDE_CONFIG_DIR per-agent) + upgrader credential consolidation

### DIFF
--- a/.lint-heredoc-baseline.tsv
+++ b/.lint-heredoc-baseline.tsv
@@ -224,6 +224,7 @@ lib/bridge-host-profile.sh	203	C3	71eccee67da1310243de68add85154e68165f16059df93
 lib/bridge-host-profile.sh	273	H3	24060087d519f37a2d9f47765c64adbda24ceb59fe155510b4e209c5fd95a8de	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-host-profile.sh	307	H3	24060087d519f37a2d9f47765c64adbda24ceb59fe155510b4e209c5fd95a8de	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-isolation-v2-migrate.sh	838	H3	f76308bcc7f5051dda9a60057540bfd3985f9d8364f1b7cb8689ef7850e07185	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
+lib/bridge-isolation-v2-migrate.sh	1069	H3	88aa0b12fe0ee603c2282a65d0d2d3b257c564c69f06730364ae840d562323fb	here-string/procsub, non-interpreter consumer	claude	shared-mode-operator-home (#1622)
 lib/bridge-isolation-v2-migrate.sh	1108	H3	c2d06bebe53400eca7b3da976ac9c1986bb8e2ba030db1d3b44abe171861bbd4	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-isolation-v2-migrate.sh	1245	H3	8641a4b0bfee263cf01bfcfca9354cd3efa54a918663d364a06f1fe327290bfa	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-isolation-v2-migrate.sh	1249	H3	2a266e0375ff91ddfa86dc69923e8bf8c488c762496b01998ebd2db061c509ab	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -1493,8 +1493,16 @@ bridge_run_export_claude_launch_env() {
   if [[ -z "$agent_home" ]]; then
     agent_home="${agent_claude_root%/.claude}"
   fi
+  # #1621/#1622: export the operator HOME ONLY. CLAUDE_CONFIG_DIR is owned by
+  # bridge_run_shared_launch's exec subshell (#1520) — it exports the per-agent
+  # config dir ONLY when the credential gate passes, and intentionally leaves
+  # it UNSET on the failed-seed graceful-degrade path so the launch falls back
+  # to the operator-global config ($HOME/.claude). Exporting CLAUDE_CONFIG_DIR
+  # here in the long-lived parent loop would leak into that degrade subshell
+  # and defeat the #1520 fallback (codex Phase-4 BLOCKING). HOME-only keeps the
+  # two concerns cleanly split: this sets shared HOME=operator; shared_launch
+  # decides CLAUDE_CONFIG_DIR per-agent-vs-degrade.
   [[ -n "$agent_home" ]] && export HOME="$agent_home"
-  [[ -n "$agent_claude_root" ]] && export CLAUDE_CONFIG_DIR="$agent_claude_root"
 }
 
 bridge_run_sync_dev_plugin_cache() {

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -1138,11 +1138,16 @@ bridge_run_schedule_dev_channels_accept() {
 bridge_run_agent_claude_root() {
   # Resolve the Claude config root the launched agent will actually use.
   # Keep this in one place so the dev-plugin cache sync and plugin enable
-  # preflight operate on the same per-agent HOME/CLAUDE_CONFIG_DIR as the
-  # final LAUNCH_CMD. Otherwise shared agents can sync into their agent
-  # home but run `claude plugin enable` against the controller's home,
-  # leaving the launched Claude process with the channel plugin disabled.
+  # preflight operate on the same CLAUDE_CONFIG_DIR as the final
+  # LAUNCH_CMD. Shared agents inherit the operator HOME for generic
+  # ~/.config tools, but Claude state remains per-agent via
+  # CLAUDE_CONFIG_DIR.
   local _agent_os_user_local=""
+
+  if command -v bridge_agent_claude_config_dir >/dev/null 2>&1; then
+    bridge_agent_claude_config_dir "$AGENT"
+    return 0
+  fi
 
   if ! bridge_isolation_disabled_by_env && bridge_agent_linux_user_isolation_effective "$AGENT"; then
     _agent_os_user_local="$(bridge_agent_os_user "$AGENT")"
@@ -1220,12 +1225,18 @@ bridge_run_claude_keychain_free_preflight() {
   BRIDGE_RUN_CLAUDE_KEYCHAIN_FREE_VALIDATED=1
 }
 
+# shellcheck disable=SC2030,SC2031 # plugin preflight intentionally scopes env to this subshell.
 bridge_run_ensure_claude_launch_channel_plugins() {
   local agent_claude_root=""
   local agent_home=""
 
   agent_claude_root="$(bridge_run_agent_claude_root)"
-  agent_home="${agent_claude_root%/.claude}"
+  if command -v bridge_agent_claude_home_dir >/dev/null 2>&1; then
+    agent_home="$(bridge_agent_claude_home_dir "$AGENT" 2>/dev/null || true)"
+  fi
+  if [[ -z "$agent_home" ]]; then
+    agent_home="${agent_claude_root%/.claude}"
+  fi
   (
     export HOME="$agent_home"
     # SC2030: subshell-local export is intentional — it scopes HOME /
@@ -1466,6 +1477,24 @@ bridge_run_shared_launch() {
     fi
   fi
   return "$_rc"
+}
+
+# shellcheck disable=SC2030,SC2031 # launch env export is intentional for the child command below.
+bridge_run_export_claude_launch_env() {
+  local agent_claude_root=""
+  local agent_home=""
+
+  [[ "$ENGINE" == "claude" ]] || return 0
+
+  agent_claude_root="$(bridge_run_agent_claude_root)"
+  if command -v bridge_agent_claude_home_dir >/dev/null 2>&1; then
+    agent_home="$(bridge_agent_claude_home_dir "$AGENT" 2>/dev/null || true)"
+  fi
+  if [[ -z "$agent_home" ]]; then
+    agent_home="${agent_claude_root%/.claude}"
+  fi
+  [[ -n "$agent_home" ]] && export HOME="$agent_home"
+  [[ -n "$agent_claude_root" ]] && export CLAUDE_CONFIG_DIR="$agent_claude_root"
 }
 
 bridge_run_sync_dev_plugin_cache() {
@@ -1793,6 +1822,10 @@ while true; do
     LAUNCH_CMD="$(bridge_rewrite_launch_cmd_engine_bin "$LAUNCH_CMD" "$BRIDGE_ENGINE_BIN")"
   fi
   local_launch_cmd_display="$(bridge_redact_inline_env_secrets "$LAUNCH_CMD")"
+
+  if [[ "$ENGINE" == "claude" ]]; then
+    bridge_run_export_claude_launch_env
+  fi
 
   if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
     bridge_run_claude_keychain_free_preflight

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1822,6 +1822,13 @@ fi
 # the v2 marker is already present + valid). Failure aborts the upgrade
 # before apply-live touches the install — the `no_v080_code_installed=yes`
 # remediation hint tells the operator they can safely retry.
+# HOME-revert follow-up (#4378): shared-mode credential config
+# consolidation is wired through this same helper. It sources
+# lib/bridge-isolation-v2-migrate.sh and calls
+# bridge_isolation_v2_migrate_apply_for_upgrade, which runs the
+# sentinel-gated .config/{gh,gws,gcloud} consolidation before any
+# marker-only, macOS/no-isolated, marker-present, or full-migrate branch
+# can return.
 ISOLATION_V2_MIGRATION_JSON='{"mode":"isolation-v2-migrate","skipped":true,"reason":"dry-run"}'
 if [[ $DRY_RUN -eq 0 ]]; then
   # Run the migration in a child shell whose env is scoped to TARGET_ROOT

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -5034,6 +5034,37 @@ bridge_agent_default_home() {
   printf '%s/%s' "$BRIDGE_AGENT_HOME_ROOT" "$agent"
 }
 
+bridge_agent_operator_home_dir() {
+  if [[ -n "${BRIDGE_CONTROLLER_HOME:-}" ]]; then
+    printf '%s' "$BRIDGE_CONTROLLER_HOME"
+    return 0
+  fi
+
+  local controller_user=""
+  local controller_home=""
+  if declare -F bridge_isolation_v2_controller_user >/dev/null 2>&1; then
+    controller_user="$(bridge_isolation_v2_controller_user 2>/dev/null || true)"
+  fi
+  if [[ -z "$controller_user" ]]; then
+    controller_user="${SUDO_USER:-${USER:-${LOGNAME:-}}}"
+  fi
+  if [[ -n "$controller_user" ]]; then
+    if command -v getent >/dev/null 2>&1; then
+      controller_home="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
+    fi
+    if [[ -z "$controller_home" && "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]] \
+        && command -v dscl >/dev/null 2>&1; then
+      controller_home="$(dscl . -read "/Users/$controller_user" NFSHomeDirectory 2>/dev/null \
+        | awk '{print $2; exit}' || true)"
+    fi
+  fi
+  if [[ -z "$controller_home" ]]; then
+    controller_home="${HOME:-}"
+  fi
+  [[ -n "$controller_home" ]] || return 1
+  printf '%s' "$controller_home"
+}
+
 bridge_agent_claude_home_dir() {
   local agent="$1"
   local os_user=""
@@ -5046,7 +5077,7 @@ bridge_agent_claude_home_dir() {
     fi
   fi
 
-  bridge_agent_default_home "$agent"
+  bridge_agent_operator_home_dir
 }
 
 # Lane A (v0.15.0-beta4): iso-v2 agents' Claude config dir must
@@ -5072,7 +5103,11 @@ bridge_agent_claude_home_dir() {
 #      iso UID prefix is conventionally `agent-bridge-` and can be
 #      overridden by `BRIDGE_AGENT_OS_USER_PREFIX` (existing project
 #      convention; `BRIDGE_OS_USER_PREFIX` was a typo introduced at r2).
-#   3) Otherwise, non-iso path — daemon HOME (caller's view).
+#   3) Otherwise, shared/non-iso path — per-agent Claude config dir.
+#      Shared agents now inherit the operator HOME, but Claude state
+#      remains anchored at the per-agent config dir so transcripts,
+#      settings, and file credentials do not collapse into the
+#      operator's ~/.claude tree.
 bridge_agent_claude_config_dir() {
   local agent="$1"
   local home_dir=""
@@ -5106,10 +5141,10 @@ bridge_agent_claude_config_dir() {
     fi
   fi
 
-  # Non-iso path or all iso-resolution attempts failed: print the
-  # legacy controller-view path. Callers gate on `[[ -d ]]`, so a
-  # non-existent path falls through to the daemon-HOME default.
-  printf '%s/.claude' "$(bridge_agent_claude_home_dir "$agent")"
+  # Shared/non-iso path or all iso-resolution attempts failed: keep
+  # Claude's config/state under the per-agent home even though shared
+  # launches use the operator HOME for generic ~/.config tools.
+  printf '%s/.claude' "$(bridge_agent_default_home "$agent")"
 }
 
 # bridge_ensure_claude_first_run_config <agent>

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -966,6 +966,211 @@ bridge_isolation_v2_migrate_shared_sentinel_write() {
   return 0
 }
 
+bridge_isolation_v2_migrate_path_abs() {
+  local path="$1"
+  local dir base
+  dir="$(dirname "$path")"
+  base="$(basename "$path")"
+  (cd "$dir" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$base") || printf '%s' "$path"
+}
+
+bridge_isolation_v2_migrate_symlink_target_abs() {
+  local link_path="$1"
+  local target=""
+  target="$(readlink "$link_path" 2>/dev/null || true)"
+  [[ -n "$target" ]] || return 1
+  case "$target" in
+    /*) printf '%s' "$target" ;;
+    *) bridge_isolation_v2_migrate_path_abs "$(dirname "$link_path")/$target" ;;
+  esac
+}
+
+bridge_isolation_v2_migrate_creds_sentinel_write() {
+  local sentinel="$1" agent="$2" operator_home="$3" status="$4" details="$5"
+  local tmp="${sentinel}.tmp.$$"
+  mkdir -p "$(dirname "$sentinel")" 2>/dev/null || {
+    bridge_warn "creds_consolidate: mkdir sentinel dir failed: $(dirname "$sentinel")"
+    return 1
+  }
+  {
+    printf '# shared-mode credential config consolidation sentinel\n'
+    printf 'agent=%s\n' "$agent"
+    printf 'operator_home=%s\n' "$operator_home"
+    printf 'status=%s\n' "$status"
+    printf 'details=%s\n' "$details"
+    printf 'written_at=%s\n' "$(date -Iseconds 2>/dev/null || date 2>/dev/null || printf 'unknown')"
+  } > "$tmp" 2>/dev/null || {
+    rm -f "$tmp" 2>/dev/null || true
+    bridge_warn "creds_consolidate: write sentinel failed: $tmp"
+    return 1
+  }
+  mv -f "$tmp" "$sentinel" 2>/dev/null || {
+    rm -f "$tmp" 2>/dev/null || true
+    bridge_warn "creds_consolidate: mv sentinel failed: $sentinel"
+    return 1
+  }
+  return 0
+}
+
+bridge_isolation_v2_migrate_consolidate_one_config_dir() {
+  local agent="$1" source_path="$2" target_path="$3" stamp="$4"
+  local source_abs=""
+  local target_abs=""
+  local link_abs=""
+  local backup_path=""
+  local -a rsync_flags
+
+  source_abs="$(bridge_isolation_v2_migrate_path_abs "$source_path")"
+  target_abs="$(bridge_isolation_v2_migrate_path_abs "$target_path")"
+
+  if [[ "$source_abs" == "$target_abs" ]]; then
+    return 0
+  fi
+
+  if [[ -L "$source_path" ]]; then
+    link_abs="$(bridge_isolation_v2_migrate_symlink_target_abs "$source_path" || true)"
+    if [[ "$link_abs" == "$target_abs" ]]; then
+      return 0
+    fi
+    bridge_warn "creds_consolidate: $agent has wrong symlink $source_path -> ${link_abs:-<unresolved>} (expected $target_abs); refusing to clobber"
+    return 1
+  fi
+
+  [[ -e "$source_path" ]] || return 0
+  if [[ ! -d "$source_path" ]]; then
+    bridge_warn "creds_consolidate: $agent source is not a directory: $source_path"
+    return 1
+  fi
+  if [[ -e "$target_path" && ! -d "$target_path" ]]; then
+    bridge_warn "creds_consolidate: target exists but is not a directory: $target_path"
+    return 1
+  fi
+
+  mkdir -p "$target_path" 2>/dev/null || {
+    bridge_warn "creds_consolidate: mkdir target failed: $target_path"
+    return 1
+  }
+
+  rsync_flags=(-a)
+  if ! rsync "${rsync_flags[@]}" "$source_path"/ "$target_path"/ 2>/dev/null; then
+    bridge_warn "creds_consolidate: rsync $source_path -> $target_path failed"
+    return 1
+  fi
+
+  backup_path="${source_path}.pre-home-revert.${stamp}"
+  if [[ -e "$backup_path" || -L "$backup_path" ]]; then
+    bridge_warn "creds_consolidate: backup path already exists, refusing to overwrite: $backup_path"
+    return 1
+  fi
+  if ! mv "$source_path" "$backup_path" 2>/dev/null; then
+    bridge_warn "creds_consolidate: move source aside failed: $source_path -> $backup_path"
+    return 1
+  fi
+  if ! ln -s "$target_path" "$source_path" 2>/dev/null; then
+    bridge_warn "creds_consolidate: symlink install failed: $source_path -> $target_path"
+    mv "$backup_path" "$source_path" 2>/dev/null || \
+      bridge_warn "creds_consolidate: rollback move failed: $backup_path -> $source_path"
+    return 1
+  fi
+  return 0
+}
+
+bridge_isolation_v2_migrate_consolidate_agent_creds() {
+  local agent="$1" agent_home="$2" operator_home="$3"
+  local sentinel="$agent_home/.creds-consolidated.sentinel"
+  local status="ok"
+  local details=""
+  local stamp=""
+  local cfg source_path target_path
+  local failed=0
+  local touched=0
+
+  [[ -f "$sentinel" ]] && return 0
+  [[ -d "$agent_home" ]] || return 0
+  [[ -n "$operator_home" ]] || {
+    bridge_warn "creds_consolidate: operator HOME is empty"
+    return 1
+  }
+
+  stamp="$(date '+%Y%m%d%H%M%S' 2>/dev/null || printf '%s' "$$")"
+  mkdir -p "$operator_home/.config" 2>/dev/null || {
+    bridge_warn "creds_consolidate: mkdir operator .config failed: $operator_home/.config"
+    return 1
+  }
+
+  for cfg in gh gws gcloud; do
+    source_path="$agent_home/.config/$cfg"
+    target_path="$operator_home/.config/$cfg"
+    if [[ -e "$source_path" || -L "$source_path" ]]; then
+      touched=1
+      if bridge_isolation_v2_migrate_consolidate_one_config_dir \
+          "$agent" "$source_path" "$target_path" "$stamp"; then
+        details="${details}${cfg}:ok;"
+      else
+        details="${details}${cfg}:failed;"
+        failed=1
+      fi
+    else
+      details="${details}${cfg}:absent;"
+    fi
+  done
+
+  if (( failed != 0 )); then
+    status="partial"
+  elif (( touched == 0 )); then
+    status="no-sources"
+  fi
+  bridge_isolation_v2_migrate_creds_sentinel_write \
+    "$sentinel" "$agent" "$operator_home" "$status" "$details" || return 1
+  (( failed == 0 ))
+}
+
+bridge_isolation_v2_migrate_shared_credential_configs() {
+  local data_root="$1" target_root="$2"
+  local operator_home=""
+  local snapshot=""
+  local agent=""
+  local agent_home=""
+  local failed=0
+
+  : "$data_root"
+
+  if command -v bridge_agent_operator_home_dir >/dev/null 2>&1; then
+    operator_home="$(bridge_agent_operator_home_dir 2>/dev/null || true)"
+  fi
+  if [[ -z "$operator_home" ]]; then
+    operator_home="${BRIDGE_CONTROLLER_HOME:-${HOME:-}}"
+  fi
+  [[ -n "$operator_home" ]] || {
+    bridge_warn "creds_consolidate: cannot resolve operator HOME"
+    return 1
+  }
+
+  bridge_isolation_v2_migrate_capture_all_agents_snapshot
+  snapshot="$(bridge_isolation_v2_migrate_all_agents_snapshot_path)"
+  [[ -f "$snapshot" ]] || return 0
+
+  while IFS= read -r agent; do
+    [[ -n "$agent" ]] || continue
+    if command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
+        && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+      continue
+    fi
+    if command -v bridge_agent_default_home >/dev/null 2>&1; then
+      agent_home="$(bridge_agent_default_home "$agent" 2>/dev/null || true)"
+    else
+      agent_home="${BRIDGE_AGENT_HOME_ROOT:-$target_root/agents}/$agent"
+    fi
+    [[ -n "$agent_home" ]] || continue
+    if ! bridge_isolation_v2_migrate_consolidate_agent_creds \
+        "$agent" "$agent_home" "$operator_home"; then
+      failed=1
+    fi
+  done < "$snapshot"
+
+  (( failed == 0 ))
+}
+
 # ---------------------------------------------------------------------------
 # 6. group ensure + post-flight probe
 # ---------------------------------------------------------------------------
@@ -2048,6 +2253,17 @@ bridge_isolation_v2_migrate_apply_for_upgrade() {
   # install keeps working exactly as before this migrate ran.
   if ! bridge_isolation_v2_migrate_shared_backfill "$data_root" "$target_root"; then
     bridge_warn "apply_for_upgrade: shared-tree backfill did not complete; resolver will keep using the legacy shared path (no split-brain, but data/shared not yet canonical — rerun \`agent-bridge upgrade --apply\` after addressing the warned cause)"
+  fi
+
+  # Shared-mode HOME-revert credential consolidation — MUST run beside
+  # shared_backfill before any skip branch. The runtime is moving shared
+  # agents back to the operator HOME for generic ~/.config tools, while
+  # Claude keeps CLAUDE_CONFIG_DIR per-agent. Preserve existing per-agent
+  # gh/gws/gcloud state by mirroring it into operator ~/.config and then
+  # flipping the per-agent path to a symlink. Sentinel-gated and
+  # non-destructive: source dirs are moved aside as backups, never deleted.
+  if ! bridge_isolation_v2_migrate_shared_credential_configs "$data_root" "$target_root"; then
+    bridge_warn "apply_for_upgrade: shared credential config consolidation reported warnings; inspect .creds-consolidated.sentinel and rerun after addressing any non-mergeable paths"
   fi
 
   # v0.13.10: markerless-existing-install + no-isolated-roster fast-path.

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -1019,6 +1019,9 @@ bridge_isolation_v2_migrate_consolidate_one_config_dir() {
   local link_abs=""
   local backup_path=""
   local -a rsync_flags
+  local source_file=""
+  local relative_path=""
+  local target_file=""
 
   source_abs="$(bridge_isolation_v2_migrate_path_abs "$source_path")"
   target_abs="$(bridge_isolation_v2_migrate_path_abs "$target_path")"
@@ -1051,17 +1054,26 @@ bridge_isolation_v2_migrate_consolidate_one_config_dir() {
     return 1
   }
 
-  rsync_flags=(-a)
-  if ! rsync "${rsync_flags[@]}" "$source_path"/ "$target_path"/ 2>/dev/null; then
-    bridge_warn "creds_consolidate: rsync $source_path -> $target_path failed"
-    return 1
-  fi
-
   backup_path="${source_path}.pre-home-revert.${stamp}"
   if [[ -e "$backup_path" || -L "$backup_path" ]]; then
     bridge_warn "creds_consolidate: backup path already exists, refusing to overwrite: $backup_path"
     return 1
   fi
+
+  while IFS= read -r -d '' source_file; do
+    relative_path="${source_file#"$source_path"/}"
+    target_file="$target_path/$relative_path"
+    if [[ -f "$target_file" ]] && ! cmp -s "$source_file" "$target_file"; then
+      bridge_warn "creds_consolidate: kept operator $target_file; agent copy preserved in $backup_path/$relative_path"
+    fi
+  done < <(find "$source_path" -type f -print0 2>/dev/null)
+
+  rsync_flags=(-a --ignore-existing)
+  if ! rsync "${rsync_flags[@]}" "$source_path"/ "$target_path"/ 2>/dev/null; then
+    bridge_warn "creds_consolidate: rsync $source_path -> $target_path failed"
+    return 1
+  fi
+
   if ! mv "$source_path" "$backup_path" 2>/dev/null; then
     bridge_warn "creds_consolidate: move source aside failed: $source_path -> $backup_path"
     return 1

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -4100,14 +4100,14 @@ bridge_persist_agent_state() {
 
 # Issue #1015: resolve the Claude config dir to hand the session-id
 # helpers — but ONLY when `agent` is a genuinely registered agent whose
-# linux-user isolation is *effective* AND whose computed config dir
-# actually exists on disk. For test / unregistered / non-isolated callers,
-# `bridge_agent_claude_config_dir` still returns a *derived* path (e.g.
-# `$BRIDGE_AGENT_HOME_ROOT/<name>/.claude`); passing that to the helper
-# would OVERRIDE the per-call `HOME` the caller relies on and search the
-# wrong tree. Returning empty in that case lets the helper fall back to
+# computed config dir actually exists on disk and is known to be live.
+# For test / unregistered callers, `bridge_agent_claude_config_dir` still
+# returns a derived path; passing that to the helper would OVERRIDE the
+# per-call `HOME` the caller relies on and search the wrong tree.
+# Returning empty in that case lets the helper fall back to
 # `CLAUDE_CONFIG_DIR` env / `HOME` / `~` exactly as on `main`. Echoes the
-# config dir on stdout, or nothing when no isolated config dir is in play.
+# config dir on stdout, or nothing when no agent-specific config dir is in
+# play.
 #
 # Issue #1370 (beta5-2 #1316 regression): the iso-effective gate below is
 # the real defense — beta5-2's Lane θ ".claude tree normalize" backfill
@@ -4134,21 +4134,17 @@ bridge_resolve_agent_claude_config_dir() {
 
   # Issue #1370 (beta5-2 #1316 regression) gated this purely on linux-user
   # isolation being *effective*: when it is NOT (every non-Linux host, and
-  # shared-mode Linux agents) the agent USUALLY shares the controller HOME
-  # ~/.claude, so a derived <agent-home>/.claude is an empty #1316 scaffold
-  # that must NOT shadow the controller HOME (it would block --continue
-  # resume).
+  # shared-mode Linux agents) the agent was assumed to share the controller
+  # HOME ~/.claude, so a derived <agent-home>/.claude looked like an empty
+  # #1316 scaffold that must NOT shadow the controller HOME.
   #
-  # But that assumption is false on installs where each agent is launched with
-  # its OWN HOME (<agent-home>) even in shared mode — e.g. per-agent-HOME
-  # layouts on macOS/non-Linux hosts. There Claude writes its session JSON
-  # under <agent-home>/.claude/projects, which IS the live session location.
-  # The old gate discarded it, so bridge_detect_claude_session_id was handed
-  # an empty config dir, scanned the stale controller HOME, found no fresh
-  # transcript, returned 1, and the restart helper rolled back every
-  # just-launched session — a whole-fleet crash-loop (surfaced when Claude CLI
-  # boot grew slower than the session-id detect window). Discriminate an empty
-  # #1316 scaffold from a live per-agent home by whether projects/ holds data.
+  # That assumption is false for shared agents that launch Claude with a
+  # per-agent CLAUDE_CONFIG_DIR. HOME may now be the operator HOME again,
+  # but Claude still writes session JSON under <agent-home>/.claude/projects,
+  # which is the live session location. Discriminate an empty #1316
+  # scaffold from a live per-agent config dir by whether projects/ holds
+  # data; this keeps stale scaffolds from shadowing the operator HOME while
+  # still allowing live shared-agent resumes.
   #
   # iso-effective Linux agents own a private config dir unconditionally and
   # skip the scaffold check (the controller cannot stat their iso-UID

--- a/scripts/smoke/4354-shared-home-revert.sh
+++ b/scripts/smoke/4354-shared-home-revert.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/4354-shared-home-revert.sh — shared-mode HOME=revert.
+#
+# Pins the #4354 invariant:
+#   * shared agents launch with operator HOME for generic ~/.config tools
+#   * Claude state remains under per-agent CLAUDE_CONFIG_DIR
+#   * channel launch command regeneration must not inject per-agent HOME
+#   * shared credential config consolidation is sentinel-gated,
+#     non-destructive, and idempotent
+
+if [[ "${BRIDGE_SMOKE_BASH4_REEXEC:-0}" != "1" && "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      BRIDGE_SMOKE_BASH4_REEXEC=1 exec "$_candidate" "$0" "$@"
+    fi
+  done
+  echo "[smoke:4354-shared-home-revert][error] bash 4+ required (got ${BASH_VERSION:-unknown})" >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+SMOKE_NAME="4354-shared-home-revert"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+smoke_require_cmd rsync
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+OPERATOR_HOME="$SMOKE_TMP_ROOT/operator-home"
+export HOME="$OPERATOR_HOME"
+export BRIDGE_CONTROLLER_HOME="$OPERATOR_HOME"
+mkdir -p "$OPERATOR_HOME/.config"
+
+# shellcheck source=bridge-lib.sh
+source "$REPO_ROOT/bridge-lib.sh"
+# shellcheck source=lib/bridge-isolation-v2-migrate.sh
+source "$REPO_ROOT/lib/bridge-isolation-v2-migrate.sh"
+
+declare -ga BRIDGE_AGENT_IDS
+declare -gA BRIDGE_AGENT_DESC
+declare -gA BRIDGE_AGENT_ENGINE
+declare -gA BRIDGE_AGENT_SESSION
+declare -gA BRIDGE_AGENT_WORKDIR
+declare -gA BRIDGE_AGENT_SOURCE
+declare -gA BRIDGE_AGENT_CREATED_AT
+declare -gA BRIDGE_AGENT_SESSION_ID
+declare -gA BRIDGE_AGENT_ISOLATION_MODE
+declare -gA BRIDGE_AGENT_OS_USER
+declare -gA BRIDGE_AGENT_CHANNELS
+
+register_shared_agent() {
+  local agent="$1"
+  local agent_home="$BRIDGE_AGENT_ROOT_V2/$agent/home"
+  local workdir="$BRIDGE_AGENT_ROOT_V2/$agent/workdir"
+
+  mkdir -p "$agent_home/.claude/projects" "$workdir"
+  BRIDGE_AGENT_IDS+=("$agent")
+  BRIDGE_AGENT_DESC["$agent"]="$agent shared HOME-revert fixture"
+  BRIDGE_AGENT_ENGINE["$agent"]="claude"
+  BRIDGE_AGENT_SESSION["$agent"]="$agent"
+  BRIDGE_AGENT_WORKDIR["$agent"]="$workdir"
+  BRIDGE_AGENT_SOURCE["$agent"]="static"
+  BRIDGE_AGENT_CREATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_SESSION_ID["$agent"]=""
+  BRIDGE_AGENT_ISOLATION_MODE["$agent"]="shared"
+}
+
+AGENT="home-revert-shared"
+register_shared_agent "$AGENT"
+AGENT_HOME="$BRIDGE_AGENT_ROOT_V2/$AGENT/home"
+AGENT_CONFIG="$AGENT_HOME/.claude"
+
+test_shared_resolvers_split_home_and_config() {
+  local resolved_home resolved_config
+  resolved_home="$(bridge_agent_claude_home_dir "$AGENT")"
+  resolved_config="$(bridge_agent_claude_config_dir "$AGENT")"
+  smoke_assert_eq "$OPERATOR_HOME" "$resolved_home" \
+    "shared bridge_agent_claude_home_dir resolves operator HOME"
+  smoke_assert_eq "$AGENT_CONFIG" "$resolved_config" \
+    "shared bridge_agent_claude_config_dir resolves per-agent .claude"
+}
+
+test_channel_launch_env_uses_operator_home() {
+  local raw launch teams_dir
+  BRIDGE_AGENT_CHANNELS["$AGENT"]="plugin:teams@agent-bridge"
+  mkdir -p "$AGENT_HOME/.teams"
+  teams_dir="$(bridge_agent_teams_state_dir "$AGENT")"
+  raw="claude --dangerously-load-development-channels plugin:teams@agent-bridge --name $AGENT"
+  launch="$(bridge_claude_launch_with_channel_state_dirs "$AGENT" "$raw")"
+  smoke_assert_contains "$launch" "HOME=$OPERATOR_HOME" \
+    "channel launch injects operator HOME for shared agent"
+  smoke_assert_not_contains "$launch" "HOME=$AGENT_HOME" \
+    "channel launch does not inject per-agent HOME for shared agent"
+  smoke_assert_contains "$launch" "CLAUDE_CONFIG_DIR=$AGENT_CONFIG" \
+    "channel launch injects per-agent CLAUDE_CONFIG_DIR"
+  smoke_assert_contains "$launch" "TEAMS_STATE_DIR=$teams_dir" \
+    "channel launch still canonicalizes plugin state dir"
+}
+
+test_auto_memory_leaf_remains_agent_scoped() {
+  local body
+  body="$(awk '/^bridge_ensure_auto_memory_isolation\(\) \{/,/^}/' "$REPO_ROOT/bridge-agent.sh")"
+  smoke_assert_contains "$body" 'expected = f"~/.claude/auto-memory/{slug}/{agent}"' \
+    "auto-memory expected path includes the agent leaf"
+}
+
+test_credential_consolidation_and_idempotency() {
+  local source_gh target_gh sentinel backup_count backup_path
+  source_gh="$AGENT_HOME/.config/gh"
+  target_gh="$OPERATOR_HOME/.config/gh"
+  mkdir -p "$source_gh" "$target_gh"
+  printf 'source: agent\n' >"$source_gh/hosts.yml"
+  printf 'source: operator\n' >"$target_gh/operator.yml"
+
+  bridge_isolation_v2_migrate_shared_credential_configs \
+    "$BRIDGE_DATA_ROOT" "$BRIDGE_HOME"
+
+  [[ -L "$source_gh" ]] || smoke_fail "credential consolidation should replace source gh dir with a symlink"
+  smoke_assert_eq "$target_gh" "$(readlink "$source_gh")" \
+    "credential consolidation symlink points at operator gh config"
+  smoke_assert_file_exists "$target_gh/hosts.yml" \
+    "credential consolidation mirrors agent gh hosts into operator config"
+  smoke_assert_file_exists "$target_gh/operator.yml" \
+    "credential consolidation preserves existing operator gh files"
+  sentinel="$AGENT_HOME/.creds-consolidated.sentinel"
+  smoke_assert_file_exists "$sentinel" \
+    "credential consolidation writes per-agent sentinel"
+  smoke_assert_contains "$(cat "$sentinel")" "status=ok" \
+    "credential sentinel records ok status"
+  backup_count="$(find "$AGENT_HOME/.config" -maxdepth 1 -type d -name 'gh.pre-home-revert.*' | wc -l | tr -d ' ')"
+  smoke_assert_eq "1" "$backup_count" \
+    "credential consolidation preserves exactly one backup dir"
+  backup_path="$(find "$AGENT_HOME/.config" -maxdepth 1 -type d -name 'gh.pre-home-revert.*' -print -quit)"
+  smoke_assert_file_exists "$backup_path/hosts.yml" \
+    "credential consolidation backup preserves source contents"
+
+  bridge_isolation_v2_migrate_shared_credential_configs \
+    "$BRIDGE_DATA_ROOT" "$BRIDGE_HOME"
+  backup_count="$(find "$AGENT_HOME/.config" -maxdepth 1 -type d -name 'gh.pre-home-revert.*' | wc -l | tr -d ' ')"
+  smoke_assert_eq "1" "$backup_count" \
+    "credential consolidation is idempotent after sentinel"
+}
+
+test_wrong_symlink_fails_closed() {
+  local bad_agent bad_home bad_source wrong_target
+  bad_agent="home-revert-badlink"
+  register_shared_agent "$bad_agent"
+  bad_home="$BRIDGE_AGENT_ROOT_V2/$bad_agent/home"
+  wrong_target="$SMOKE_TMP_ROOT/wrong-gh"
+  mkdir -p "$bad_home/.config" "$wrong_target"
+  bad_source="$bad_home/.config/gh"
+  ln -s "$wrong_target" "$bad_source"
+
+  if bridge_isolation_v2_migrate_consolidate_agent_creds \
+      "$bad_agent" "$bad_home" "$OPERATOR_HOME"; then
+    smoke_fail "wrong gh symlink should fail closed"
+  fi
+  smoke_assert_eq "$wrong_target" "$(readlink "$bad_source")" \
+    "wrong symlink is not clobbered"
+}
+
+test_existing_correct_symlink_is_absorbed() {
+  local link_agent link_home target_gh source_gh sentinel
+  link_agent="home-revert-existing-link"
+  register_shared_agent "$link_agent"
+  link_home="$BRIDGE_AGENT_ROOT_V2/$link_agent/home"
+  target_gh="$OPERATOR_HOME/.config/gh"
+  source_gh="$link_home/.config/gh"
+  mkdir -p "$link_home/.config" "$target_gh"
+  ln -s "$target_gh" "$source_gh"
+
+  bridge_isolation_v2_migrate_consolidate_agent_creds \
+    "$link_agent" "$link_home" "$OPERATOR_HOME"
+
+  [[ -L "$source_gh" ]] || smoke_fail "existing correct gh symlink should remain a symlink"
+  smoke_assert_eq "$target_gh" "$(readlink "$source_gh")" \
+    "existing correct gh symlink still points at operator gh config"
+  sentinel="$link_home/.creds-consolidated.sentinel"
+  smoke_assert_file_exists "$sentinel" \
+    "existing correct symlink writes consolidation sentinel"
+  smoke_assert_contains "$(cat "$sentinel")" "gh:ok;" \
+    "existing correct symlink records gh ok"
+}
+
+test_iso_agent_is_skipped_by_bulk_consolidation() {
+  local iso_agent iso_home
+  iso_agent="home-revert-iso"
+  iso_home="$BRIDGE_AGENT_ROOT_V2/$iso_agent/home"
+  mkdir -p "$iso_home/.config/gh"
+  printf 'iso\n' >"$iso_home/.config/gh/hosts.yml"
+  BRIDGE_AGENT_IDS+=("$iso_agent")
+  BRIDGE_AGENT_DESC["$iso_agent"]="$iso_agent iso skip fixture"
+  BRIDGE_AGENT_ENGINE["$iso_agent"]="claude"
+  BRIDGE_AGENT_SESSION["$iso_agent"]="$iso_agent"
+  BRIDGE_AGENT_WORKDIR["$iso_agent"]="$BRIDGE_AGENT_ROOT_V2/$iso_agent/workdir"
+  BRIDGE_AGENT_SOURCE["$iso_agent"]="static"
+  BRIDGE_AGENT_CREATED_AT["$iso_agent"]="$(date +%s)"
+  BRIDGE_AGENT_SESSION_ID["$iso_agent"]=""
+  BRIDGE_AGENT_ISOLATION_MODE["$iso_agent"]="linux-user"
+  BRIDGE_AGENT_OS_USER["$iso_agent"]="agent-bridge-home-revert-iso"
+
+  local saved_platform="${BRIDGE_HOST_PLATFORM_OVERRIDE:-}"
+  export BRIDGE_HOST_PLATFORM_OVERRIDE="Linux"
+  bridge_isolation_v2_migrate_shared_credential_configs \
+    "$BRIDGE_DATA_ROOT" "$BRIDGE_HOME"
+  export BRIDGE_HOST_PLATFORM_OVERRIDE="$saved_platform"
+  [[ ! -f "$iso_home/.creds-consolidated.sentinel" ]] \
+    || smoke_fail "iso agent should not receive shared credential consolidation sentinel"
+  [[ -d "$iso_home/.config/gh" && ! -L "$iso_home/.config/gh" ]] \
+    || smoke_fail "iso agent gh config should remain a real directory"
+}
+
+smoke_run "shared resolvers split HOME and config" test_shared_resolvers_split_home_and_config
+smoke_run "channel launch env uses operator HOME" test_channel_launch_env_uses_operator_home
+smoke_run "auto-memory path keeps per-agent leaf" test_auto_memory_leaf_remains_agent_scoped
+smoke_run "credential consolidation and idempotency" test_credential_consolidation_and_idempotency
+smoke_run "wrong symlink fails closed" test_wrong_symlink_fails_closed
+smoke_run "existing correct symlink is absorbed" test_existing_correct_symlink_is_absorbed
+smoke_run "iso agent skipped by bulk consolidation" test_iso_agent_is_skipped_by_bulk_consolidation
+
+smoke_log "PASS"

--- a/scripts/smoke/4354-shared-home-revert.sh
+++ b/scripts/smoke/4354-shared-home-revert.sh
@@ -117,22 +117,35 @@ test_auto_memory_leaf_remains_agent_scoped() {
 
 test_credential_consolidation_and_idempotency() {
   local source_gh target_gh sentinel backup_count backup_path
+  local operator_hosts_before operator_hosts_after consolidation_output
   source_gh="$AGENT_HOME/.config/gh"
   target_gh="$OPERATOR_HOME/.config/gh"
   mkdir -p "$source_gh" "$target_gh"
-  printf 'source: agent\n' >"$source_gh/hosts.yml"
+  printf 'source: agent-stub\n' >"$source_gh/hosts.yml"
+  printf 'source: agent-only\n' >"$source_gh/agent-only.yml"
+  printf 'source: operator-valid-token\n' >"$target_gh/hosts.yml"
   printf 'source: operator\n' >"$target_gh/operator.yml"
+  operator_hosts_before="$SMOKE_TMP_ROOT/operator-hosts-before.yml"
+  operator_hosts_after="$SMOKE_TMP_ROOT/operator-hosts-after.yml"
+  cp "$target_gh/hosts.yml" "$operator_hosts_before"
 
-  bridge_isolation_v2_migrate_shared_credential_configs \
-    "$BRIDGE_DATA_ROOT" "$BRIDGE_HOME"
+  consolidation_output="$(bridge_isolation_v2_migrate_shared_credential_configs \
+    "$BRIDGE_DATA_ROOT" "$BRIDGE_HOME" 2>&1)"
+  cp "$target_gh/hosts.yml" "$operator_hosts_after"
 
   [[ -L "$source_gh" ]] || smoke_fail "credential consolidation should replace source gh dir with a symlink"
   smoke_assert_eq "$target_gh" "$(readlink "$source_gh")" \
     "credential consolidation symlink points at operator gh config"
+  cmp -s "$operator_hosts_before" "$operator_hosts_after" \
+    || smoke_fail "credential consolidation must not overwrite operator hosts.yml with agent stub"
   smoke_assert_file_exists "$target_gh/hosts.yml" \
-    "credential consolidation mirrors agent gh hosts into operator config"
+    "credential consolidation preserves operator gh hosts"
+  smoke_assert_file_exists "$target_gh/agent-only.yml" \
+    "credential consolidation mirrors agent-only gh files into operator config"
   smoke_assert_file_exists "$target_gh/operator.yml" \
     "credential consolidation preserves existing operator gh files"
+  smoke_assert_contains "$consolidation_output" "kept operator $target_gh/hosts.yml" \
+    "credential consolidation warns on divergent operator/agent overlap"
   sentinel="$AGENT_HOME/.creds-consolidated.sentinel"
   smoke_assert_file_exists "$sentinel" \
     "credential consolidation writes per-agent sentinel"
@@ -144,6 +157,8 @@ test_credential_consolidation_and_idempotency() {
   backup_path="$(find "$AGENT_HOME/.config" -maxdepth 1 -type d -name 'gh.pre-home-revert.*' -print -quit)"
   smoke_assert_file_exists "$backup_path/hosts.yml" \
     "credential consolidation backup preserves source contents"
+  smoke_assert_contains "$(cat "$backup_path/hosts.yml")" "agent-stub" \
+    "credential consolidation backup preserves divergent agent stub"
 
   bridge_isolation_v2_migrate_shared_credential_configs \
     "$BRIDGE_DATA_ROOT" "$BRIDGE_HOME"

--- a/scripts/smoke/A-beta4-iso-path-resolution.sh
+++ b/scripts/smoke/A-beta4-iso-path-resolution.sh
@@ -74,8 +74,9 @@ fi
 #       `<pwent_home>/.claude` via getent fallback when the roster
 #       array is empty AND iso v2 is effective.
 #
-#   T4: `bridge_agent_claude_config_dir` returns the legacy / daemon
-#       HOME path for a non-iso agent (backward compatibility).
+#   T4: `bridge_agent_claude_config_dir` returns the per-agent Claude
+#       config path for shared/non-iso agents, while
+#       `bridge_agent_claude_home_dir` returns operator HOME.
 #
 #   T5: snippet absence — the reader silently no-ops (no error
 #       output, no array population) when `agent-meta.env` is missing
@@ -248,22 +249,26 @@ fi
 smoke_log "T3 PASS — getent-based iso v2 fallback wired into bridge_agent_claude_config_dir"
 
 # ---------------------------------------------------------------------
-# T4: non-iso path preserves legacy / daemon HOME resolution.
+# T4: shared/non-iso path splits HOME from Claude config resolution.
 # ---------------------------------------------------------------------
-smoke_log "T4: bridge_agent_claude_config_dir non-iso path returns legacy controller-view"
+smoke_log "T4: shared/non-iso Claude config stays per-agent while HOME is operator"
 
-# The function body must still call `bridge_agent_claude_home_dir`
-# (which contains the non-iso fallback to `bridge_agent_default_home`).
-if [[ "$T3_FN_BODY" != *"bridge_agent_claude_home_dir"* ]]; then
-  smoke_fail "T4: bridge_agent_claude_config_dir non-iso path dropped — non-iso agents will lose their config dir resolution"
+# The config-dir fallback must be anchored at the per-agent default home,
+# not at `bridge_agent_claude_home_dir` (which now resolves shared HOME to
+# the operator home).
+if [[ "$T3_FN_BODY" != *"bridge_agent_default_home"* ]]; then
+  smoke_fail "T4: bridge_agent_claude_config_dir shared fallback dropped bridge_agent_default_home — shared agents will lose per-agent Claude state"
 fi
-# And `bridge_agent_claude_home_dir` itself must keep the non-iso
-# branch returning `bridge_agent_default_home`.
+if [[ "$T3_FN_BODY" == *"bridge_agent_claude_home_dir"* ]]; then
+  smoke_fail "T4: bridge_agent_claude_config_dir still derives from HOME — shared agents would collapse into operator .claude"
+fi
+# And `bridge_agent_claude_home_dir` itself must return the operator home
+# for shared/non-iso agents.
 T4_HOME_FN_BODY="$(awk '/^bridge_agent_claude_home_dir\(\) \{/,/^\}/' "$AGENTS_LIB")"
-if [[ "$T4_HOME_FN_BODY" != *"bridge_agent_default_home"* ]]; then
-  smoke_fail "T4: bridge_agent_claude_home_dir non-iso branch removed — non-iso agents will lose their HOME default"
+if [[ "$T4_HOME_FN_BODY" != *"bridge_agent_operator_home_dir"* ]]; then
+  smoke_fail "T4: bridge_agent_claude_home_dir shared branch does not resolve operator HOME"
 fi
-smoke_log "T4 PASS — non-iso resolution preserved (backward compat)"
+smoke_log "T4 PASS — shared HOME/config split is wired"
 
 # ---------------------------------------------------------------------
 # T5: snippet absence → reader silently no-ops.
@@ -371,7 +376,7 @@ T7_TMP="$(mktemp "${SMOKE_TMP_ROOT:-/tmp}/A-beta4-T7-lines.XXXXXX")"
 printf '%s\n' "$T7_LINES" >"$T7_TMP"
 T7_ISO_BRANCH="$(awk '
   /bridge_agent_linux_user_isolation_effective/,0
-' <"$T7_TMP" | sed -n '1,/Non-iso path/p')"
+' <"$T7_TMP" | sed -n '1,/Shared\/non-iso path/p')"
 rm -f "$T7_TMP"
 
 if [[ "$T7_ISO_BRANCH" == *"bridge_agent_default_home"* ]]; then

--- a/scripts/smoke/launch-dev-channels-injection.sh
+++ b/scripts/smoke/launch-dev-channels-injection.sh
@@ -220,20 +220,29 @@ assert_teams_delivery_mode_source_grep_gate() {
 }
 
 assert_stale_claude_home_prefix_is_rewritten() {
-  local launch_cmd home_count config_count
+  local launch_cmd home_count config_count operator_home
+  # #1621/#1622 shared-mode contract: a shared (non-iso) Claude agent now runs
+  # with HOME = the OPERATOR home (so generic ~/.config tools stay shared) and
+  # CLAUDE_CONFIG_DIR = the PER-AGENT config dir (so Claude identity/settings/
+  # transcripts/credentials stay isolated). Pin the operator home to a fixture
+  # via BRIDGE_CONTROLLER_HOME so the assertion is portable (otherwise it
+  # resolves to the real $HOME of whoever runs the smoke).
+  operator_home="$BRIDGE_AGENT_ROOT_V2/operator-home"
   BRIDGE_AGENT_CHANNELS["worker"]="server:teams"
   BRIDGE_AGENT_LAUNCH_CMD["worker"]="HOME=/home/ec2-user CLAUDE_CONFIG_DIR=/home/ec2-user/.claude claude --dangerously-skip-permissions"
 
-  launch_cmd="$(bridge_agent_launch_cmd worker)"
+  launch_cmd="$(BRIDGE_CONTROLLER_HOME="$operator_home" bridge_agent_launch_cmd worker)"
 
-  smoke_assert_contains "$launch_cmd" "HOME=$BRIDGE_AGENT_ROOT_V2/worker/home" \
-    "stale inherited HOME is rewritten to the agent-scoped home"
+  smoke_assert_contains "$launch_cmd" "HOME=$operator_home " \
+    "stale inherited HOME is rewritten to the operator home (shared-mode #1621)"
   smoke_assert_contains "$launch_cmd" "CLAUDE_CONFIG_DIR=$BRIDGE_AGENT_ROOT_V2/worker/home/.claude" \
-    "stale inherited Claude config dir is rewritten to the agent-scoped config dir"
+    "Claude config dir stays the per-agent config dir (#1520/#1621 isolation)"
   smoke_assert_not_contains "$launch_cmd" "HOME=/home/ec2-user " \
     "stale controller HOME does not survive"
   smoke_assert_not_contains "$launch_cmd" "CLAUDE_CONFIG_DIR=/home/ec2-user/.claude" \
     "stale controller Claude config dir does not survive"
+  smoke_assert_not_contains "$launch_cmd" "HOME=$BRIDGE_AGENT_ROOT_V2/worker/home " \
+    "shared-mode HOME is NOT the per-agent home (would fragment ~/.config; #1370)"
 
   home_count="$(count_substring "$launch_cmd" "HOME=")"
   config_count="$(count_substring "$launch_cmd" "CLAUDE_CONFIG_DIR=")"


### PR DESCRIPTION
Fixes #1621

Fixes the shared-mode HOME-split bug described in the linked issue.

## What this changes

- **Shared Claude agents now launch with `HOME` = operator HOME**, while **`CLAUDE_CONFIG_DIR` stays per-agent**. Result: `~/.config` (gh/gws/gcloud) is shared from the operator; `.claude` (identity/settings/transcripts/Claude-OAuth) remains per-agent.
- **Isolated (Linux OS-user) agents are unchanged** — the isolation gate is preserved; the operator-HOME branch only applies when the agent is not OS-user-isolated.
- **Upgrader credential consolidation** (`bridge_isolation_v2_migrate_shared_credential_configs`, invoked from `apply_for_upgrade` **before any skip branch**): consolidates each shared agent's `~/.config/{gh,gws,gcloud}` into the operator, then backs up the per-agent dir (`*.pre-home-revert.<stamp>`) and replaces it with a symlink to the operator's. Sentinel-gated (`.creds-consolidated.sentinel`) + idempotent; skips isolated agents.

## Why `CLAUDE_CONFIG_DIR` stays per-agent

A naive "HOME=operator" that also moved the config dir would re-introduce the HOME↔config misalignment behind the `#1370`/`#1316` session-detect crash-loop. This change deliberately decouples them: HOME→operator, config→per-agent. Identity files (SOUL/CLAUDE/MEMORY) are hook-injected from the agent home + read from the workdir (HOME-independent); `auto-memory` follows `CLAUDE_CONFIG_DIR`, so its per-agent leaf is preserved (covered by a smoke assertion).

## Data-safety (operator-authoritative merge)

The consolidation uses `rsync -a --ignore-existing` so an agent's stale stub can **never** overwrite the operator's valid credential. Before the rsync it walks the source tree and, for any file that exists in the operator and differs, emits a `bridge_warn` (`kept operator <file>; agent copy preserved in <backup>`) — no silent loss; the agent's copy survives in the `.pre-home-revert` backup. A smoke case proves the operator's `gh/hosts.yml` is **byte-identical** before/after when the agent carries a divergent stub, while an agent-only file is still mirrored in.

## Migration coverage (operator directive — please keep)

The consolidation call is positioned **before all skip branches** in `apply_for_upgrade` (Linux full / macOS-no-isolated / marker-only fast-path), so existing installs migrate on every path. Omitting the macOS/no-isolated path is the `#897`/`#1431` split-brain root cause; this is intentionally guarded against here. Reviewers integrating this: please preserve that ordering.

## Tests

- `scripts/smoke/4354-shared-home-revert.sh` (8 cases): resolver HOME/config split; channel-launch env uses operator HOME; auto-memory keeps per-agent leaf; consolidation idempotency; wrong-symlink fail-closed; existing-correct-symlink absorbed; iso agent skipped; **anti-clobber** (operator file byte-unchanged vs divergent agent stub, agent-only file mirrored, warning emitted, backup preserves stub). All pass.
- `bash -n` (Bash 5.x) + `shellcheck -S error` clean on changed files.
- **Verified on a live macOS install (v0.16.0-rc3)**: the runtime delta applies cleanly; resolvers return `claude_home`=operator and `claude_cfg_dir`=per-agent; a real Claude agent boots healthy under operator HOME; the live credential migration preserved the operator's `gh` auth byte-for-byte, flipped per-agent cred dirs to operator symlinks, and is reversible via the backups.

## Base / release-line note

This branch is based on `origin/main` (currently `0.15.3`). The current release line is `v0.16.0-rc3`, which is **ahead of `main`** (rc work not yet merged back). The runtime delta was verified to apply cleanly to both. When reconciling the rc line, please re-verify the four touched resolver/launch functions still receive the operator-HOME branch.
