### PR TITLE
fix(agents): guard roster map accessors under nounset

### DIFF
--- a/agent-roster.sh
+++ b/agent-roster.sh
@@ -21,6 +21,21 @@ declare -Ag BRIDGE_AGENT_DESC=()
 # shellcheck disable=SC2034
 declare -Ag BRIDGE_AGENT_ENGINE=()
 
+# #1407/#1213/#1457 follow-up: SOURCE / PROVENANCE / PRECOMPACT_NOTIFY share
+# ENGINE's associative-map contract but were added (accessors + populate code)
+# without a declaration here. An undeclared map makes ${MAP[$agent]} evaluate
+# the agent id as an arithmetic subscript and abort the launcher under `set -u`
+# ("<agent>: unbound variable"). Declare them empty up front, exactly like the
+# maps above, so element assignment and reads always hit a real assoc array.
+# shellcheck disable=SC2034
+declare -Ag BRIDGE_AGENT_SOURCE=()
+
+# shellcheck disable=SC2034
+declare -Ag BRIDGE_AGENT_PROVENANCE=()
+
+# shellcheck disable=SC2034
+declare -Ag BRIDGE_AGENT_PRECOMPACT_NOTIFY=()
+
 # shellcheck disable=SC2034
 declare -Ag BRIDGE_AGENT_SESSION=()
 

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -854,13 +854,46 @@ bridge_agent_desc() {
   printf '%s' "${BRIDGE_AGENT_DESC[$agent]-}"
 }
 
+# bridge_var_is_assoc <varname> — return 0 iff <varname> is currently a set
+# associative array. The test is ANCHORED to the `declare -p` flag field (the
+# token between `declare -` and the variable name) so a scalar/indexed variable
+# whose VALUE merely contains the text "declare -A" cannot false-positive
+# (#1457 codex r1: an unanchored `grep 'declare -[A-Za-z]*A'` over the full
+# `declare -p` output matched `BRIDGE_AGENT_ENGINE="declare -A"` and fell through
+# to the aborting indexed read). Safe under `set -u`.
+bridge_var_is_assoc() {
+  local _decl _flags
+  _decl="$(declare -p "$1" 2>/dev/null)" || return 1
+  _flags="${_decl#declare -}"   # `declare -A name=(...)` -> `A name=(...)`
+  _flags="${_flags%% *}"        # keep only the flag token   -> `A` / `-` / `ax`
+  case "$_flags" in
+    *A*) return 0 ;;
+    *)   return 1 ;;
+  esac
+}
+
 bridge_agent_engine() {
   local agent="$1"
+  # #1407/#1213: scalar-clobbered maps arithmetic-index agent ids under `set -u`
+  # and abort. Guard with the flag-field anchored check (#1457 r1) so a scalar/
+  # indexed value containing the text "declare -A" can't slip into the read.
+  if ! bridge_var_is_assoc BRIDGE_AGENT_ENGINE; then
+    printf '%s' 'unknown'
+    return 0
+  fi
   printf '%s' "${BRIDGE_AGENT_ENGINE[$agent]-unknown}"
 }
 
 bridge_agent_source() {
   local agent="$1"
+  # #1457 follow-up: guard the same scalar-clobbered / undeclared-map hazard
+  # that bridge_agent_engine handles. Without this, an undeclared
+  # BRIDGE_AGENT_SOURCE makes the [$agent] subscript an arithmetic eval that
+  # aborts under `set -u`. Fall back to the documented historical default.
+  if ! bridge_var_is_assoc BRIDGE_AGENT_SOURCE; then
+    printf '%s' 'static'
+    return 0
+  fi
   printf '%s' "${BRIDGE_AGENT_SOURCE[$agent]-static}"
 }
 
