### PR TITLE
docs: release-lines & LTS policy (CLAUDE.md + AGENTS.md + docs/release-lines.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,16 @@ Claude authors the change; Codex reviews; Claude merges only after Codex signs o
 
 A release PR updates only `VERSION` and `CHANGELOG.md`. Keep it in a branch named `release/vX.Y.Z`. Codex reviews the CHANGELOG entries and verifies the version-bump convention before `git tag -a vX.Y.Z <merge-sha>` and `git push origin vX.Y.Z`. Do not tag on a non-merge commit or on the feature branch.
 
+### 3a. Release lines & LTS policy
+
+Agent Bridge runs an **LTS line + mainline**, not a single moving tag. Full policy: [`docs/release-lines.md`](./docs/release-lines.md). What a Codex reviewer needs to hold (operator-decided 2026-06-08):
+
+- **Current LTS: v0.16.2.** An LTS is a blessed stable tag (release title `(LTS)` + README marker) for conservative/production installs.
+- **One line until features diverge** — the v0.16.x hardening sequence (v0.16.3, …) rides `main` and *is* the LTS line; do not fork a maintenance branch until the first new *feature* lands. Fork trigger: branch `release/0.16-lts` from the latest `v0.16.x` tag and bump `main` to `v0.17.0-beta`. New features → beta first, never onto the LTS line.
+- **Support window**: an LTS is supported until the next LTS is declared.
+- **Backport criteria** (LTS branch only): security · data loss · upgrade/rollback breakage · fleet-host-down regression. Not features/cosmetic/perf-only/refactors. Fix on `main` first, cherry-pick back only if it qualifies. When reviewing a backport PR, confirm it meets these criteria.
+- **Versioning**: LTS = patch bumps; mainline features = minor. **Channel enforcement**: `--channel stable` currently resolves to the highest global tag, so an `lts` version-line-pin channel (landing in v0.16.3, on the v0.16.x line) is what keeps LTS installs from auto-jumping when a higher minor ships. The upgrader is high-risk — review channel-resolver changes adversarially and confirm the default channel behavior is unchanged.
+
 ### 4. Forbidden operations under shared worktree
 
 Even when a Codex agent is attached to a shared worktree for legacy reasons, the following are forbidden on the operator's primary checkout:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,19 @@ Acceptable: prep VERSION + CHANGELOG drafts, run codex-rescue review on a releas
 
 **A release is not done at the tag — sync the docs index in the same session** (operator directive 2026-05-31). After the `vX.Y.Z` tag lands, update `README.md`'s top block to the new version: the `**Current version**` line, the one-line **Headline** (name the release's marquee feature + notable fixes), and the `Recommended upgrade target` + leap-path. Then confirm any new feature's usage docs are current (`OPERATIONS.md`, `docs/developer-handover.md`, `docs/<feature>-design.md`). This is a **separate `docs/vX.Y.Z-...` PR** — the release PR itself stays VERSION + CHANGELOG only (see "Working With Codex Reviewers" point 3). Why it matters: installing agents and patch read the README headline + feature docs — *not* the CHANGELOG — to discover and correctly use new capabilities, so a stale README ships new features invisible (v0.15.1's `agb setup template-sync` had 0 README refs right after the cut until PR #1435).
 
