### PR TITLE
smoke: harden daemon socket loop-restart against CI startup flake (#1644)

### DIFF
--- a/scripts/smoke/daemon.sh
+++ b/scripts/smoke/daemon.sh
@@ -720,7 +720,15 @@ EOF
   bash "$SMOKE_REPO_ROOT/bridge-daemon.sh" run >"$daemon_log" 2>&1 &
   DAEMON_SOCKET_PID="$!"
 
-  for ((i = 0; i < 50; i++)); do
+  # Issue #1644 CI flake: first_pid is `local`-declared (above) but left UNSET, so if
+  # the initial listener does not bind within the wait budget the loop exits without
+  # ever assigning it and `set -u` aborts at the check below with a cryptic
+  # "first_pid: unbound variable" instead of the intended smoke_fail. Initialize it
+  # (mirroring second_pid="" below) AND give cold daemon boot more headroom on a loaded
+  # CI runner: 50*0.1=5s was too tight; 100*0.1=10s matches the restart loop's
+  # generosity. Common case is unaffected — the loop breaks as soon as the socket binds.
+  first_pid=""
+  for ((i = 0; i < 100; i++)); do
     if [[ -S "$socket_path" && -f "$pid_file" ]] && kill -0 "$DAEMON_SOCKET_PID" 2>/dev/null; then
       first_pid="$(sed -n '1p' "$pid_file" 2>/dev/null || true)"
       [[ "$first_pid" =~ ^[0-9]+$ ]] && break


### PR DESCRIPTION
## Summary
Fixes the chronic `scripts/smoke/daemon.sh: line 730: first_pid: unbound variable` CI flake that intermittently fails `unit/static smoke` (most recently on PR #1644, unrelated change).

## Root cause
`first_pid` is `local`-declared (~line 693) but only ever assigned **inside** the wait loop's `if`. On a loaded CI runner where the initial queue-gateway socket listener does not bind within the old `50*0.1=5s` budget, the loop exits with `first_pid` still UNSET → `set -u` aborts at the `[[ "$first_pid" =~ ... ]]` check with a cryptic "unbound variable" instead of the intended graceful `smoke_fail`.

## Fix (test-only)
1. Initialize `first_pid=""` before the loop (mirrors the existing `second_pid=""`) — converts a cold-boot miss into the intended `smoke_fail` diagnostic, never a `set -u` crash.
2. Widen the initial-listener wait budget `50→100` iterations (5s→10s) to match the restart loop's generosity, so cold daemon boot on a loaded runner has headroom. Common case unaffected — the loop `break`s as soon as the socket binds.

## Verification
- `bash -n` + `shellcheck --severity=warning` (CI threshold) — clean.
- `scripts/smoke/daemon.sh` PASS on macOS (the four socket-listener tests skip non-Linux; the change is in the Linux-only loop-restart path, validated by CI on Linux).
- ci-select: a change to `scripts/smoke/daemon.sh` selects the `daemon` smoke (confirmed).
- No VERSION/CHANGELOG bump (v0.16.1 batches separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)