### PR TITLE
ci: raise unit/static smoke timeout 20m->25m (battery outgrew the wall)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,14 +128,15 @@ jobs:
   unit-static-smoke:
     name: unit/static smoke
     runs-on: ubuntu-latest
-    # 15m (not 10m): the required-smoke suite legitimately runs ~9m30s-10m on
-    # ubuntu-latest, so a 10m cap intermittently CANCELLED the job on normal
-    # runner variance (+20s tips it over) — surfacing as the recurring
-    # "unit/static smoke" false-red mislabeled as the #1509 kappa flake. The
-    # hermetic-snapshot fix in this PR closes a real source-mutation race but
-    # is secondary; the tight timeout was the dominant cause. 15m matches the
-    # integration-smoke budget below. See #1509.
-    timeout-minutes: 20
+    # 25m (was 20m; before that 15m/10m): the required-smoke battery grows with
+    # every release wave — by v0.16.6 it legitimately runs ~17-18m on a healthy
+    # ubuntu-latest runner, so the 20m cap was CANCELLED twice in one day on
+    # normal congestion variance (20m14s/20m16s, all smokes passing at the
+    # kill point). Same failure mode as the original #1509 10m-cap false-red.
+    # 25m gives ~40% headroom over the healthy-runner baseline without masking
+    # a genuine hang. If the battery crosses ~20m on healthy runners, split the
+    # suite instead of bumping again. See #1509.
+    timeout-minutes: 25
     needs:
       - syntax
       - lint


### PR DESCRIPTION
## What
Raise `unit-static-smoke` `timeout-minutes` **20 → 25** (comment updated with the rationale + a split-don't-bump guideline for the future).

## Why
The required-smoke battery grows with every release wave. By v0.16.6 it legitimately runs **~17-18m** on a healthy `ubuntu-latest` runner, so the 20m cap was **cancelled twice today** under normal congestion variance — #1749's runs died at **20m16s** and **20m14s** with every logged smoke passing at the kill point (`##[error]The operation was canceled.`). Same failure mode as the original #1509 10m-cap false-red that motivated the 15m and 20m bumps.

Sibling of #1747 (lint-heredoc-ban 5→10m, merged). One job's timeout + comment; no logic change. Base: `feat/v0166-mesh-quiet` (folds into v0.16.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)