### PR TITLE
ci: raise lint-heredoc-ban timeout 5m->10m (chronic runner-congestion timeout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,11 @@ jobs:
     # See docs/developer-handover.md §5.7 and
     # scripts/lint-heredoc-ban.sh --baseline-check for the policy.
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 10m (not 5m): the scan itself is seconds, but a 5m wall was being hit
+    # (job killed at exactly 5m04s = `cancelled`) on congested ubuntu-latest
+    # runners during release waves, eating reruns on PRs whose diff has zero
+    # heredoc regression. 10m gives headroom without masking a real hang.
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What
Raise the `lint-heredoc-ban` CI job's `timeout-minutes` from **5 → 10**.

## Why
The job (scanner self-test + baseline ratchet) runs in **seconds** locally, but on congested `ubuntu-latest` runners during the v0.16.6 release wave it was being killed at **exactly 5m04s** (`conclusion=cancelled`) on multiple PRs whose diff has **zero** heredoc regression:
- #1744 head `0276955b` — codex implement-ok + `--self-test` PASS locally + diff-grep found no added heredoc; CI heredoc-ban cancelled twice (both reruns exhausted).
- #1745 head `9adfdfea` — fixer's `--baseline-check` PASS locally (C1=110 baseline); CI heredoc-ban `cancelled` at 5m04s.
- #1746 head — *passed* at **4m59s** (right at the boundary), proving the job fits in <5m only when the runner is fast.

This is a runner-congestion timeout, not a content failure. The tight 5m wall was eating reruns and blocking the wave. 10m gives headroom to absorb congestion while still surfacing a genuine hang.

## Scope
- `.github/workflows/ci.yml` — one job's `timeout-minutes` + an explanatory comment. **No scan-logic change.**
- Base: `feat/v0166-mesh-quiet` (folds into v0.16.6, no VERSION/CHANGELOG bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)