### PR TITLE
a2a: WARP bounce gate honors transient-peer class (#1732 × #1733 cross-lane fix)

### DIFF
--- a/bridge_reconcile_common.py
+++ b/bridge_reconcile_common.py
@@ -802,9 +802,24 @@ def _fresh_peer_reachability_loss(conn: sqlite3.Connection, cfg: dict[str, Any],
     peers = cfg.get("peers")
     if not isinstance(peers, list):
         return None, counts
-    peer_ids = [str(p.get("id")) for p in peers
-                if isinstance(p, dict) and p.get("id")]
+    # #1732 × #1733 cross-lane (codex integration review): the WARP bounce gate
+    # acts ONLY on BOUNCE-RELEVANT (persistent / alarm-on) peers. A transient
+    # (expected-disconnect, #1732) peer going suspect/down is NOT proof of
+    # substrate loss — counting it would bounce the tunnel on an expected blip,
+    # and a transient peer's stale state would even suppress a real persistent-
+    # loss bounce. `peer_alarm_on_unreachable` is the SAME policy the stuck-outbox
+    # admin alarm consumes (persistent default + explicit per-peer override).
+    bounce_relevant = [p for p in peers
+                       if isinstance(p, dict) and p.get("id")
+                       and a2a.peer_alarm_on_unreachable(p)]
+    counts["transient_excluded"] = sum(
+        1 for p in peers
+        if isinstance(p, dict) and p.get("id")
+        and not a2a.peer_alarm_on_unreachable(p))
+    peer_ids = [str(p.get("id")) for p in bounce_relevant]
     if not peer_ids:
+        # No bounce-relevant peers configured (all transient / alarm-off) — we
+        # can prove neither all-up nor a real loss; never bounce.
         return None, counts
 
     window = warp_peer_freshness_window()

--- a/scripts/smoke/v0166-la-tunnel-bounce-gate-helper.py
+++ b/scripts/smoke/v0166-la-tunnel-bounce-gate-helper.py
@@ -498,6 +498,157 @@ def cmd_mixed_loss_stale(repo_root: str) -> int:
     return 0
 
 
+def cmd_transient_only(repo_root: str) -> int:
+    """#1732 × #1733 cross-lane: a TRANSIENT-only mesh whose sole peer is fresh-
+    DOWN must NEVER bounce — a transient (expected-disconnect) peer is not
+    bounce-relevant, so there is no proof of substrate loss (codex integration
+    review)."""
+    reconcile = _load_reconcile(repo_root)
+    a2a = _load_a2a(repo_root)
+    transport = a2a.TRANSPORT_CLOUDFLARE_WARP_MESH
+    cfg = {"transport": {"kind": "cloudflare-warp-mesh"},
+           "listen": {"address": "10.128.0.25", "port": 8787},
+           "peers": [{"id": "laptop", "class": "transient"}]}
+
+    bounce = _Spy()
+    soft = _Spy()
+    orig_b = reconcile._WARP_TUNNEL_BOUNCE
+    orig_s = reconcile._WARP_TUNNEL_SOFT_REFRESH
+    orig_age = a2a.warp_tunnel_handshake_age
+    reconcile._WARP_TUNNEL_BOUNCE = bounce
+    reconcile._WARP_TUNNEL_SOFT_REFRESH = soft
+    a2a.warp_tunnel_handshake_age = lambda: 5106
+    conn = reconcile.open_reconcile_db()
+    n = reconcile.warp_stale_streak_threshold()
+    try:
+        last = None
+        for _ in range(n + 1):
+            _seed_peers(reconcile, conn,
+                        {"laptop": reconcile.PEER_STATE_DOWN}, time.time())
+            last = reconcile.tunnel_health(transport, cfg, conn)
+    finally:
+        reconcile._WARP_TUNNEL_BOUNCE = orig_b
+        reconcile._WARP_TUNNEL_SOFT_REFRESH = orig_s
+        a2a.warp_tunnel_handshake_age = orig_age
+        conn.close()
+
+    if bounce.calls != 0 or soft.calls != 0:
+        sys.stderr.write(
+            f"FAIL transient-only: bounce={bounce.calls} soft={soft.calls} on a "
+            "transient-only DOWN mesh (a transient peer is not bounce-relevant)\n")
+        return 1
+    if last.fields.get("bounce_suppressed_reason") != \
+            reconcile.BOUNCE_SUPPRESSED_PEER_STATE_UNKNOWN:
+        sys.stderr.write(
+            f"FAIL transient-only: wrong suppressed reason {last.fields}\n")
+        return 1
+    print(f"OK transient-only bounces={bounce.calls} "
+          f"peer_counts={last.fields.get('peer_counts')} "
+          f"reason={last.fields.get('bounce_suppressed_reason')}")
+    return 0
+
+
+def cmd_persistent_up_transient_down(repo_root: str) -> int:
+    """#1732 × #1733: persistent peer fresh-UP + transient peer fresh-DOWN must
+    NOT bounce — the only bounce-relevant peer is up (codex integration review)."""
+    reconcile = _load_reconcile(repo_root)
+    a2a = _load_a2a(repo_root)
+    transport = a2a.TRANSPORT_CLOUDFLARE_WARP_MESH
+    cfg = {"transport": {"kind": "cloudflare-warp-mesh"},
+           "listen": {"address": "10.128.0.25", "port": 8787},
+           "peers": [{"id": "server"}, {"id": "laptop", "class": "transient"}]}
+
+    bounce = _Spy()
+    soft = _Spy()
+    orig_b = reconcile._WARP_TUNNEL_BOUNCE
+    orig_s = reconcile._WARP_TUNNEL_SOFT_REFRESH
+    orig_age = a2a.warp_tunnel_handshake_age
+    reconcile._WARP_TUNNEL_BOUNCE = bounce
+    reconcile._WARP_TUNNEL_SOFT_REFRESH = soft
+    a2a.warp_tunnel_handshake_age = lambda: 5106
+    conn = reconcile.open_reconcile_db()
+    n = reconcile.warp_stale_streak_threshold()
+    try:
+        last = None
+        for _ in range(n + 1):
+            _seed_peers(reconcile, conn, {
+                "server": reconcile.PEER_STATE_UP,
+                "laptop": reconcile.PEER_STATE_DOWN}, time.time())
+            last = reconcile.tunnel_health(transport, cfg, conn)
+    finally:
+        reconcile._WARP_TUNNEL_BOUNCE = orig_b
+        reconcile._WARP_TUNNEL_SOFT_REFRESH = orig_s
+        a2a.warp_tunnel_handshake_age = orig_age
+        conn.close()
+
+    if bounce.calls != 0 or soft.calls != 0:
+        sys.stderr.write(
+            f"FAIL persistent-up-transient-down: bounce={bounce.calls} "
+            f"soft={soft.calls} (the bounce-relevant peer is UP — no bounce)\n")
+        return 1
+    if last.fields.get("bounce_suppressed_reason") != \
+            reconcile.BOUNCE_SUPPRESSED_ALL_PEERS_FRESH_UP:
+        sys.stderr.write(
+            f"FAIL persistent-up-transient-down: wrong reason {last.fields}\n")
+        return 1
+    print(f"OK persistent-up-transient-down bounces={bounce.calls} "
+          f"peer_counts={last.fields.get('peer_counts')} "
+          f"reason={last.fields.get('bounce_suppressed_reason')}")
+    return 0
+
+
+def cmd_persistent_down_transient_up(repo_root: str) -> int:
+    """#1732 × #1733: persistent peer fresh-DOWN + transient peer fresh-UP DOES
+    bounce after the N-streak — a transient peer must not DILUTE a real
+    persistent loss (codex integration review)."""
+    reconcile = _load_reconcile(repo_root)
+    a2a = _load_a2a(repo_root)
+    transport = a2a.TRANSPORT_CLOUDFLARE_WARP_MESH
+    cfg = {"transport": {"kind": "cloudflare-warp-mesh"},
+           "listen": {"address": "10.128.0.25", "port": 8787},
+           "peers": [{"id": "server"}, {"id": "laptop", "class": "transient"}]}
+
+    order: list = []
+    bounce = _OrderSpy("bounce", order)
+    soft = _OrderSpy("soft", order)
+    orig_b = reconcile._WARP_TUNNEL_BOUNCE
+    orig_s = reconcile._WARP_TUNNEL_SOFT_REFRESH
+    orig_age = a2a.warp_tunnel_handshake_age
+    reconcile._WARP_TUNNEL_BOUNCE = bounce
+    reconcile._WARP_TUNNEL_SOFT_REFRESH = soft
+    a2a.warp_tunnel_handshake_age = lambda: 5106
+    conn = reconcile.open_reconcile_db()
+    n = reconcile.warp_stale_streak_threshold()
+    try:
+        results = []
+        for _ in range(n):
+            _seed_peers(reconcile, conn, {
+                "server": reconcile.PEER_STATE_DOWN,
+                "laptop": reconcile.PEER_STATE_UP}, time.time())
+            results.append(reconcile.tunnel_health(transport, cfg, conn))
+    finally:
+        reconcile._WARP_TUNNEL_BOUNCE = orig_b
+        reconcile._WARP_TUNNEL_SOFT_REFRESH = orig_s
+        a2a.warp_tunnel_handshake_age = orig_age
+        conn.close()
+
+    if bounce.calls != 1:
+        sys.stderr.write(
+            f"FAIL persistent-down-transient-up: bounce fired {bounce.calls}x "
+            f"over {n} ticks (want exactly 1 — a real persistent loss bounces "
+            "despite the transient peer being up)\n")
+        return 1
+    if order != ["soft", "bounce"]:
+        sys.stderr.write(
+            f"FAIL persistent-down-transient-up: order {order} "
+            "(soft must precede bounce)\n")
+        return 1
+    print(f"OK persistent-down-transient-up N={n} bounces={bounce.calls} "
+          f"order={order} "
+          f"peer_counts={results[-1].fields.get('peer_counts')}")
+    return 0
+
+
 _COMMANDS = {
     "all-up": cmd_all_up,
     "loss-bounces": cmd_loss_bounces,
@@ -506,6 +657,9 @@ _COMMANDS = {
     "mixed-loss-stale": cmd_mixed_loss_stale,
     "soft-first": cmd_soft_first,
     "soft-no-disc": cmd_soft_no_disc,
+    "transient-only": cmd_transient_only,
+    "persistent-up-transient-down": cmd_persistent_up_transient_down,
+    "persistent-down-transient-up": cmd_persistent_down_transient_up,
 }
 
 
@@ -514,7 +668,8 @@ def main() -> int:
         sys.stderr.write(
             "usage: v0166-la-tunnel-bounce-gate-helper.py "
             "<all-up|loss-bounces|single-stale|unknown-stale|mixed-loss-stale|"
-            "soft-first|soft-no-disc> <repo_root>\n")
+            "soft-first|soft-no-disc|transient-only|persistent-up-transient-down|"
+            "persistent-down-transient-up> <repo_root>\n")
         return 2
     cmd, repo_root = sys.argv[1], sys.argv[2]
     _isolate_reconcile_db(cmd)

--- a/scripts/smoke/v0166-la-tunnel-bounce-gate.sh
+++ b/scripts/smoke/v0166-la-tunnel-bounce-gate.sh
@@ -147,4 +147,16 @@ smoke_assert_contains "$out_soft_first" "OK soft-first" "(e) soft-refresh is att
 out_soft_nd="$(run_helper soft-no-disc)"
 smoke_assert_contains "$out_soft_nd" "OK soft-no-disc" "(f) default soft-refresh nudges via connect, never disconnect"
 
+# --- (g) #1732 x #1733 cross-lane: a TRANSIENT peer's loss is NOT bounce-relevant ---
+out_tr_only="$(run_helper transient-only)"
+smoke_assert_contains "$out_tr_only" "OK transient-only" "(g) transient-only DOWN mesh -> NO bounce (transient peer not bounce-relevant)"
+smoke_assert_contains "$out_tr_only" "bounces=0" "(g) a transient peer going down never bounces the WARP tunnel"
+
+out_pu_td="$(run_helper persistent-up-transient-down)"
+smoke_assert_contains "$out_pu_td" "OK persistent-up-transient-down" "(h) persistent-UP + transient-DOWN -> NO bounce (the bounce-relevant peer is up)"
+smoke_assert_contains "$out_pu_td" "bounces=0" "(h) a transient-down peer alongside a healthy persistent peer never bounces"
+
+out_pd_tu="$(run_helper persistent-down-transient-up)"
+smoke_assert_contains "$out_pd_tu" "OK persistent-down-transient-up" "(i) persistent-DOWN + transient-UP -> bounce STILL fires after N-streak (transient must not dilute a real loss)"
+
 smoke_log "ALL CHECKS PASSED ($SMOKE_NAME)"


### PR DESCRIPTION

The v0.16.6 integration full-branch review (agb-dev-codex) caught a cross-lane
regression that no per-lane review could see: Lane B (#1732) made transient
(expected-disconnect) peers a distinct quiet/no-alarm class, but Lane A's
(#1733) WARP bounce classifier `_fresh_peer_reachability_loss()` still treated
EVERY configured peer as bounce-relevant. So a transient peer going fresh
suspect/down was counted as proven reachability loss and bounced the WARP
tunnel — and a transient peer's stale state could even suppress a real
persistent-loss bounce.

Fix: the loss classifier now builds its peer set from BOUNCE-RELEVANT peers only
— `a2a.peer_alarm_on_unreachable(p)` (persistent default + explicit per-peer
override), the SAME policy the stuck-outbox admin alarm already consumes. A
transient peer is excluded from the loss proof (and counted as
`transient_excluded` for observability). When no bounce-relevant peer is
configured the gate returns loss=None (never bounce).

Verified against codex's no-write probe:
- transient-only fresh-down            -> loss=None  (was True → bounce)
- persistent-up + transient-down       -> loss=False (was True → bounce)
- persistent-only down                 -> loss=True  (unchanged)
- persistent-down + transient-up       -> loss=True  (a transient peer does not
                                          dilute a real persistent loss)

Smoke v0166-la-tunnel-bounce-gate +3 cases (transient-only / persistent-up-
transient-down / persistent-down-transient-up) covering the exact axes the
review required. Lane B (v0166-lb-transient-peers) + reconcile smokes (l0/l2/l3)
unchanged. py_compile + bash -n + shellcheck + oss-preflight clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)