### PR TITLE
a2a: thread active config_path through reconcile desired-config writers (#11573 integration fix)

### DIFF
--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -1061,6 +1061,12 @@ def _run_reconcile_steps(server: "HandoffServer", result: "ReconcileResult",
         # stubs. Fall back to the default.
         transport = a2a.TRANSPORT_TAILSCALE
 
+    # The active config the receiver loaded (set on `serve --config <path>`,
+    # else None → adapters resolve the default). Threaded into the steps that
+    # PERSIST desired config so a custom-config daemon converges its OWN file
+    # instead of drifting the default one forever (integration review #11573).
+    config_path = getattr(server, "config_path", None)
+
     try:
         # open_reconcile_db mkdir's the handoff dir, so an OSError (read-only fs,
         # perms) is as possible as a sqlite3.Error on a corrupt/locked store —
@@ -1084,7 +1090,7 @@ def _run_reconcile_steps(server: "HandoffServer", result: "ReconcileResult",
         # 1. stable-addr — proposes desired listen address (stub #1705).
         r = reconcile.run_step(
             conn, reconcile.STEP_STABLE_ADDR,
-            lambda: reconcile.stable_local_addr(transport, proof_cfg),
+            lambda: reconcile.stable_local_addr(transport, proof_cfg, config_path),
             on_event=_emit)
         result.steps[reconcile.STEP_STABLE_ADDR] = r.status
 
@@ -1112,7 +1118,7 @@ def _run_reconcile_steps(server: "HandoffServer", result: "ReconcileResult",
         # 4. peer-reachability (stub #1707).
         r = reconcile.run_step(
             conn, reconcile.STEP_PEER_REACHABILITY,
-            lambda: reconcile.peer_reachability_step(proof_cfg, conn),
+            lambda: reconcile.peer_reachability_step(proof_cfg, conn, config_path),
             on_event=_emit)
         result.steps[reconcile.STEP_PEER_REACHABILITY] = r.status
 

--- a/bridge_reconcile_common.py
+++ b/bridge_reconcile_common.py
@@ -400,7 +400,8 @@ def all_step_status(conn: sqlite3.Connection) -> dict[str, dict[str, Any]]:
 # config; the actual bind stays behind resolve_bind() in bridge-handoffd.py.
 
 
-def stable_local_addr(transport: str, cfg: dict[str, Any]) -> ReconcileStepResult:
+def stable_local_addr(transport: str, cfg: dict[str, Any],
+                      config_path: Optional[Path] = None) -> ReconcileStepResult:
     """Detect the stable substrate listen address and converge desired config (#1705).
 
     Detect the stable address the receiver SHOULD listen on for `transport`
@@ -500,7 +501,14 @@ def stable_local_addr(transport: str, cfg: dict[str, Any]) -> ReconcileStepResul
     try:
         listen["address"] = observed
         cfg["listen"] = listen
-        a2a.write_config_atomic(a2a.config_path(), cfg)
+        # Persist to the ACTIVE config the receiver loaded — `config_path` when
+        # the daemon was started with `serve --config <path>`, else the default
+        # (BRIDGE_A2A_CONFIG / bridge-home) resolved by a2a.config_path(). Without
+        # this the writer would drift the DEFAULT file while the receiver keeps
+        # reloading the unchanged custom file, re-proposing the same drift every
+        # tick and never converging (integration review #11573, the cross-lane
+        # L0×L1×L3 config_path seam).
+        a2a.write_config_atomic(config_path or a2a.config_path(), cfg)
     except (OSError, a2a.A2AError) as exc:
         # Roll the in-memory desired back so a failed persist does not leave the
         # live cfg dict claiming a converged state it never wrote to disk.
@@ -960,7 +968,8 @@ def _local_listen_address_drifted(transport: str,
 
 
 def peer_reachability_step(cfg: dict[str, Any],
-                           conn: sqlite3.Connection) -> ReconcileStepResult:
+                           conn: sqlite3.Connection,
+                           config_path: Optional[Path] = None) -> ReconcileStepResult:
     """Advance the per-peer UP→SUSPECT→DOWN→(recovery)→UP state machine (#1707).
 
     For each configured peer this step probes reachability via a lightweight
@@ -1190,7 +1199,9 @@ def peer_reachability_step(cfg: dict[str, Any],
     if any_unreachable:
         drifted = _local_listen_address_drifted(transport, cfg)
         if drifted is True:
-            drift_res = stable_local_addr(transport, cfg)
+            # Thread the active config_path so the IP-drift rebind persists to the
+            # SAME file the receiver loaded (not the default) — #11573 seam.
+            drift_res = stable_local_addr(transport, cfg, config_path)
             # stable_local_addr returns step_changed when it actually updated
             # the desired listen.address (the rebind we want recorded). A
             # converged/error result means there was nothing to (or it could

--- a/scripts/smoke/v0165-l1-stable-addr-helper.py
+++ b/scripts/smoke/v0165-l1-stable-addr-helper.py
@@ -281,6 +281,51 @@ def cmd_malformed(repo_root: str, cfg_path: str) -> int:
     return 0
 
 
+def cmd_custom_config_path(repo_root: str, cfg_path: str) -> int:
+    """A `serve --config <custom>` daemon must drift the CUSTOM file, not default.
+
+    Integration review #11573 (cross-lane L0×L1×L3 config_path seam): the
+    reconcile writer used to persist desired drift to `a2a.config_path()`
+    (BRIDGE_A2A_CONFIG / bridge-home default) regardless of the active config
+    the receiver loaded. A daemon started on a custom `--config` path then
+    drifted the DEFAULT file forever and never converged its own. This asserts
+    the threaded `config_path` makes the writer update the SAME file and leave
+    the default untouched. The custom path is passed via L1_CUSTOM_CFG to keep
+    the 3-arg helper argv contract.
+    """
+    from pathlib import Path
+    reconcile = _load_reconcile(repo_root)
+    a2a = _load_a2a(repo_root)
+    custom_path = os.environ.get("L1_CUSTOM_CFG", "")  # noqa: iso-helper-boundary
+    if not custom_path or not os.path.exists(custom_path):
+        sys.stderr.write("FAIL custom-config: L1_CUSTOM_CFG not set/missing\n")
+        return 1
+    # cfg_path is the DEFAULT (BRIDGE_A2A_CONFIG) — must stay byte-identical.
+    default_before = _read_listen_addr(cfg_path)
+    with open(custom_path, encoding="utf-8") as fh:
+        custom_cfg = json.load(fh)
+    expected = a2a.tailscale_stable_addr()
+    res = reconcile.stable_local_addr("tailscale", custom_cfg, Path(custom_path))
+    if res.status != reconcile.RESULT_CHANGED:
+        sys.stderr.write(
+            f"FAIL custom-config: status {res.status} ({res.detail})\n")
+        return 1
+    # The CUSTOM file got the stable addr...
+    if _read_listen_addr(custom_path) != expected:
+        sys.stderr.write(
+            f"FAIL custom-config: custom file not updated to {expected}\n")
+        return 1
+    # ...and the DEFAULT (BRIDGE_A2A_CONFIG) file was NOT drifted (the bug).
+    if _read_listen_addr(cfg_path) != default_before:
+        sys.stderr.write(
+            f"FAIL custom-config: DEFAULT config drifted ({default_before} -> "
+            f"{_read_listen_addr(cfg_path)}); writer ignored the active "
+            f"--config path (the #11573 regression)\n")
+        return 1
+    print(f"OK custom-config -> custom file updated to {expected}, default untouched")
+    return 0
+
+
 _COMMANDS = {
     "warp-converged": cmd_warp_converged,
     "warp-changed": cmd_warp_changed,
@@ -290,6 +335,7 @@ _COMMANDS = {
     "ts-error": cmd_ts_error,
     "isolation": cmd_isolation,
     "malformed": cmd_malformed,
+    "custom-config-path": cmd_custom_config_path,
 }
 
 

--- a/scripts/smoke/v0165-l1-stable-addr.sh
+++ b/scripts/smoke/v0165-l1-stable-addr.sh
@@ -239,6 +239,24 @@ malformed_transport_no_guess() {
     "(d) tailscale CLI never shelled under a guessed transport (config-derived kind validated)"
 }
 
+# === (f) active --config seam: a custom-config daemon drifts its OWN file, not
+# the default (integration review #11573, cross-lane L0×L1×L3 config_path) ===
+custom_config_path_drifts_active_file() {
+  # The DEFAULT (BRIDGE_A2A_CONFIG) carries a baseline addr that must stay put.
+  local default_cfg="$CFG_DIR/seam-default.json"
+  write_cfg "$default_cfg" '' "9.9.9.9"
+  # The custom `serve --config` file carries the drift to be corrected.
+  local custom_cfg="$CFG_DIR/seam-custom.json"
+  write_cfg "$custom_cfg" '' "1.2.3.4"
+  local out
+  out="$(BRIDGE_A2A_CONFIG="$default_cfg" \
+        BRIDGE_A2A_TAILSCALE_CLI="$TS_MOCK" \
+        L1_CUSTOM_CFG="$custom_cfg" \
+        run_helper custom-config-path "$default_cfg")"
+  smoke_assert_contains "$out" "OK custom-config" \
+    "(f) custom --config daemon drifts ITS OWN file; the default (BRIDGE_A2A_CONFIG) is left untouched (#11573)"
+}
+
 warp_changed
 warp_converged
 warp_error
@@ -247,5 +265,6 @@ ts_converged
 ts_error
 isolation_warp_never_shells_ts
 malformed_transport_no_guess
+custom_config_path_drifts_active_file
 
 smoke_log "ALL CHECKS PASSED ($SMOKE_NAME)"


### PR DESCRIPTION
Fix-forward on the v0.16.5 integration branch for the **BLOCKING cross-lane finding** from the integration full-branch review (#11573).

## The bug (L0×L1×L3 config_path seam)
The Lane-1 stable-address reconcile writer persisted desired listen-address drift to `a2a.config_path()` (BRIDGE_A2A_CONFIG / bridge-home default) regardless of the active config the receiver loaded via `serve --config <path>`. `reconcile_once` already carried `config_path`, but `_run_reconcile_steps` called `stable_local_addr(transport, proof_cfg)` with no path, and the writer wrote to `a2a.config_path()`. A custom-config daemon drifted the **default** file forever while reloading its unchanged custom file each tick → re-proposed the same drift, never converged the real bind.

## Fix
Thread the active `config_path` (`server.config_path`, set on `serve --config`) into the two reconcile steps that persist desired config:
- `stable_local_addr(transport, cfg, config_path=None)` → writes `config_path or a2a.config_path()`.
- `peer_reachability_step(cfg, conn, config_path=None)` → forwards it to its nested IP-drift `stable_local_addr` call.
- `_run_reconcile_steps` derives `config_path = getattr(server, "config_path", None)` and passes it to both.

**Default-path behavior is byte-identical** (`config_path=None` → `a2a.config_path()`), so the VM-verify GO + 5-node churn (both default-config) remain valid.

## Verification
- Reproduced codex's exact repro: with the fix, the custom config is updated to the stable addr and the default is NOT created.
- New L1 smoke tooth `(f) custom-config-path` asserts a custom-config daemon drifts ITS OWN file and leaves the default untouched.
- L0/L1/L3/L6 smokes PASS; py_compile + bash -n + shellcheck clean; whole-diff os.environ pre-verify = 0 un-noqa'd.

Base = `feat/v0165-rooms-mesh` (integration). No VERSION/CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)