+## Release Lines & LTS Policy
+
+Agent Bridge runs an **LTS line + mainline**, not a single moving tag. Full policy: [`docs/release-lines.md`](./docs/release-lines.md). Headlines (operator-decided 2026-06-08 with the v0.16.2 LTS cut):
+
+- **Current LTS: v0.16.2** (declared 2026-06-08). An LTS is a blessed stable tag (release title `(LTS)` + README marker) that conservative/production installs pin to.
+- **One line until features diverge.** Until the first new *feature* lands there is a single line (`main`); the v0.16.x **hardening** sequence (v0.16.3, …) rides `main` and *is* the LTS line. Do **not** fork a maintenance branch prematurely.
+- **Fork trigger** = the first real new feature: branch `release/0.16-lts` from the latest `v0.16.x` tag, bump `main` to `v0.17.0-beta`. New features → **beta first** (existing rule), never onto the LTS line.
+- **Support window**: an LTS gets fixes **until the next LTS is declared**.
+- **Backport criteria** (LTS branch only): security · data loss · upgrade/rollback breakage · fleet-host-down regression. **Not** features/cosmetic/perf-only/refactors. Fix on `main` first, cherry-pick back only if it qualifies.
+- **Versioning**: LTS = patch bumps (v0.16.3 …); mainline features = minor (v0.17.0 …). Bump size is the operator's call (small-bumps preference); a capability-add in a patch is allowed when operator-directed.
+- **Channel enforcement (gap being closed in v0.16.3)**: `--channel stable` (default) resolves to the *highest global* tag today, so shipping v0.17.0 would auto-pull every default install off the LTS. v0.16.3 adds an **`lts` channel** (version-line pin → latest `v0.16.x`); it must ship on the v0.16.x line so LTS installs can pin. Prod installs track `lts`.
+- **Ownership**: one dev orchestrator + the codex pair own *both* lines; the fleet are consumers. A dedicated LTS agent is only warranted post-fork when feature + backport work compete — and then via a **worktree**, not a separate clone/folder.
+
 ## Environment Variables Worth Knowing
 
 - `BRIDGE_HOME` — override live runtime root; essential for isolated tests.