@@ -872,6 +905,12 @@ bridge_agent_source() {
 # only has BRIDGE_AGENT_SOURCE=static.
 bridge_agent_provenance() {
   local agent="$1"
+  # #1457 follow-up: see bridge_agent_source — guard before the arithmetic-index
+  # read so an undeclared/scalar map yields the default instead of aborting.
+  if ! bridge_var_is_assoc BRIDGE_AGENT_PROVENANCE; then
+    printf '%s' 'static-roster'
+    return 0
+  fi
   printf '%s' "${BRIDGE_AGENT_PROVENANCE[$agent]-static-roster}"
 }
 
@@ -883,6 +922,11 @@ bridge_agent_provenance() {
 # one place. Default is OFF — only the literal value "1" enables the notice.
 bridge_agent_precompact_notify_enabled() {
   local agent="$1"
+  # #1457 follow-up: see bridge_agent_source — an undeclared/scalar map must not
+  # abort under `set -u`; treat it as the default (opt-out) instead.
+  if ! bridge_var_is_assoc BRIDGE_AGENT_PRECOMPACT_NOTIFY; then
+    return 1
+  fi
   local val="${BRIDGE_AGENT_PRECOMPACT_NOTIFY[$agent]-0}"
   [[ "$val" == "1" ]]
 }
@@ -5282,7 +5326,14 @@ bridge_agent_mattermost_state_dir() {
 
 bridge_agent_workdir() {
   local agent="$1"
-  local explicit="${BRIDGE_AGENT_WORKDIR[$agent]-}"
+  local explicit=""
+  # #1407/#1213: if the map is unset or scalar-clobbered, fall through to
+  # existing v2/default resolution instead of aborting under `set -u`. Use the
+  # flag-field anchored check (#1457 r1) so a scalar/indexed value containing the
+  # text "declare -A" can't false-positive into the aborting indexed read.
+  if bridge_var_is_assoc BRIDGE_AGENT_WORKDIR; then
+    explicit="${BRIDGE_AGENT_WORKDIR[$agent]-}"
+  fi
 
   # v2 anchor precedence is conditional on isolation mode (issue #895,
   # ymprince WSL2 report, v0.13.8):

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -256,6 +256,44 @@ else
   log "shellcheck not installed; skipping"
 fi
 
+log "guarding agent map accessors against unset/scalar maps under set -u (#4411)"
+"$BASH4_BIN" -s "$REPO_ROOT" <<'BASH_AGENT_MAP_GUARD'
+set -euo pipefail
+repo="$1"
+source "$repo/lib/bridge-core.sh"
+source "$repo/lib/bridge-agents.sh"
+
+agent="unbound-agent"
+BRIDGE_AGENT_HOME_ROOT="${TMPDIR:-/tmp}/agb-agent-map-guard-home"
+expected_workdir="$(bridge_agent_default_home "$agent")"
+unset -v BRIDGE_AGENT_ENGINE BRIDGE_AGENT_SOURCE BRIDGE_AGENT_PROVENANCE \
+  BRIDGE_AGENT_PRECOMPACT_NOTIFY BRIDGE_AGENT_WORKDIR
+
+[[ "$(bridge_agent_engine "$agent")" == "unknown" ]]
+[[ "$(bridge_agent_source "$agent")" == "static" ]]
+[[ "$(bridge_agent_provenance "$agent")" == "static-roster" ]]
+if bridge_agent_precompact_notify_enabled "$agent"; then
+  printf 'precompact notify unexpectedly enabled for unset map\n' >&2
+  exit 1
+fi
+[[ "$(bridge_agent_workdir "$agent")" == "$expected_workdir" ]]
+
+BRIDGE_AGENT_ENGINE="declare -A spoof"
+BRIDGE_AGENT_SOURCE="declare -A spoof"
+BRIDGE_AGENT_PROVENANCE="declare -A spoof"
+BRIDGE_AGENT_PRECOMPACT_NOTIFY="declare -A spoof"
+BRIDGE_AGENT_WORKDIR="declare -A spoof"
+
+[[ "$(bridge_agent_engine "$agent")" == "unknown" ]]
+[[ "$(bridge_agent_source "$agent")" == "static" ]]
+[[ "$(bridge_agent_provenance "$agent")" == "static-roster" ]]
+if bridge_agent_precompact_notify_enabled "$agent"; then
+  printf 'precompact notify unexpectedly enabled for scalar map\n' >&2
+  exit 1
+fi
+[[ "$(bridge_agent_workdir "$agent")" == "$expected_workdir" ]]
+BASH_AGENT_MAP_GUARD
+
 log "redacting sensitive inline env vars from launch display paths (#428)"
 LAUNCH_REDACTION_OUTPUT="$("$BASH4_BIN" -s "$REPO_ROOT" <<'BASH_REDACTION'
 set -euo pipefail


### PR DESCRIPTION
## Summary

Source-port the live P0 fix for launcher aborts under `set -u` when roster map variables are undeclared or scalar-clobbered:

- declare `BRIDGE_AGENT_SOURCE`, `BRIDGE_AGENT_PROVENANCE`, and `BRIDGE_AGENT_PRECOMPACT_NOTIFY` in `agent-roster.sh`
- add anchored `bridge_var_is_assoc` guard helper
- guard `bridge_agent_engine`, `bridge_agent_source`, `bridge_agent_provenance`, and `bridge_agent_precompact_notify_enabled`
- include the same-root `bridge_agent_workdir` guard already present in live
- add an early smoke regression for unset maps and scalar spoof values containing `declare -A`

This matches the live hotfix behavior and prevents hyphenated agent ids from being arithmetic-evaluated as array subscripts before defaults apply.

## Adjacent-defect audit

I audited `lib/bridge-agents.sh` for `${BRIDGE_AGENT_*[$agent]...}` reads. The additional same-root source drift versus live was `BRIDGE_AGENT_WORKDIR`, so this PR includes that guard as well. The remaining direct reads match the current live file and are backed by the normal roster/reset declaration path; they are not expanded in this source-port PR.

## Target note

Target is `main` because the defect exists on `main` (`8993f46`, v0.15.3 line). The rc3 line has the same defect class in source/live history; when rc3/main are reconciled, this fix should be included there too. This PR is intentionally separate from HOME-revert PR #1622 and cron-fold PR #1625.

## Verification

- `bash -n agent-roster.sh lib/bridge-agents.sh scripts/smoke-test.sh`
- `/opt/homebrew/bin/bash -n agent-roster.sh lib/bridge-agents.sh scripts/smoke-test.sh`
- `shellcheck agent-roster.sh lib/bridge-agents.sh scripts/smoke-test.sh`
- `git diff --check`
- direct regression: unset/scalar `BRIDGE_AGENT_ENGINE/SOURCE/PROVENANCE/PRECOMPACT_NOTIFY/WORKDIR` under `set -u`
- direct roster-source reproducer: `patch-dev` hyphenated id with `bridge_agent_source/provenance/precompact` under `set -u`
- isolated full smoke with clean env reached the known #365 guard after the new #4411 block passed:
  `expected output to contain: refusing to write isolated agent-env.sh from ephemeral controller path BRIDGE_HOME=`

No live mutation. Shared source checkout was not changed.
