### PR TITLE
ms365: add get-valid-token CLI subcommand for sibling stdio callers (#1650 B1)

### DIFF
--- a/plugins/ms365/server.ts
+++ b/plugins/ms365/server.ts
@@ -1647,5 +1647,39 @@ process.on('uncaughtException', err => {
   process.stderr.write(`ms365 channel: uncaught exception: ${err}\n`)
 })
 
+// #1650 B1: one-shot CLI entrypoint for sibling stdio callers (the cosmax-crm
+// proxy crm-mcp-proxy.mjs) that are NOT MCP clients and so cannot invoke the
+// get_valid_token MCP tool. `bun server.ts get-valid-token [upn]` prints one
+// JSON line { upn, access_token, expires_at, expires_in_seconds } to stdout and
+// exits — same contract as the get_valid_token tool: refresh-on-expiry via
+// getAccessToken (refresh_token grant + SingleFlight), NEVER the refresh_token.
+// Handled before mcp.connect so it never starts the server.
+if (process.argv[2] === 'get-valid-token') {
+  // #1654 codex r1 BLOCKING: resolveUpn() throws when no upn arg AND no
+  // MS365_DEFAULT_UPN. Keep it INSIDE the try so that failure exits non-zero
+  // (the global uncaughtException handler only logs — it would exit 0). `upn`
+  // is declared outside so the catch can still name it in the audit.
+  let upn = ''
+  try {
+    upn = resolveUpn(process.argv[3])
+    const access_token = await getAccessToken(upn)
+    const cur = loadJson<TokenFile>(tokenPath(upn))
+    const now = Math.floor(Date.now() / 1000)
+    const expires_at = cur?.expires_at ?? null
+    const expires_in_seconds = expires_at != null ? expires_at - now : null
+    // Redacted audit (upn + expiry only, never the token body), like the tool.
+    process.stderr.write(
+      `ms365 channel: ms365_token_issued upn=${upn} expires_in_seconds=${expires_in_seconds ?? 'unknown'} (cli)\n`,
+    )
+    process.stdout.write(JSON.stringify({ upn, access_token, expires_at, expires_in_seconds }) + '\n')
+    process.exit(0)
+  } catch (e) {
+    process.stderr.write(
+      `ms365 channel: ms365_token_issue_failed upn=${upn || process.argv[3] || '<none>'} err=${e instanceof Error ? e.message : String(e)}\n`,
+    )
+    process.exit(1)
+  }
+}
+
 await mcp.connect(new StdioServerTransport())
 process.stderr.write(`ms365: MCP connected (tenant=${TENANT_ID.slice(0, 8)}..., client=${CLIENT_ID.slice(0, 8)}..., secret_len=${CLIENT_SECRET.length}, default_upn=${DEFAULT_UPN}, state_dir=${STATE_DIR})\n`)

--- a/scripts/smoke/1650-ms365-get-valid-token.sh
+++ b/scripts/smoke/1650-ms365-get-valid-token.sh
@@ -82,4 +82,47 @@ if grep -E "ms365_token_issued" "$WORK/block.txt" | grep -Eq '\$\{access_token\}
   fail "T5: ms365_token_issued audit appears to embed the access_token body (must be upn+expiry only)"
 fi
 
+# T6 — #1650 B1: the one-shot CLI entrypoint for sibling stdio callers (the
+# cosmax-crm proxy, which is not an MCP client). `get-valid-token` argv branch
+# handled before mcp.connect, prints JSON, reuses getAccessToken, no refresh_token.
+log "T6: get-valid-token CLI entrypoint"
+grep -Eq "process\.argv\[2\] === 'get-valid-token'" "$MS365_TS" \
+  || fail "T6: server.ts does not handle the get-valid-token CLI subcommand"
+# Must be handled BEFORE mcp.connect (one-shot, never starts the server).
+CLI_LINE="$(grep -nE "process\.argv\[2\] === 'get-valid-token'" "$MS365_TS" | head -n1 | cut -d: -f1)"
+CONNECT_LINE="$(grep -nE 'mcp\.connect\(new StdioServerTransport' "$MS365_TS" | head -n1 | cut -d: -f1)"
+[[ -n "$CLI_LINE" && -n "$CONNECT_LINE" ]] || fail "T6: cannot locate CLI branch ($CLI_LINE) or mcp.connect ($CONNECT_LINE)"
+(( CLI_LINE < CONNECT_LINE )) || fail "T6: get-valid-token CLI branch (line $CLI_LINE) must precede mcp.connect (line $CONNECT_LINE)"
+# Isolate the CLI branch body (from the argv test to its process.exit(0)).
+awk "
+  /process.argv\[2\] === 'get-valid-token'/ {cap=1}
+  cap {buf=buf\$0 ORS}
+  cap && /process.exit\(0\)/ {print buf; exit}
+" "$MS365_TS" >"$WORK/cli.txt"
+[[ -s "$WORK/cli.txt" ]] || fail "T6: could not isolate the get-valid-token CLI branch body"
+grep -Eq "getAccessToken\(upn\)" "$WORK/cli.txt" || fail "T6: CLI branch does not reuse getAccessToken(upn)"
+grep -Eq "access_token" "$WORK/cli.txt" || fail "T6: CLI branch does not emit access_token"
+grep -vE "^[[:space:]]*//|^[[:space:]]*\*" "$WORK/cli.txt" >"$WORK/clicode.txt" || true
+if grep -Eq "refresh_token" "$WORK/clicode.txt"; then
+  fail "T6: CLI branch references refresh_token — must never leave the ms365 plugin"
+fi
+
+# T7 — #1654 codex r1 BLOCKING regression guard: resolveUpn() MUST be inside the
+# CLI try/catch so a missing-upn/no-default failure exits non-zero. If it sits
+# before `try {`, resolveUpn throws to the global uncaughtException handler which
+# only logs and the process exits 0 (false success), breaking the proxy contract.
+# Capture the FULL branch (through the catch's exit 1) and assert ordering + exit.
+log "T7: resolveUpn inside try, failure exits non-zero (no-upn regression guard)"
+awk "
+  /process.argv\[2\] === 'get-valid-token'/ {cap=1}
+  cap {n++; if (\$0 ~ /try \{/ && !tryline) tryline=n; if (\$0 ~ /resolveUpn\(process.argv\[3\]\)/ && !upnline) upnline=n; print}
+  cap && /process.exit\(1\)/ {exit}
+" "$MS365_TS" >"$WORK/full.txt"
+[[ -s "$WORK/full.txt" ]] || fail "T7: could not isolate the full CLI branch (through the catch)"
+TRY_AT="$(grep -nE 'try \{' "$WORK/full.txt" | head -n1 | cut -d: -f1)"
+UPN_AT="$(grep -nE 'resolveUpn\(process.argv\[3\]\)' "$WORK/full.txt" | head -n1 | cut -d: -f1)"
+[[ -n "$TRY_AT" && -n "$UPN_AT" ]] || fail "T7: cannot locate try ($TRY_AT) or resolveUpn ($UPN_AT) in the CLI branch"
+(( TRY_AT < UPN_AT )) || fail "T7: resolveUpn(process.argv[3]) (line $UPN_AT) must be INSIDE the try (try at line $TRY_AT) so a no-upn failure exits non-zero"
+grep -Eq "process\.exit\(1\)" "$WORK/full.txt" || fail "T7: CLI branch has no process.exit(1) failure path"
+
 log "passed"


### PR DESCRIPTION
## Summary
#1650 B1 enabler. The cosmax-crm proxy (`crm-mcp-proxy.mjs`) is a **sibling node stdio process, not an MCP client**, so it cannot call the `get_valid_token` MCP tool (added in #1651). This adds a one-shot **CLI entrypoint** so the proxy can fetch a guaranteed-valid token.

## Change (plugins/ms365/server.ts)
`bun server.ts get-valid-token [upn]`:
- Handled **before `mcp.connect`** (one-shot; never starts the MCP server).
- Reuses `getAccessToken(upn)` (pre-call expiry + refresh_token grant + SingleFlight) — same refresh path as the MCP tool.
- Prints **one JSON line** `{ upn, access_token, expires_at, expires_in_seconds }` to stdout, exits 0; on failure prints a redacted error to stderr, exits 1.
- `upn` = `argv[3]` or `MS365_DEFAULT_UPN`.
- **Security**: NEVER prints the `refresh_token`; redacted `ms365_token_issued ... (cli)` audit to stderr.

## Out of scope (coordinated separately)
- `MS365_PLUGIN_ROOT` injection (so the proxy locates `bun server.ts`) — bridge/cosmax-crm `.mcp.json` coordination, tracked with patch/crm-dev. crm-dev's B1 implementation (which calls this CLI) lands in the cosmax-crm repo after this entrypoint deploys.

## Verification
- `bun build` (real siblings, sdk external) — clean.
- `scripts/smoke/1650-ms365-get-valid-token.sh` extended with **T6** (CLI branch handled before `mcp.connect`, reuses `getAccessToken`, emits `access_token`, `refresh_token` never referenced). 6/6 PASS; `shellcheck --severity=warning` clean.
- ci-select: `plugins/ms365/server.ts` change selects the 1650 smoke (already registered).
- Live behavior to be confirmed by patch on cm-prod (same as the MCP tool, which already live-PASSED).
- No VERSION/CHANGELOG bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)