--- a/docs/release-lines.md
+++ b/docs/release-lines.md
@@ -1,0 +1,63 @@
+# Release Lines & LTS Policy
+
+This file is the canonical policy for how Agent Bridge versions are branched, supported, and shipped. CLAUDE.md and AGENTS.md carry the headlines and point here. Operator-decided 2026-06-08 (with the v0.16.2 LTS cut); update this file when the policy changes.
+
+## Model: one LTS line + a mainline
+
+Agent Bridge runs a **Long-Term Support (LTS) line** for conservative/production installs plus a **mainline** for new development. An LTS is not a separate product — it is a blessed stable tag on a maintenance line that only receives vetted fixes. LTS and mainline share ~all code; they differ only in *what is allowed to land*.
+
+- **`main`** — mainline development. After the first new feature lands it carries the next minor's beta (e.g. `v0.17.0-beta`). All new features and refactors go here first. **New features ship on a beta line first, never directly onto a stable/LTS line.**
+- **`release/0.16-lts`** (created at fork time) — the LTS maintenance branch. Only backports that meet the criteria below land here, each cut as `v0.16.3`, `v0.16.4`, …
+
+### One line until features diverge — do not fork prematurely
+
+An LTS line and a mainline only pay off **once there is real feature divergence**. Until the first new *feature* exists, there is a single line (`main`), and the v0.16.x **hardening** sequence (v0.16.3, …) rides `main` and *is* the LTS line. Forking a maintenance branch before there is divergent work just creates two branches that must be kept in sync for no benefit.
+
+### Fork trigger
+
+The **first real new feature** is the fork point. At that moment:
+
+1. Branch `release/0.16-lts` from the latest `v0.16.x` tag.
+2. Bump `main` to `v0.17.0-beta` and start feature development there.
+
+## Current LTS
+
+- **v0.16.2 — declared LTS 2026-06-08.** GitHub release titled `v0.16.2 (LTS)` (Latest); README current-stable line marked LTS. Converged across the fleet (macbook / SYRS mac-mini / cm-prod) + a 4th host (ip-10-242, AL2023) + orbstack Linux iso v2 VM-verify, zero new issues.
+- An LTS is declared only on **proven convergence**: shipped + tagged, VM-verified on Linux iso v2, and a full fleet re-rollout surfacing zero new issues. (LTS declaration is delegated to the dev orchestrator when results are good — report, don't ask.)
+
+## Support window
+
+An LTS receives qualifying fixes **until the next LTS is declared** (operator, 2026-06-08). When the next LTS ships, the previous LTS support ends (optionally with a short overlap — decide per-cut; default is no overlap).
+
+## Backport criteria (what may land on the LTS branch)
+
+Land on the LTS branch **only**:
+
+- Security fixes
+- Data loss / corruption
+- Upgrade / rollback breakage
+- A regression that takes a fleet host down
+
+**Not** on the LTS branch: new features, cosmetic fixes, performance-only changes (unless severe), refactors.
+
+**Fix flow:** land on `main` first, then cherry-pick to the LTS branch **only if** it meets the criteria above. Most fixes are main-only; only qualifying fixes get backported.
+
+## Versioning
+
+- LTS line: **patch** bumps — `v0.16.3`, `v0.16.4`, …
+- Mainline features: **minor** bump — `v0.17.0`, … The next LTS candidate is typically a later minor (e.g. `v0.18.0`).
+- Bump size is the **operator's call** (standing preference: small bumps). A capability-add in a patch bump is allowed when the operator directs it (e.g. the `lts` channel in v0.16.3).
+- Every release — LTS patch or mainline — still requires **explicit operator GO**, codex pair-review, and the README/docs sync (see CLAUDE.md "Releases require explicit operator permission").
+
+## Upgrade-channel mapping (operational enforcement)
+
+The LTS designation must be **enforced by the upgrader**, or it is only a label:
+
+- Today `--channel stable` (the default) resolves to the **highest global `vX.Y.Z` tag** (`bridge_upgrade_latest_stable_tag` sorts all tags and takes the max). So the moment `v0.17.0` ships, every default-channel install would auto-jump **off** the v0.16 LTS on its next `upgrade --apply`. The LTS is currently **unenforced**.
+- **v0.16.3 adds an `lts` channel** (a version-line pin that resolves to the latest `v0.16.x` tag). It **must ship on the v0.16.x line itself** so existing v0.16 installs can pin to their own line. The upgrader is a High-Risk area (CLAUDE.md High-Risk #3) → design it with codex direction-consensus first, leave the default channel behavior unchanged.
+- **Channel guidance**: conservative / production installs (e.g. cm-prod) track `lts`. Adventurous installs track `stable` (latest stable), `dev` (main), or `current`/`--source` (the checkout).
+
+## Agent ownership
+
+- **One dev orchestrator** (`agb-dev-claude`) + **one codex pair** (`agb-dev-codex`) own **both** lines for now. The fleet patches (macbook / SYRS / cm-prod / ip-10-242) are **consumers** of releases, not co-developers.
+- A **dedicated LTS agent** is warranted only **after the mainline fork**, when feature work on `main` and backporting to the LTS branch genuinely run concurrently and compete for one orchestrator's attention. Even then, use a **`git worktree` + an agent in the same repo** — **not** a separate clone/folder. Two working directories from one clone is the idiom; a second full checkout is only worth it for OS-user/credential isolation, which is not needed yet.


### PR DESCRIPTION
Captures the LTS-line/mainline policy so future sessions don't lose it — operator ask 2026-06-08 ("앞으로 세션에서도 에이전트가 잊지 않도록 CLAUDE.md / AGENTS.md 업데이트").

## What
- **`docs/release-lines.md`** (new) — canonical policy: model, fork trigger, current LTS, support window, backport criteria, versioning, channel mapping, agent ownership.
- **`CLAUDE.md`** — new `## Release Lines & LTS Policy` section (headlines + pointer), after "Releases require explicit operator permission".
- **`AGENTS.md`** — new `### 3a. Release lines & LTS policy` (Codex-facing headlines + pointer), after "3. Release mechanics".

## Policy (operator-decided 2026-06-08 with the v0.16.2 LTS cut)
- Current **LTS = v0.16.2**.
- **One line until features diverge** — v0.16.x hardening (v0.16.3, …) rides `main` and *is* the LTS line; don't fork prematurely.
- **Fork trigger** = first new feature → branch `release/0.16-lts` at the latest v0.16.x tag, bump `main` to `v0.17.0-beta`. New features → beta first, never onto the LTS line.
- **Support window** = until the next LTS is declared.
- **Backport criteria** (LTS branch only) = security / data-loss / upgrade-rollback breakage / fleet-host-down regression; fix on `main` first, cherry-pick back only if it qualifies.
- **Channel enforcement**: `--channel stable` resolves to the highest *global* tag today, so an `lts` version-line-pin channel lands in **v0.16.3** (on the v0.16.x line) so LTS installs don't auto-jump when a higher minor ships.
- **Ownership**: one dev orchestrator + codex pair own both lines; dedicated LTS agent only warranted post-fork, via a worktree (not a separate clone/folder).

Docs-only. No VERSION/CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)