### PR TITLE
bridge-agent: resume fresh/idle session on restart via trusted marker (#1769)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -6784,6 +6784,23 @@ run_restart() {
   local resume_session_snapshot=""
   resume_session_snapshot="$(bridge_agent_session_id "$agent" 2>/dev/null || true)"
 
+  # #1769: vouch for the snapshot id with a short-TTL trusted-resume marker so
+  # the relaunch's post-kill re-validation accepts that exact id once even
+  # though its pid is now dead — without this a freshly-started / idle session
+  # (live-session JSON only, no eligible transcript yet) is rejected and the
+  # agent launches fresh, silently defeating the #981 re-inject. Consumed by
+  # the resolver on the relaunch's decision-site accept; the short TTL is the
+  # crash backstop; cleared at every restart terminal point below.
+  #
+  # codex-r1 write-site defense: we do NOT trust the persisted id blindly.
+  # `_write_if_live` runs the resolver BEFORE the kill (pid still alive) and
+  # writes the marker ONLY when the #827 live-session shortcut accepts the id
+  # (sessions/<pid>.json carries it, pid alive, cwd matches, not quarantined).
+  # A stale or quarantined persisted id is therefore never vouched for. The
+  # helper is a no-op for non-claude engines / empty id.
+  bridge_agent_resume_trusted_marker_write_if_live "$agent" "$resume_session_snapshot" \
+    >/dev/null 2>&1 || true
+
   # Issue #1251 Phase 2 entry: pick the rollback snapshot + write the
   # in-progress marker BEFORE the kill. The marker is the Lane C2
   # (#1254) contract for watchdog drift suppression; the snapshot is the
@@ -6843,6 +6860,13 @@ run_restart() {
   restart_rollback() {
     local rb_kind="${1:-launch-failed}"
     local rb_detail="${2:-restart failed mid-flight}"
+
+    # #1769: drop the trusted-resume marker before rolling back — the
+    # rollback restores a PRIOR config and re-launches, so a vouch for the
+    # pre-rollback live id must not survive into the restored-config relaunch.
+    # The TTL would expire it anyway; clearing here makes the one-restart-
+    # cycle guarantee explicit instead of TTL-approximate.
+    bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
 
     # Mark the marker with rolled_back state up-front so a watchdog tick
     # that races the rollback's restart_once sees the terminal state
@@ -6909,6 +6933,9 @@ run_restart() {
     # operator's perspective" — clear the marker so a watchdog tick does
     # not enqueue drift on a no-verify happy path.
     bridge_agent_restart_marker_clear "$agent" 2>/dev/null || true
+    # #1769: restart cycle is done — drop any trusted-resume marker the
+    # relaunch did not already consume (idempotent; TTL is the backstop).
+    bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
     return 0
   fi
 
@@ -6922,6 +6949,9 @@ run_restart() {
   if bridge_tmux_wait_for_claude_plugin_mcp_alive "$agent" "$verify_timeout"; then
     # Issue #1251: success path — clear the marker + snapshot.
     bridge_agent_restart_marker_clear "$agent" 2>/dev/null || true
+    # #1769: restart cycle is done — drop any trusted-resume marker the
+    # relaunch did not already consume (idempotent; TTL is the backstop).
+    bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
     return 0
   fi
 
@@ -6942,6 +6972,13 @@ run_restart() {
       # block for the full rationale.
       bridge_load_roster >/dev/null 2>&1 || true
       resume_session_snapshot="$(bridge_agent_session_id "$agent" 2>/dev/null || true)"
+      # #1769: re-vouch for the (possibly advanced) live id before this
+      # kill too — the same dead-pid rejection applies on each verify-retry
+      # relaunch. `_write_if_live` re-validates against the CURRENT live
+      # session (and clears any prior marker first) so a retry never carries
+      # a stale vouch forward; a fresh write refreshes the TTL window.
+      bridge_agent_resume_trusted_marker_write_if_live "$agent" "$resume_session_snapshot" \
+        >/dev/null 2>&1 || true
       bridge_kill_agent_session "$agent" >/dev/null 2>&1 || true
       bridge_refresh_runtime_state
       if [[ -n "$resume_session_snapshot" ]]; then
@@ -6958,6 +6995,9 @@ run_restart() {
     if bridge_tmux_wait_for_claude_plugin_mcp_alive "$agent" "$verify_timeout"; then
       # Issue #1251: success path on a verify-retry — clear the marker.
       bridge_agent_restart_marker_clear "$agent" 2>/dev/null || true
+      # #1769: restart cycle is done — drop any trusted-resume marker the
+      # relaunch did not already consume (idempotent; TTL is the backstop).
+      bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
       return 0
     fi
   done
@@ -6973,6 +7013,10 @@ run_restart() {
     "${BRIDGE_AGENT_RESTART_MARKER_TTL:-60}" "rolled_back" \
     "verify-failed: plugin MCP liveness missing after $verify_max_attempts attempts (session left alive — see issue #69)" \
     >/dev/null 2>&1 || true
+  # #1769: terminal failure — the relaunch already consumed the marker on
+  # the last successful restart_once, but clear explicitly so no trusted
+  # vouch outlives this restart cycle (idempotent; TTL is the backstop).
+  bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
   return 1
 }
 

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -9081,6 +9081,194 @@ bridge_agent_restart_marker_clear() {
   return 0
 }
 
+# --------------------------------------------------------------------------
+# Issue #1769 — trusted-resume marker (one restart cycle, short TTL).
+#
+# `run_restart` snapshots and re-injects the live session id around its
+# SIGKILL (#981) so the relaunch emits `--resume <id>`. But the relaunch
+# re-validates that id post-kill through `bridge_resolve_resume_session_id`
+# → `resolve-claude-resume-session-id.py`, whose #827 live-session shortcut
+# requires an ALIVE pid. A freshly-started / idle session that has not yet
+# flushed a `>0`-byte in-window transcript has only its `sessions/<pid>.json`
+# record; after the kill that pid is dead, the transcript scan finds nothing
+# eligible (rc=1), `bridge_normalize_agent_session_id` clears the re-injected
+# id, and the agent launches fresh — silently defeating #981 for exactly the
+# case it was meant to protect.
+#
+# The id `run_restart` snapshots was, by construction, LIVE AND ACCEPTED
+# immediately before the kill. The trusted-resume marker honors that: after
+# validating the live session it is killing, `run_restart` writes this marker
+# and the resolver accepts that EXACT id once even though the pid is now
+# dead. It is additive — the marker only ever forces acceptance of the single
+# id `run_restart` just confirmed live, is bounded to one restart cycle (short
+# TTL + cleared at every restart terminal point), and never relaxes the
+# freshness/quarantine gate for any other id or any later resolve.
+#
+# Marker schema (key=value lines, mirrors restart.in-progress conventions):
+#   id=<session-id>     # the snapshotted, pre-kill-validated session id.
+#   started=<unix-ts>   # marker write time; the TTL window is measured from
+#                       # here so a stale/abandoned marker self-expires.
+#   ttl=<seconds>       # short window (minutes), default 300. Resolver
+#                       # acceptance is gated on `now < started + ttl`.
+# Lives under `state/agents/<a>/resume.trusted`, mode 0600 (controller-only;
+# unlike the watchdog marker the iso UID never needs to read this one — the
+# resolver consults it controller-side, or as the iso UID via the same
+# sudo-as-user path the resolver already takes for the jsonl scan).
+# --------------------------------------------------------------------------
+
+# Default trusted-resume marker TTL in seconds (issue #1769). Short by design
+# — it only needs to survive a single relaunch's resolver passes. Operators
+# can widen it for cold-cache hosts where `claude` first-launch is slow.
+: "${BRIDGE_RESUME_TRUSTED_MARKER_TTL:=300}"
+
+bridge_agent_resume_trusted_marker_path() {
+  local agent="$1"
+  printf '%s/resume.trusted' "$(bridge_agent_restart_state_dir "$agent")"
+}
+
+# Write the trusted-resume marker (low-level). The caller MUST have proven
+# the id is the live session — production callers go through
+# bridge_agent_resume_trusted_marker_write_if_live, which performs that
+# validation. Atomic write + mode 0600. A write failure is non-fatal to the
+# caller (best-effort: the worst case is the resolver falls back to the
+# normal freshness gate, i.e. today's behavior).
+#
+# Args:
+#   $1 — agent id
+#   $2 — session id (required; empty is a no-op success so callers can pass
+#        an unconditional snapshot without guarding)
+#   $3 — ttl seconds (defaults to BRIDGE_RESUME_TRUSTED_MARKER_TTL)
+bridge_agent_resume_trusted_marker_write() {
+  local agent="$1"
+  local session_id="${2:-}"
+  local ttl="${3:-$BRIDGE_RESUME_TRUSTED_MARKER_TTL}"
+  local state_dir=""
+  local marker=""
+  local started=""
+
+  [[ -n "$agent" ]] || return 1
+  # Empty id → nothing to trust. Not an error: run_restart passes the
+  # snapshot unconditionally and a session with no id simply has nothing
+  # to protect.
+  [[ -n "$session_id" ]] || return 0
+
+  state_dir="$(bridge_agent_restart_state_dir "$agent")"
+  marker="$(bridge_agent_resume_trusted_marker_path "$agent")"
+  started="$(date +%s)"
+
+  mkdir -p "$state_dir" 2>/dev/null || return 1
+
+  local tmp="${marker}.tmp.$$"
+  {
+    printf 'id=%s\n' "$session_id"
+    printf 'started=%s\n' "$started"
+    printf 'ttl=%s\n' "$ttl"
+  } >"$tmp" || { rm -f "$tmp" 2>/dev/null; return 1; }
+  mv -f "$tmp" "$marker" 2>/dev/null || { rm -f "$tmp" 2>/dev/null; return 1; }
+  chmod 0600 "$marker" 2>/dev/null || true
+  return 0
+}
+
+# Read the trusted-resume id IF the marker is present, well-formed, and
+# still inside its TTL window. Prints the id on stdout (rc=0) only when the
+# marker vouches for an in-window id; prints nothing + rc=1 otherwise
+# (absent, malformed, or expired). Expiry is the resolver's single-restart-
+# cycle backstop independent of run_restart's terminal cleanup.
+bridge_agent_resume_trusted_marker_id() {
+  local agent="$1"
+  local marker=""
+  local id="" started="" ttl="" now=""
+  marker="$(bridge_agent_resume_trusted_marker_path "$agent")"
+  [[ -f "$marker" ]] || return 1
+  id="$(awk -F'=' '$1=="id"{sub(/^[^=]*=/,""); print; exit}' "$marker" 2>/dev/null || true)"
+  started="$(awk -F'=' '$1=="started"{sub(/^[^=]*=/,""); print; exit}' "$marker" 2>/dev/null || true)"
+  ttl="$(awk -F'=' '$1=="ttl"{sub(/^[^=]*=/,""); print; exit}' "$marker" 2>/dev/null || true)"
+  [[ -n "$id" ]] || return 1
+  [[ "$started" =~ ^[0-9]+$ && "$ttl" =~ ^[0-9]+$ ]] || return 1
+  now="$(date +%s)"
+  (( now < started + ttl )) || return 1
+  printf '%s' "$id"
+  return 0
+}
+
+# Remove the trusted-resume marker. Idempotent. Called by the resolver on
+# consume (one-shot acceptance) AND by run_restart at every restart terminal
+# point (success, kill-switch, rollback) so a successful or rolled-back
+# restart never strands a trusted id past its cycle. The short TTL is the
+# crash backstop for a restart that dies before reaching a terminal point.
+bridge_agent_resume_trusted_marker_clear() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 0
+  rm -f "$(bridge_agent_resume_trusted_marker_path "$agent")" 2>/dev/null || true
+  return 0
+}
+
+# Validate-then-write the trusted-resume marker (issue #1769 codex-r1 write-
+# site defense). run_restart MUST NOT vouch for an id merely because it sits
+# in BRIDGE_AGENT_SESSION_ID — a stale or quarantined persisted id would then
+# be force-accepted on relaunch. This helper proves the candidate is the
+# CURRENT live session being killed before writing the marker:
+#
+#   - run it BEFORE the SIGKILL, while the pid is still alive, so the resolver's
+#     #827 live-session shortcut can fire;
+#   - it calls bridge_resolve_resume_session_id (the SSOT freshness/live/
+#     quarantine gate) with the candidate. rc=0 AND stdout == candidate means
+#     the #827 shortcut accepted it: `sessions/<pid>.json` carries this id,
+#     the pid is alive, the cwd matches the agent workdir, and the id is NOT
+#     in the resume-quarantine set (the #827 shortcut is quarantine-aware as
+#     of #1769 codex-r2). Any other outcome (rc=1 reject, rc=2 swap, or a
+#     different stdout) means the id is NOT the validated live session, so NO
+#     marker is written and the relaunch falls back to today's behavior.
+#
+# codex-r2 defense in depth: we ALSO reject up-front when the id is in the
+# agent's resume-quarantine set, before the resolver call, so the write-site
+# refusal does not depend solely on the resolver's quarantine-awareness.
+#
+# Returns 0 when a marker was written, 1 when validation failed / no marker.
+# Non-claude engines and an empty id are a no-op success (nothing to protect).
+bridge_agent_resume_trusted_marker_write_if_live() {
+  local agent="$1"
+  local session_id="${2:-}"
+  local ttl="${3:-$BRIDGE_RESUME_TRUSTED_MARKER_TTL}"
+  local workdir="" accepted="" rc=0 quarantine_csv=""
+
+  [[ -n "$agent" && -n "$session_id" ]] || return 1
+  [[ "$(bridge_agent_engine "$agent" 2>/dev/null)" == "claude" ]] || return 1
+
+  workdir="$(bridge_agent_workdir "$agent" 2>/dev/null || true)"
+  [[ -n "$workdir" ]] || return 1
+
+  # codex-r2 belt-and-braces: refuse to vouch for a quarantined id directly,
+  # independent of the resolver. The quarantine CSV is comma-delimited; match
+  # the whole id between delimiters so a substring cannot false-positive.
+  if command -v bridge_agent_resume_quarantine_ids >/dev/null 2>&1; then
+    quarantine_csv="$(bridge_agent_resume_quarantine_ids "$agent" 2>/dev/null || true)"
+    if [[ ",${quarantine_csv}," == *",${session_id},"* ]]; then
+      bridge_agent_resume_trusted_marker_clear "$agent"
+      return 1
+    fi
+  fi
+
+  # Clear any marker left from a prior kill in this same restart (the
+  # verify-retry path re-validates before each kill). Otherwise the
+  # validation resolve below would observe that stale marker and short-
+  # circuit accept, defeating the live re-check. We are about to either
+  # re-write it (validation passes) or intentionally leave it absent
+  # (validation fails), so dropping it first is correct either way.
+  bridge_agent_resume_trusted_marker_clear "$agent"
+
+  # Prove the id is the live session: the #827 shortcut accepts only a
+  # live-pid, same-cwd, non-quarantined candidate. We require the resolver
+  # to return rc=0 with the SAME id (rc=2 would mean it swapped to a
+  # fresher transcript — i.e. the candidate itself was not the live one).
+  accepted="$(bridge_resolve_resume_session_id claude "$agent" "$workdir" "$session_id" 2>/dev/null)" || rc=$?
+  if [[ "$rc" != 0 || "$accepted" != "$session_id" ]]; then
+    return 1
+  fi
+
+  bridge_agent_resume_trusted_marker_write "$agent" "$session_id" "$ttl"
+}
+
 # Snapshot the agent's managed block from the local roster file so the
 # rollback path can restore the pre-restart configuration if launch
 # fails after the kill. The snapshot captures the whole `# BEGIN AGENT

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -282,8 +282,14 @@ bridge_normalize_agent_session_id() {
       # rc=2 swaps in a fresher in-window transcript for the same workdir;
       # we persist that replacement here, since hydration sites intentionally
       # do not write state.
+      # Issue #1769: this is the decision/persist site, so it is the one
+      # call that consumes the trusted-resume marker on a rc=0 trusted
+      # accept (read-only hydration probes leave the flag unset). The
+      # accepted id is the live id run_restart re-injected; emitting it
+      # here is what restores `--resume <id>` on the relaunch.
       local _accepted="" _rc=0
-      _accepted="$(bridge_resolve_resume_session_id claude "$agent" "$workdir" "$session_id")" || _rc=$?
+      _accepted="$(BRIDGE_RESUME_TRUSTED_CONSUME=1 \
+        bridge_resolve_resume_session_id claude "$agent" "$workdir" "$session_id")" || _rc=$?
       case "$_rc" in
         0)
           ;;
@@ -4325,23 +4331,56 @@ bridge_resolve_resume_session_id() {
   # calls execute as the iso UID. Empty user → legacy direct-as-controller
   # invocation (back-compat for non-iso and dev hosts).
   local _resolve_py="$BRIDGE_SCRIPT_DIR/scripts/python-helpers/resolve-claude-resume-session-id.py"
+
+  # Issue #1769: trusted-resume marker. run_restart writes a short-TTL
+  # marker after validating the live session it kills; honor it here so
+  # the post-kill resolver accepts that exact id once even though the pid
+  # is now dead — repairing the #981 re-inject for a freshly-started /
+  # idle session that has no eligible transcript yet. We only pass a
+  # trusted id when it MATCHES the candidate (the resolver applies the
+  # same guard), so this can never force-resume an id other than the one
+  # the caller already holds. The marker is consumed below on the
+  # decision-site call so the bypass is genuinely one-shot.
+  local _trusted_id=""
+  if [[ -n "$agent" && -n "$candidate" ]] \
+      && command -v bridge_agent_resume_trusted_marker_id >/dev/null 2>&1; then
+    _trusted_id="$(bridge_agent_resume_trusted_marker_id "$agent" 2>/dev/null || true)"
+    [[ "$_trusted_id" == "$candidate" ]] || _trusted_id=""
+  fi
+
   local _iso_sudo_user=""
   if command -v bridge_resolve_agent_iso_sudo_user >/dev/null 2>&1; then
     _iso_sudo_user="$(bridge_resolve_agent_iso_sudo_user "$agent" 2>/dev/null || true)"
   fi
+  local _rc=0
   if [[ -n "$_iso_sudo_user" ]] \
       && command -v bridge_linux_sudo_as_user >/dev/null 2>&1; then
     local _bash_bin="${BRIDGE_BASH_BIN:-$(command -v bash 2>/dev/null || printf '/bin/bash')}"
     bridge_linux_sudo_as_user "$_iso_sudo_user" \
       "$_bash_bin" -c 'exec python3 "$@"' bash \
       "$_resolve_py" "$workdir" "$candidate" "$max_age_hours" "$agent" \
-      "$exclude_csv" "$claude_config_dir"
-    return $?
+      "$exclude_csv" "$claude_config_dir" "$_trusted_id"
+    _rc=$?
+  else
+    python3 "$_resolve_py" \
+      "$workdir" "$candidate" "$max_age_hours" "$agent" "$exclude_csv" \
+      "$claude_config_dir" "$_trusted_id"
+    _rc=$?
   fi
 
-  python3 "$_resolve_py" \
-    "$workdir" "$candidate" "$max_age_hours" "$agent" "$exclude_csv" \
-    "$claude_config_dir"
+  # Consume the trusted-resume marker on a decision-site accept so the
+  # bypass is one id / one restart cycle. Only the decision/persist site
+  # (bridge_normalize_agent_session_id) sets BRIDGE_RESUME_TRUSTED_CONSUME=1;
+  # read-only hydration probes leave it unset so they may observe the same
+  # trusted id without burning it before the launch builder runs. rc=0 with
+  # a non-empty trusted id is the only outcome that reflects the bypass
+  # firing (rc=1/2 mean the marker did not decide the result).
+  if [[ -n "$_trusted_id" && "$_rc" == 0 \
+        && "${BRIDGE_RESUME_TRUSTED_CONSUME:-0}" == 1 ]] \
+      && command -v bridge_agent_resume_trusted_marker_clear >/dev/null 2>&1; then
+    bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
+  fi
+  return $_rc
 }
 
 # Returns 0 (true) if the given workdir has any in-window

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -109,6 +109,12 @@ add_all_required_static() {
 
 add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering 1495-settings-invalid-hook-key 1453-channel-sticky-false-inbound 1455-settings-two-tree-doctor isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1342-write-state-marker-matrix 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys 1689-statusline-preserve-rerender 1756-settings-preserve-model-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup 1400-purge-home-degrade-no-sudo nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent 1323-nudge-eligibility-recheck-twostage 1199-action-required-claimed-skip tool-policy-roster-read-classify 1690-tasksdb-read-carveout 1692-admin-bash-symmetry 1709-shared-secret-suffix-guard 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1405-handoffd-supervision 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize 1209-ms365-redirect-resolver 1210-ms365-scope-normalize 1212-bridge-hooks-marketplace 1213-iso-uid-predicate 1214-channel-validator-iso-fallback 1215-ms365-dir-mode beta27-D-inject-timestamp-resolved beta27-E-hook-permission-fail-open-markers G-channel-spec-resolution F-daemon-supp-groups-mock F-daemon-supp-groups-real H-bootstrap-memory-iso-rebuild I-agent-description-roster ζ-1236-plugins-list-marketplaces β-1231-1236-fresh-install-seed-sudoers 6607-hook-admin-allowlist γ-cli-consistency δ-1234-daemon-start-policy B-beta3-1249-1250-plugin-ux C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir C-beta4-logger-and-spec B-beta4-setup-wizard A-beta4-iso-path-resolution D-beta4-daemon-lifecycle E-beta4-fresh-install-gate-state-dir H-beta4-iso-ownership F-beta4-oauth-bootstrap G-beta4-watchdog-noise I-beta4-a2a-3-gaps J-beta4-workflow-docs K-beta4-nits Beta-beta5-session-id-detect-sudo α-beta5-upgrade-backfill-normalize gamma-beta5-reconcile-helper-status beta5-1-session-id-detect-race dev-channel-auto-accept-no-attach mcp-liveness-giveup-auto-clear beta5-2-epsilon-tmux-inject-busy beta5-2-zeta-teams-mcp-dedup beta5-2-pi-daemon-crashloop-no-set-e-leak beta5-2-eta-cron-iso-uid-preflight beta5-2-delta-nudge-session-empty beta5-2-theta-upgrade-backfill-perms beta5-2-nu-daemon-path-quarantine beta5-2-kappa-state-audit-reconcile beta5-2-iota-daemon-escalation-family beta5-2-lambda-a2a-robustness beta5-2-mu-cron-channel-creds beta5-2-xi-misc-fixes 1359-cron-create-iso-staging 1379-iso-cron-staging-group 1383-iso-cron-result-json-group 1354-setup-teams-fd-password 1360-onboarding-next-actions-persona 1353-setup-pending-grace 1355-1356-ms365-wizard 1357-iso-boundary-quickref 1358-admin-credential-routine-exempt 1352-shared-codex-pair-path 1343-ms365-token-refresh 1378-iso-session-lock-fresh-start 1388-daemon-lock-fd-cloexec 1416-onboarding-state-field-anchor a2a-setup-wizard 1408-daemon-alert-nudge-hygiene 1409-claude-midturn-busy-gate 1427-A-roster-materialize 1427-B-template-sync-wizard 1426-cron-shell-noniso-help 1437-reactive-cron-rotation 1425-spool-rederive 1617-pending-attention-arrival-stale 1437-native-usage-probe 1468-usage-429-positive-signal 1464-cron-aware-stale-health 1497-v2-dynamic-handoff 1497-p1-home-resolver 1506-isolate-normalize 1497-p2-operator-home 1513-iso-teams-prune-eacces 1516-upgrade-downgrade-guard 1612-upgrade-restart-receiver plugin-requires-resolver 1520-shared-claude-config-dir 1520b-create-time-creds-sync 1520c-create-isolate-profile-publish 1533-create-isolate-content-publish 1402-stat-platform-order 1398-a2a-inbound-stopped-target-force 1463-launchd-keepalive-singleton-thrash 1470-engine-auth-seam 1470-codex-fleet-sync 1459-cron-dispatch-recovery 1417-identity-sync-on-start 1750-admin-workdir-identity-not-pair-template upgrade-migrate-rematerialize-workdir 1367-auth-sealed-paste 1563-daemon-singleton 9882-daemon-audit-fp 9981-iso-urgent-instant-wake 9981-iso-pending-attention-readable 1563-pr2-daemon-self-abort 1563-pr3-daemon-escalation 1563-pr4-a2a-receiver-healthz 1563-pr5-fp-control-matrix 1563-pr6-watchdog-scan-timeout 1563-pr7-tick-cadence 1563-pr8-a2a-diag-recovery 1602-dryrun-ref-fidelity 1601-conflicts-adopt-guard 1569-askuserquestion-bound 1611-migrate-orphan-skip 1613-wiki-mention-fence-indent 1623-a2a-backpressure-failopen 1628-a2a-deliver-per-row-guard 1631-nudge-helper-db-guard 1630-a2a-fresh-arrival-nudge 1637-agb-list-iso-marker 1635-iso-backup-perm-skip 1629-healthz-not-semaphore-gated 1640-urgent-from-override 1639-post-restart-auto-wake 1638-settings-cosmetic-conflict 1650-ms365-get-valid-token 1636-rematerialize-scaffolding 1659-cron-status-walk-perf 1663-plugin-cache-sidecar-skip 1660-upgrade-emit-brokenpipe 1661-upgrade-singleton-lock 1662-upgrade-complete-marker 1667-daemon-control-lock-serialize 1672-link-shared-settings-idempotent 1671-teams-eaddrinuse-diagnostic 1670-rematerialize-dryrun-agent-preserved 1677-cron-summary-short-derive lts-channel-sticky-resolver 1685-receiver-staleness-selfheal 1701-warp-healthz-socket-held 1697-a2a-net-status 1693-read-viewers v0165-l0-reconcile-skeleton v0165-l2-tunnel-health v0165-l1-stable-addr v0165-l3-peer-reachability v0165-l4-token-join v0165-l5-relay-roster v0165-l6-net-status-v2 v0166-la-tunnel-bounce-gate v0166-lb-transient-peers v0166-lc-config-set-env 1567-codex-orphan-upgrade-reaper 1675-1694-settings-homebrew-abspath-conflict 1652-queue-gateway-crashloop 11901-shared-global-settings-inherit 1759-selfref-global-loop-guard 1679-1680-a2a-receiver-supervisor-robustness 1762-picker-autoresolve 1764-ratchet-anchoring 1769-freshness-gate-resume
 add_required 1425-cron-dispatch-nudge-scope
+# Issue #1769: trusted-resume marker — a fresh/idle Claude agent restart now
+# resumes instead of launching a brand-new session. In the full static suite
+# so any scripts/smoke/* or session-resume helper change re-runs the
+# regression guard (no marker → still reject) alongside the acceptance +
+# single-use + launch-builder paths.
+add_required 1769-restart-trusted-resume
 # Issue #1755: dynamic-agent every-prompt UserPromptSubmit hook error
 # (FileNotFoundError on the prompt_timestamp tmp rename, from a fixed tmp name +
 # concurrent dup hook registration). In the static suite so any scripts/smoke/*
@@ -540,6 +546,14 @@ select_for_path() {
         # bridge-agent.sh move so a refactor cannot drop the guard or let the
         # plan drift back into perpetual needs-rerender on the self-ref layout.
         add_required 1759-selfref-global-loop-guard
+        # Issue #1769: bridge-agent.sh's run_restart writes the short-TTL
+        # trusted-resume marker after validating the live session it kills,
+        # so the relaunch's post-kill resolver accepts that exact id once
+        # despite the now-dead pid (repairing the #981 re-inject for a
+        # fresh/idle session with no eligible transcript yet). Pull the smoke
+        # on every bridge-agent.sh move so a refactor cannot drop the marker
+        # write (re-breaking fresh/idle restart resume).
+        add_required 1769-restart-trusted-resume
       fi
       ;;
     lib/bridge-cron.sh|lib/bridge-state.sh)
@@ -624,6 +638,15 @@ select_for_path() {
         # bridge-state.sh move so a refactor of the resume-id helper cannot
         # silently re-break the silent-fresh-discard fix.
         add_required 1769-freshness-gate-resume
+        # Issue #1769 mechanism 1: lib/bridge-state.sh's
+        # bridge_resolve_resume_session_id threads the trusted-resume marker id
+        # to the python resolver and consumes it on the decision-site accept
+        # (BRIDGE_RESUME_TRUSTED_CONSUME=1 set only by
+        # bridge_normalize_agent_session_id). Pull the smoke on every
+        # bridge-state.sh move so a refactor cannot drop the marker plumbing
+        # (re-breaking #981 fresh/idle restart resume) or consume on a
+        # read-only hydration probe (burning it pre-launch).
+        add_required 1769-restart-trusted-resume
       fi
       ;;
 
@@ -3796,7 +3819,15 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # `bridge_resolve_agent_iso_sudo_user` returned empty for this
       # PID). Pull the smoke whenever either helper moves so a change to
       # the read-side contract cannot regress the write-side guard.
-      add_required 1015-resume-claude-config-dir 981-restart-session-resume-snapshot Beta-beta5-session-id-detect-sudo beta5-1-session-id-detect-race
+      #
+      # Issue #1769: resolve-claude-resume-session-id.py gained the
+      # trusted_id (argv[7]) acceptance — when the candidate equals the id
+      # run_restart vouched for via the short-TTL marker, the live-session
+      # shortcut accepts it despite the dead pid. Pull 1769-restart-trusted-
+      # resume on every helper move so a refactor cannot drop the trusted
+      # accept (re-breaking fresh/idle restart resume) or widen it past the
+      # candidate==trusted_id guard into a freshness-gate bypass.
+      add_required 1015-resume-claude-config-dir 981-restart-session-resume-snapshot Beta-beta5-session-id-detect-sudo beta5-1-session-id-detect-race 1769-restart-trusted-resume
       add_integration integration-minimal
       ;;
 
@@ -3885,6 +3916,14 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # master-list / catch-all coupling cannot silently drop it on a
       # bridge-lib.sh / bridge-config.sh move.
       add_required v0166-lc-config-set-env
+      # Issue #1769: lib/bridge-agents.sh hosts the trusted-resume marker
+      # helpers (bridge_agent_resume_trusted_marker_write / _id / _clear /
+      # _path) that run_restart writes and the resolver consults.
+      # `add_all_required_static` already pulls the smoke via the master
+      # list; the explicit add_required pins it independently so a future
+      # master-list/catch-all coupling change cannot silently drop it on a
+      # bridge-agents.sh move.
+      add_required 1769-restart-trusted-resume
       ;;
 
     bridge-watchdog.py)

--- a/scripts/python-helpers/resolve-claude-resume-session-id.py
+++ b/scripts/python-helpers/resolve-claude-resume-session-id.py
@@ -30,6 +30,16 @@ Args (positional, order-sensitive):
         falls back to the `CLAUDE_CONFIG_DIR` env var, then `<HOME>/.claude`,
         then `os.path.expanduser("~/.claude")` — keeping the non-isolated
         path and existing call sites byte-for-byte unchanged.
+    sys.argv[7] — trusted_id (optional, issue #1769): a session id the bash
+        wrapper has vouched for via the short-TTL trusted-resume marker that
+        `run_restart` writes after validating the live session it killed.
+        When this equals the candidate, the live-session shortcut accepts the
+        candidate even though its pid is now dead — repairing the #981
+        re-inject for a freshly-started / idle session that had no eligible
+        transcript yet. The marker is TTL-bounded and consumed bash-side, so
+        this is additive (one id, one restart cycle) and never relaxes the
+        freshness/quarantine gate for any other id. Empty = no trusted id,
+        i.e. every pre-#1769 call site behaves byte-for-byte as before.
 
 Stdout: accepted session id, or empty when there is nothing to resume.
 Exit code:
@@ -46,7 +56,10 @@ Issue #827 live-session shortcut (preserved here):
     and exit 0 immediately — fresh Claude sessions create the session
     JSON before the transcript jsonl exists; rejecting that id would
     strand `AGENT_SESSION_ID` until the first transcript write. Dead-pid
-    records fall through to the transcript freshness path below.
+    records fall through to the transcript freshness path below — EXCEPT
+    when the candidate equals the issue #1769 trusted_id (argv[7]), in
+    which case the dead-pid record is accepted once (run_restart vouched
+    for it pre-kill via the short-TTL trusted-resume marker).
 """
 
 import glob
@@ -131,8 +144,39 @@ def main() -> int:
     config_root = claude_config_root(
         sys.argv[6] if len(sys.argv) > 6 else ""
     )
+    # Issue #1769: a session id the bash wrapper vouched for via the
+    # short-TTL trusted-resume marker run_restart writes pre-kill. Only
+    # honored when it equals the candidate (see live-session shortcut).
+    trusted_id = (sys.argv[7] if len(sys.argv) > 7 else "") or ""
 
     cutoff = time.time() - max_age_hours * 3600
+
+    # Issue #1769: when the candidate equals the trusted id the bash
+    # wrapper supplied, accept it once even though its pid is now dead.
+    # run_restart validated this exact id while the session was still
+    # live and re-injected it across the kill; without this the post-kill
+    # re-validation rejects a freshly-started / idle session (live-session
+    # JSON only, no eligible transcript yet) and the agent launches fresh,
+    # silently defeating #981. The marker is TTL-bounded and consumed
+    # bash-side after the wrapper observes this rc=0, so the bypass is
+    # one id / one restart cycle, not a standing relaxation of the gate.
+    #
+    # The trusted path relaxes ONLY the dead-pid / freshness rejection — it
+    # never bypasses the #820 resume-quarantine set. A candidate the runner
+    # quarantined (because `claude --resume` rejected it as "No conversation
+    # found") must stay rejected even with a marker, so it falls through to
+    # the normal logic below (rc=2 swap to a fresher non-quarantined id, or
+    # rc=1). This is the accept-site half of the #1769 codex-r1 defense in
+    # depth; the write-site (run_restart) independently refuses to vouch for
+    # an id that is not the validated live session.
+    if (
+        candidate
+        and trusted_id
+        and candidate == trusted_id
+        and candidate not in exclude
+    ):
+        print(candidate, end="")
+        return 0
 
     # Issue #827: when the candidate id matches a live same-cwd
     # `~/.claude/sessions/<pid>.json` with an alive pid, accept it
@@ -141,7 +185,17 @@ def main() -> int:
     # strands AGENT_SESSION_ID until the first transcript write. Dead-pid
     # records remain ineligible and fall through to the transcript-based
     # path below.
-    if candidate:
+    #
+    # Issue #1769 (codex-r2): the shortcut is quarantine-aware. A
+    # quarantined candidate must never resolve — live or not — because the
+    # quarantine set exists precisely to stop resuming that id (the runner
+    # added it after `claude --resume <id>` reported "No conversation
+    # found"). Without this guard a quarantined-but-still-live session would
+    # be accepted here (and, via the pre-kill `_write_if_live` validation,
+    # would get a trusted-resume marker). Skipping the shortcut lets the
+    # candidate fall through to the #820 quarantine branch below, which
+    # resolves to the freshest non-quarantined transcript (rc=2) or rc=1.
+    if candidate and candidate not in exclude:
         for session_path in glob.glob(
             os.path.join(config_root, "sessions", "*.json")
         ):

--- a/scripts/smoke/1769-restart-trusted-resume.sh
+++ b/scripts/smoke/1769-restart-trusted-resume.sh
@@ -1,0 +1,517 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1769-restart-trusted-resume.sh — Issue #1769.
+#
+# `agent restart` of a freshly-started / idle Claude agent launched a
+# FRESH session instead of resuming, because the post-kill re-validation
+# rejected the re-injected (#981) session id: the #827 live-session
+# shortcut needs an ALIVE pid, and after the SIGKILL the pid is dead while
+# the only on-disk state is the `sessions/<pid>.json` record (no eligible
+# `>0`-byte in-window transcript yet) — so the freshness scan returns rc=1,
+# `bridge_normalize_agent_session_id` clears the id, and the relaunch drops
+# `--resume`.
+#
+# Fix (option 2 of the issue's suggested fixes): a short-TTL trusted-resume
+# marker. `run_restart`, having just validated the live session it kills,
+# writes `state/agents/<a>/resume.trusted` with the snapshotted id; the
+# resolver (`resolve-claude-resume-session-id.py`) accepts THAT EXACT id
+# once even with a dead pid, then the marker is consumed (decision-site
+# resolve) / expires. It never relaxes the gate for any other id.
+#
+# Test plan (bash helpers + the resolver/launch builder, no live tmux):
+#   T1. WITHOUT a trusted marker, a dead-pid + no-transcript candidate is
+#       still REJECTED (rc=1). Regression guard for the #827/#820 freshness
+#       contract: the marker is additive, not a blanket bypass.
+#   T2. WITH a valid trusted marker for that exact id, the resolver ACCEPTS
+#       it (rc=0, same id) despite the dead pid + absent transcript.
+#   T3. The marker is single-use: after a decision-site resolve consumes it
+#       (BRIDGE_RESUME_TRUSTED_CONSUME=1), a second resolve REJECTS (rc=1).
+#       Also: an EXPIRED marker (ttl already elapsed) is not honored.
+#   T4. End-to-end — the static Claude launch builder emits `--resume <id>`
+#       for a continue=1 agent whose only state is the dead-pid session
+#       record plus a fresh trusted marker (the operator-visible symptom).
+#
+# Isolation: temp BRIDGE_HOME (v2 layout) via smoke_setup_bridge_home + a
+# fixture HOME for the Claude config tree. Never touches the operator's
+# live runtime or real ~/.claude.
+#
+# Footgun #11 (heredoc_write deadlock class): the fixture writes JSON via
+# `python3 ... > "$tmp"` then `cp` into place (the same recipe as the #827
+# smoke); no command-substitution feeds a heredoc-stdin into a bridge
+# function, no `<<<` here-string into one.
+
+set -euo pipefail
+
+# Re-exec under Bash 4+ for associative arrays. macOS ships /bin/bash 3.2.
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$HOME/.local/bin/bash"; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      exec "$_candidate" "${BASH_SOURCE[0]}" "$@"
+    fi
+  done
+  echo "[smoke:1769-restart-trusted-resume] requires Bash 4+ (host is ${BASH_VERSION})" >&2
+  exit 1
+fi
+
+SMOKE_NAME="1769-restart-trusted-resume"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "1769-restart-trusted-resume"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+smoke_require_cmd "$PY_BIN"
+
+# shellcheck source=bridge-lib.sh disable=SC1091
+source "$REPO_ROOT/bridge-lib.sh"
+
+for fn in \
+  bridge_resolve_resume_session_id \
+  bridge_agent_resume_trusted_marker_write \
+  bridge_agent_resume_trusted_marker_write_if_live \
+  bridge_agent_resume_trusted_marker_id \
+  bridge_agent_resume_trusted_marker_clear \
+  bridge_agent_resume_trusted_marker_path \
+  bridge_build_static_claude_launch_cmd \
+  bridge_reset_roster_maps; do
+  if ! declare -F "$fn" >/dev/null; then
+    smoke_fail "$fn not defined after sourcing bridge-lib.sh"
+  fi
+done
+
+# Path to the resolver helper (for direct-probe tests that exercise argv
+# ordering precisely, mirroring the codex-r1 quarantine probe).
+RESOLVER_PY="$REPO_ROOT/scripts/python-helpers/resolve-claude-resume-session-id.py"
+smoke_assert_file_exists "$RESOLVER_PY" "resolver helper present"
+
+# A pid overwhelmingly likely to be unallocated (matches the #827 smoke).
+DEAD_PID="999999"
+
+guard_dead_pid_is_dead() {
+  if kill -0 "$DEAD_PID" 2>/dev/null; then
+    smoke_fail "guard: pid $DEAD_PID happens to be alive on this host; choose a different sentinel"
+  fi
+}
+
+# Synthesize a fixture HOME with a dead-pid sessions/<pid>.json record and
+# NO transcript jsonl — the exact "freshly-started / idle" on-disk shape
+# from the issue. Echoes the session id on stdout.
+make_fixture_home() {
+  local fixture_home="$1"
+  local pid="$2"
+  local cwd="$3"
+
+  local sid sessions_dir session_file body_tmp
+  sid="$("$PY_BIN" -c 'import uuid; print(uuid.uuid4())')"
+  sessions_dir="$fixture_home/.claude/sessions"
+  mkdir -p "$sessions_dir"
+  session_file="$sessions_dir/${pid}.json"
+
+  body_tmp="$(mktemp "${TMPDIR:-/tmp}/agb-1769-body.XXXXXX")"
+  PID="$pid" SID="$sid" CWD="$cwd" \
+    "$PY_BIN" -c '
+import json
+import os
+
+print(
+    json.dumps(
+        {
+            "pid": int(os.environ["PID"]),
+            "sessionId": os.environ["SID"],
+            "cwd": os.environ["CWD"],
+            "name": "test",
+            "status": "idle",
+            "startedAt": 1778722000000,
+        }
+    )
+)
+' > "$body_tmp"
+  cp "$body_tmp" "$session_file"
+  rm -f "$body_tmp"
+
+  printf '%s\n' "$sid"
+}
+
+# ---------------------------------------------------------------------------
+# T1 — no marker: dead pid + no transcript is still rejected (rc=1).
+# ---------------------------------------------------------------------------
+test_no_marker_rejects() {
+  local fixture_home tmp_cwd sid rc
+
+  fixture_home="$SMOKE_TMP_ROOT/t1-home"
+  tmp_cwd="$SMOKE_TMP_ROOT/t1-cwd"
+  mkdir -p "$tmp_cwd"
+  tmp_cwd="$(cd -P "$tmp_cwd" && pwd -P)"
+
+  guard_dead_pid_is_dead
+  sid="$(make_fixture_home "$fixture_home" "$DEAD_PID" "$tmp_cwd")"
+
+  # Ensure no marker is lying around for this agent name.
+  bridge_agent_resume_trusted_marker_clear "agent-t1" 2>/dev/null || true
+
+  set +e
+  HOME="$fixture_home" bridge_resolve_resume_session_id claude agent-t1 "$tmp_cwd" "$sid" >/dev/null 2>/dev/null
+  rc=$?
+  set -e
+  smoke_assert_eq "1" "$rc" "T1 resolve rejects dead-pid + no-transcript WITHOUT a trusted marker"
+}
+
+# ---------------------------------------------------------------------------
+# T2 — valid trusted marker: the exact id is accepted (rc=0, same id).
+# ---------------------------------------------------------------------------
+test_marker_accepts() {
+  local fixture_home tmp_cwd sid resolved rc marker
+
+  fixture_home="$SMOKE_TMP_ROOT/t2-home"
+  tmp_cwd="$SMOKE_TMP_ROOT/t2-cwd"
+  mkdir -p "$tmp_cwd"
+  tmp_cwd="$(cd -P "$tmp_cwd" && pwd -P)"
+
+  guard_dead_pid_is_dead
+  sid="$(make_fixture_home "$fixture_home" "$DEAD_PID" "$tmp_cwd")"
+
+  # run_restart writes the marker after validating the (now-killed) live id.
+  bridge_agent_resume_trusted_marker_write "agent-t2" "$sid"
+  marker="$(bridge_agent_resume_trusted_marker_path "agent-t2")"
+  smoke_assert_file_exists "$marker" "T2 trusted marker written under state dir"
+
+  # Marker mode is 0600 (controller-only). Canonical GNU-first order
+  # (#1402): `stat -c '%a'` first — on GNU `stat -f` is FILESYSTEM mode
+  # (exits 0 with a multi-line report), so a BSD-first order would never
+  # fall through on Linux and the assertion would see a filesystem blob.
+  local mode
+  mode="$(stat -c '%a' "$marker" 2>/dev/null || stat -f '%Lp' "$marker" 2>/dev/null || true)"
+  smoke_assert_eq "600" "$mode" "T2 trusted marker is mode 0600"
+
+  # A non-consume (hydration-probe-style) resolve must accept but NOT burn
+  # the marker, so the launch builder can still see it.
+  resolved="$(HOME="$fixture_home" bridge_resolve_resume_session_id claude agent-t2 "$tmp_cwd" "$sid" 2>/dev/null)"
+  rc=$?
+  smoke_assert_eq "0" "$rc" "T2 resolve accepts the trusted id (rc=0)"
+  smoke_assert_eq "$sid" "$resolved" "T2 resolve returns the same trusted id"
+  smoke_assert_file_exists "$marker" "T2 non-consume resolve leaves the marker intact"
+
+  # Guard: the marker only ever vouches for ITS id. A different candidate is
+  # still gated by freshness (rc=1), even with the marker present.
+  set +e
+  HOME="$fixture_home" bridge_resolve_resume_session_id claude agent-t2 "$tmp_cwd" "some-other-id" >/dev/null 2>/dev/null
+  rc=$?
+  set -e
+  smoke_assert_eq "1" "$rc" "T2 a non-matching candidate is NOT force-accepted by the marker"
+
+  bridge_agent_resume_trusted_marker_clear "agent-t2" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# T3 — single-use: a decision-site consume burns the marker; the next
+#      resolve rejects. Plus: an expired marker is not honored.
+# ---------------------------------------------------------------------------
+test_marker_single_use_and_expiry() {
+  local fixture_home tmp_cwd sid resolved rc marker
+
+  fixture_home="$SMOKE_TMP_ROOT/t3-home"
+  tmp_cwd="$SMOKE_TMP_ROOT/t3-cwd"
+  mkdir -p "$tmp_cwd"
+  tmp_cwd="$(cd -P "$tmp_cwd" && pwd -P)"
+
+  guard_dead_pid_is_dead
+  sid="$(make_fixture_home "$fixture_home" "$DEAD_PID" "$tmp_cwd")"
+
+  bridge_agent_resume_trusted_marker_write "agent-t3" "$sid"
+  marker="$(bridge_agent_resume_trusted_marker_path "agent-t3")"
+
+  # Decision-site resolve (consume). Mirrors bridge_normalize_agent_session_id.
+  resolved="$(HOME="$fixture_home" BRIDGE_RESUME_TRUSTED_CONSUME=1 \
+    bridge_resolve_resume_session_id claude agent-t3 "$tmp_cwd" "$sid" 2>/dev/null)"
+  rc=$?
+  smoke_assert_eq "0" "$rc" "T3 decision-site resolve accepts (rc=0)"
+  smoke_assert_eq "$sid" "$resolved" "T3 decision-site resolve returns the id"
+  if [[ -f "$marker" ]]; then
+    smoke_fail "T3 marker was not consumed by the decision-site resolve: $marker"
+  fi
+
+  # Second resolve: marker gone ⇒ back to the freshness gate ⇒ rc=1.
+  set +e
+  HOME="$fixture_home" bridge_resolve_resume_session_id claude agent-t3 "$tmp_cwd" "$sid" >/dev/null 2>/dev/null
+  rc=$?
+  set -e
+  smoke_assert_eq "1" "$rc" "T3 second resolve after consume rejects (single-use)"
+
+  # Expiry: a marker whose ttl has already elapsed is not honored even
+  # before any consume. Write with ttl=0 so now >= started + ttl.
+  bridge_agent_resume_trusted_marker_write "agent-t3" "$sid" 0
+  smoke_assert_file_exists "$marker" "T3 expired-marker fixture written"
+  if bridge_agent_resume_trusted_marker_id "agent-t3" >/dev/null 2>&1; then
+    smoke_fail "T3 expired marker (ttl=0) was reported as in-window"
+  fi
+  set +e
+  HOME="$fixture_home" bridge_resolve_resume_session_id claude agent-t3 "$tmp_cwd" "$sid" >/dev/null 2>/dev/null
+  rc=$?
+  set -e
+  smoke_assert_eq "1" "$rc" "T3 expired marker is not honored (rc=1)"
+  bridge_agent_resume_trusted_marker_clear "agent-t3" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# T4 — end-to-end: the static Claude launch builder emits `--resume <id>`
+#      for a continue=1 agent whose only state is the dead-pid session
+#      record + a fresh trusted marker. This is the operator-visible
+#      symptom the issue describes ("restart starts over").
+# ---------------------------------------------------------------------------
+test_launch_builder_emits_resume() {
+  local agent fixture_home workdir sid cmd
+
+  agent="agent-t4"
+  fixture_home="$SMOKE_TMP_ROOT/t4-home"
+  workdir="$SMOKE_TMP_ROOT/t4-cwd"
+  mkdir -p "$workdir"
+  workdir="$(cd -P "$workdir" && pwd -P)"
+
+  guard_dead_pid_is_dead
+  sid="$(make_fixture_home "$fixture_home" "$DEAD_PID" "$workdir")"
+
+  # Register a minimal static Claude agent (mirrors the #981 smoke seed).
+  bridge_reset_roster_maps
+  BRIDGE_AGENT_IDS=("$agent")
+  BRIDGE_AGENT_DESC["$agent"]="$agent smoke fixture"
+  BRIDGE_AGENT_ENGINE["$agent"]="claude"
+  BRIDGE_AGENT_SESSION["$agent"]="$agent"
+  BRIDGE_AGENT_WORKDIR["$agent"]="$workdir"
+  BRIDGE_AGENT_LOOP["$agent"]="1"
+  BRIDGE_AGENT_CONTINUE["$agent"]="1"
+  BRIDGE_AGENT_SOURCE["$agent"]="static"
+  BRIDGE_AGENT_HISTORY_KEY["$agent"]="$(bridge_history_key_for claude "$agent" "$workdir")"
+  BRIDGE_AGENT_CREATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_SESSION_ID["$agent"]="$sid"
+  BRIDGE_AGENT_LAUNCH_CMD["$agent"]="claude --dangerously-skip-permissions --name $agent"
+
+  # Point the agent's Claude config tree at the fixture so the resolver
+  # scans it (the resolver reads CLAUDE_CONFIG_DIR for unregistered/non-iso
+  # agents via HOME). The builder runs in-process here, so pinning HOME is
+  # what reaches the helper's session-record glob.
+  export CLAUDE_CONFIG_DIR="$fixture_home/.claude"
+
+  # run_restart's contract: validate live → snapshot → write marker → kill.
+  bridge_agent_resume_trusted_marker_write "$agent" "$sid"
+
+  cmd="$(HOME="$fixture_home" bridge_build_static_claude_launch_cmd "$agent" 2>/dev/null || true)"
+  smoke_assert_contains "$cmd" "--resume $sid" \
+    "T4 static launch builder emits --resume <id> with the trusted marker"
+
+  # The builder routes through bridge_normalize_agent_session_id (the
+  # decision/consume site), so the marker must have been consumed by the
+  # real chain — proving the one-shot fires end-to-end, not just that a
+  # lingering marker happened to be present.
+  local marker
+  marker="$(bridge_agent_resume_trusted_marker_path "$agent")"
+  if [[ -f "$marker" ]]; then
+    smoke_fail "T4 trusted marker was not consumed by the launch builder chain: $marker"
+  fi
+
+  unset CLAUDE_CONFIG_DIR
+  bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# T5 — accept-site (codex-r1 BLOCKING): a QUARANTINED id passed via the
+#      trusted path must NOT be force-accepted. The trusted bypass relaxes
+#      only the dead-pid/freshness piece, never the #820 quarantine set.
+#      Direct resolver probe mirrors the codex repro: argv[5]=exclude_csv
+#      contains the sid, argv[7]=trusted_id == sid.
+# ---------------------------------------------------------------------------
+test_quarantined_trusted_id_rejected() {
+  local fixture_home tmp_cwd sid rc out
+
+  fixture_home="$SMOKE_TMP_ROOT/t5-home"
+  tmp_cwd="$SMOKE_TMP_ROOT/t5-cwd"
+  mkdir -p "$tmp_cwd"
+  tmp_cwd="$(cd -P "$tmp_cwd" && pwd -P)"
+
+  guard_dead_pid_is_dead
+  sid="$(make_fixture_home "$fixture_home" "$DEAD_PID" "$tmp_cwd")"
+
+  # Probe: workdir, candidate=sid, max_age=48, agent, exclude_csv=sid (the
+  # id is quarantined), config_dir=fixture .claude, trusted_id=sid.
+  set +e
+  out="$(HOME="$fixture_home" "$PY_BIN" "$RESOLVER_PY" \
+    "$tmp_cwd" "$sid" 48 agent-t5 "$sid" "$fixture_home/.claude" "$sid" 2>/dev/null)"
+  rc=$?
+  set -e
+  # The trusted accept must NOT fire for a quarantined id. With no eligible
+  # transcript either, the resolver rejects (rc=1, empty). The decisive
+  # assertion is that it did NOT print the quarantined sid with rc=0.
+  if [[ "$rc" == 0 && "$out" == "$sid" ]]; then
+    smoke_fail "T5 trusted path force-accepted a QUARANTINED id (rc=$rc out=$out) — #820 bypass"
+  fi
+  smoke_assert_eq "1" "$rc" "T5 quarantined id + trusted marker → rejected (rc=1)"
+
+  # Control: the SAME probe WITHOUT quarantine (empty exclude_csv) DOES
+  # accept via the trusted path — proving the rejection above is the
+  # quarantine guard, not a broken trusted path.
+  set +e
+  out="$(HOME="$fixture_home" "$PY_BIN" "$RESOLVER_PY" \
+    "$tmp_cwd" "$sid" 48 agent-t5 "" "$fixture_home/.claude" "$sid" 2>/dev/null)"
+  rc=$?
+  set -e
+  smoke_assert_eq "0" "$rc" "T5 control: same id, NOT quarantined, trusted → accepted (rc=0)"
+  smoke_assert_eq "$sid" "$out" "T5 control: trusted accept returns the id"
+}
+
+# ---------------------------------------------------------------------------
+# T6 — write-site (codex-r1 BLOCKING): the marker is written ONLY when the
+#      id is the CURRENT live session. bridge_agent_resume_trusted_marker_
+#      write_if_live must:
+#        (a) write the marker for a LIVE-pid, same-cwd, matching id, and
+#        (b) refuse to write for an id ABSENT from the live-session record
+#            (e.g. a dead-pid record only), even though it is the persisted
+#            session id.
+# ---------------------------------------------------------------------------
+test_write_if_live_validates() {
+  local agent fixture_home workdir live_sid dead_sid marker rc
+
+  agent="agent-t6"
+  fixture_home="$SMOKE_TMP_ROOT/t6-home"
+  workdir="$SMOKE_TMP_ROOT/t6-cwd"
+  mkdir -p "$workdir"
+  workdir="$(cd -P "$workdir" && pwd -P)"
+
+  # (a) live record: our own pid is alive, cwd matches.
+  if ! kill -0 "$$" 2>/dev/null; then
+    smoke_fail "T6 self pid $$ not alive — environment broken"
+  fi
+  live_sid="$(make_fixture_home "$fixture_home" "$$" "$workdir")"
+
+  bridge_reset_roster_maps
+  BRIDGE_AGENT_IDS=("$agent")
+  BRIDGE_AGENT_DESC["$agent"]="$agent smoke fixture"
+  BRIDGE_AGENT_ENGINE["$agent"]="claude"
+  BRIDGE_AGENT_SESSION["$agent"]="$agent"
+  BRIDGE_AGENT_WORKDIR["$agent"]="$workdir"
+  BRIDGE_AGENT_LOOP["$agent"]="1"
+  BRIDGE_AGENT_CONTINUE["$agent"]="1"
+  BRIDGE_AGENT_SOURCE["$agent"]="static"
+  BRIDGE_AGENT_HISTORY_KEY["$agent"]="$(bridge_history_key_for claude "$agent" "$workdir")"
+  BRIDGE_AGENT_CREATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_SESSION_ID["$agent"]="$live_sid"
+
+  export CLAUDE_CONFIG_DIR="$fixture_home/.claude"
+  marker="$(bridge_agent_resume_trusted_marker_path "$agent")"
+
+  set +e
+  HOME="$fixture_home" bridge_agent_resume_trusted_marker_write_if_live "$agent" "$live_sid"
+  rc=$?
+  set -e
+  smoke_assert_eq "0" "$rc" "T6a write_if_live validates a LIVE id (rc=0)"
+  smoke_assert_file_exists "$marker" "T6a marker written for the live session id"
+  bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
+
+  # (b) an id ABSENT from the live-session record (only a DEAD-pid record
+  # carries a *different* id; the persisted id we pass is not live). No
+  # marker must be written.
+  guard_dead_pid_is_dead
+  dead_sid="$("$PY_BIN" -c 'import uuid; print(uuid.uuid4())')"  # never in any record
+  set +e
+  HOME="$fixture_home" bridge_agent_resume_trusted_marker_write_if_live "$agent" "$dead_sid"
+  rc=$?
+  set -e
+  if [[ "$rc" == 0 ]]; then
+    smoke_fail "T6b write_if_live vouched for an id absent from the live-session record (rc=0)"
+  fi
+  if [[ -f "$marker" ]]; then
+    smoke_fail "T6b marker was written for a non-live id: $marker"
+  fi
+
+  unset CLAUDE_CONFIG_DIR
+  bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# T7 — write-site quarantine hole (codex-r2 BLOCKING): a QUARANTINED id that
+#      still has a LIVE sessions/<pid>.json must NOT be vouched for. Before
+#      this fix the resolver's #827 live-session shortcut accepted a live
+#      same-cwd candidate without consulting the quarantine set, so
+#      _write_if_live (which trusts the resolver's rc=0) wrote a marker for a
+#      quarantined-but-live id. Exercises BOTH defense layers: the resolver's
+#      now-quarantine-aware #827 shortcut and the explicit up-front guard.
+# ---------------------------------------------------------------------------
+test_write_if_live_rejects_quarantined_live() {
+  local agent fixture_home workdir live_sid marker rc
+
+  agent="agent-t7"
+  fixture_home="$SMOKE_TMP_ROOT/t7-home"
+  workdir="$SMOKE_TMP_ROOT/t7-cwd"
+  mkdir -p "$workdir"
+  workdir="$(cd -P "$workdir" && pwd -P)"
+
+  # Live record: our own pid is alive, cwd matches — the candidate IS the
+  # live session (so the only thing that should block it is the quarantine).
+  if ! kill -0 "$$" 2>/dev/null; then
+    smoke_fail "T7 self pid $$ not alive — environment broken"
+  fi
+  live_sid="$(make_fixture_home "$fixture_home" "$$" "$workdir")"
+
+  bridge_reset_roster_maps
+  BRIDGE_AGENT_IDS=("$agent")
+  BRIDGE_AGENT_DESC["$agent"]="$agent smoke fixture"
+  BRIDGE_AGENT_ENGINE["$agent"]="claude"
+  BRIDGE_AGENT_SESSION["$agent"]="$agent"
+  BRIDGE_AGENT_WORKDIR["$agent"]="$workdir"
+  BRIDGE_AGENT_LOOP["$agent"]="1"
+  BRIDGE_AGENT_CONTINUE["$agent"]="1"
+  BRIDGE_AGENT_SOURCE["$agent"]="static"
+  BRIDGE_AGENT_HISTORY_KEY["$agent"]="$(bridge_history_key_for claude "$agent" "$workdir")"
+  BRIDGE_AGENT_CREATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_SESSION_ID["$agent"]="$live_sid"
+
+  export CLAUDE_CONFIG_DIR="$fixture_home/.claude"
+  marker="$(bridge_agent_resume_trusted_marker_path "$agent")"
+
+  # Control: WITHOUT quarantine the live id IS vouched (proves the rejection
+  # below is the quarantine, not a broken live-validation path).
+  set +e
+  HOME="$fixture_home" bridge_agent_resume_trusted_marker_write_if_live "$agent" "$live_sid"
+  rc=$?
+  set -e
+  smoke_assert_eq "0" "$rc" "T7 control: live, NOT quarantined → vouched (rc=0)"
+  smoke_assert_file_exists "$marker" "T7 control: marker written for live non-quarantined id"
+  bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
+
+  # Now quarantine the SAME (still-live) id and assert the vouch is refused.
+  if ! bridge_agent_resume_quarantine_add "$agent" "$live_sid" "smoke-quarantine" 2>/dev/null; then
+    smoke_fail "T7 could not quarantine the live id (fixture setup failed)"
+  fi
+  # Sanity: the id is now in the quarantine set.
+  smoke_assert_contains ",$(bridge_agent_resume_quarantine_ids "$agent")," ",$live_sid," \
+    "T7 fixture: live id is quarantined"
+
+  set +e
+  HOME="$fixture_home" bridge_agent_resume_trusted_marker_write_if_live "$agent" "$live_sid"
+  rc=$?
+  set -e
+  if [[ "$rc" == 0 ]]; then
+    smoke_fail "T7 write_if_live vouched for a QUARANTINED live id (rc=0) — codex-r2 hole"
+  fi
+  if [[ -f "$marker" ]]; then
+    smoke_fail "T7 marker was written for a quarantined live id: $marker"
+  fi
+
+  unset CLAUDE_CONFIG_DIR
+  bridge_agent_resume_trusted_marker_clear "$agent" 2>/dev/null || true
+}
+
+smoke_run "T1 no marker → dead-pid + no-transcript rejected"   test_no_marker_rejects
+smoke_run "T2 valid marker → trusted id accepted"              test_marker_accepts
+smoke_run "T3 single-use + expiry"                             test_marker_single_use_and_expiry
+smoke_run "T4 launch builder emits --resume <id>"              test_launch_builder_emits_resume
+smoke_run "T5 quarantined id + marker → rejected"              test_quarantined_trusted_id_rejected
+smoke_run "T6 write_if_live validates the live session"        test_write_if_live_validates
+smoke_run "T7 write_if_live rejects a quarantined LIVE id"     test_write_if_live_rejects_quarantined_live
+
+smoke_log "all checks passed"


### PR DESCRIPTION
## Summary

`agent restart <a>` of a **freshly-started / idle** Claude agent launched a brand-new session instead of resuming the previous conversation. Sessions with substantial transcript content already resume correctly; this fixes the "fresh/empty session" edge.

**Root cause** (per the issue): `run_restart` snapshots and re-injects the live session id around its SIGKILL (#981), but the relaunched `bridge-start.sh` re-validates that id through `resolve-claude-resume-session-id.py`:
- The #827 live-session shortcut requires an **alive** pid — after the kill the pid is dead.
- The transcript freshness scan finds **no eligible transcript** for a fresh session whose only on-disk state is `sessions/<pid>.json` (no `>0`-byte in-window `.jsonl` yet) → `rc=1`.
- `bridge_normalize_agent_session_id` treats `rc=1` as reject and `bridge_clear_agent_session_id` wipes the re-injected id → `--resume`/`--continue` dropped → fresh launch.

## Fix — short-TTL trusted-resume marker (issue's suggested option 2)

The id `run_restart` snapshots was, by construction, **live and accepted** immediately before the kill. Honor that for one restart cycle:

- **`bridge-agent.sh::run_restart`** writes `state/agents/<a>/resume.trusted` (mode `0600`; `id` + `started` + `ttl`, default 300s) after validating the live session it kills — at the first kill and at each verify-retry kill. Claude-only; the short TTL is the crash backstop.
- **`lib/bridge-state.sh::bridge_resolve_resume_session_id`** reads the marker and passes its id to the resolver as a new `argv[7]` **only when it matches the candidate**, then consumes the marker on a decision-site `rc=0` accept — gated on `BRIDGE_RESUME_TRUSTED_CONSUME=1`, which is set **only** by `bridge_normalize_agent_session_id` so read-only hydration probes never burn it before the launch builder runs.
- **`scripts/python-helpers/resolve-claude-resume-session-id.py`** accepts `candidate == trusted_id` once even with a dead pid, ahead of the #827/#820 paths. Empty `trusted_id` leaves every pre-#1769 call site **byte-identical**.
- Marker helpers (`bridge_agent_resume_trusted_marker_write/_id/_clear/_path`) live in `lib/bridge-agents.sh` next to the existing `restart.in-progress` marker family.

**Additive, not a bypass.** One id, one restart cycle. A non-matching candidate is still gated by freshness; a truly-stale id is still rejected on later passes; an expired/consumed marker falls back to the existing freshness/quarantine logic.

## Verification

Local repo at `~/Projects/agent-bridge-public` (worktree), macOS, Homebrew bash 5.3.9.

- `bash -n` (bash 5) + `shellcheck --severity=warning`: PASS on all touched `.sh` (`bridge-agent.sh`, `lib/bridge-state.sh`, `lib/bridge-agents.sh`, `scripts/ci-select-smoke.sh`, new smoke).
- `python3 -m py_compile scripts/python-helpers/resolve-claude-resume-session-id.py`: PASS.
- `git diff --check`: clean.
- `scripts/iso-helper-ratchet.sh`: PASS (the 3 `os.environ` matches in the inline test-fixture python are `\.env`-substring false positives, marked `# noqa: iso-helper-boundary` with reason — same shape as the #827 neighbor smoke; **not** a baseline bump). `scripts/lint-raw-pathlib-on-isolated.sh`: PASS.
- **New smoke `scripts/smoke/1769-restart-trusted-resume.sh`: PASS** — T1 reject-without-marker (freshness regression guard), T2 accept-with-marker (+ mode 0600, non-matching candidate still rejected, non-consume probe leaves marker intact), T3 single-use + expiry (ttl=0 not honored), T4 static launch builder emits `--resume <id>` end-to-end and the marker is consumed by the real builder chain.
- **Blast-radius regression — all 16 session/resume/restart/launch smokes GREEN**, including `claude-live-session-pretranscript` (#827 shortcut untouched), `981-restart-session-resume-snapshot`, `A3-beta3-1248-restart-session-id-resume`, `C1-beta3-1251-restart-preflight-rollback`, `835-static-admin-launch`, `4494-integrated-dynamic-recovery` (Case B "#827 live session pre-transcript" still passes).
- `ci-select-smoke.sh --changed-file scripts/python-helpers/resolve-claude-resume-session-id.py --run`: PASS (8/8).
- Registered `1769-restart-trusted-resume` in `ci-select-smoke.sh` at every site existing session-resume smokes use: master list + per-file blocks for the resolver, `lib/bridge-state.sh`, `bridge-agent.sh`, and `lib/bridge-agents.sh`. Selection verified for all changed files.

> `scripts/smoke-test.sh` (monolithic harness) aborts in its early lint phase on a **pre-existing** `SC2102` info finding in `bridge-run.sh` (untouched by this PR; reproduces identically on `origin/main`). The modular `ci-select-smoke.sh` suite is the gate and is green.

## High-risk note (session resume — queue/daemon/status triangle)

This touches the resume resolver and restart semantics (CLAUDE.md High-Risk #1). The change is strictly additive: the trusted-id accept is double-guarded (`candidate == trusted_id` in **both** the bash wrapper and the python resolver), consume is one-shot at the decision site only, and the normal/substantial-transcript paths are byte-identical when no marker exists. Edge cases unit-checked: absent / empty-id / malformed (no `id`) / non-numeric-ttl markers all reject safely; iso-v2 ownership is safe (marker is controller-owned 0600; resolver may run as the iso UID via the existing sudo passthrough but only receives `trusted_id` as read-only argv, and consume runs controller-side). Did **not** touch Lane C's files (`launch-cmd-static-claude-build.py`, dispatcher) — T4 only *calls* the static builder end-to-end.

## Codex self-review

Local Codex CLI is **usage-limited** today (resets 2026-06-11 09:28 — exactly as the dispatch brief flagged), so the in-worktree `codex review` could not run (`codex_rounds: 0`). I ran a manual self-review against the focus checklist (force-resume safety, one-shot/consume correctness, iso ownership, byte-identical normal path, footgun #11/lint) — all clear; details above. The orchestrator's queue-based pair-review is the gate.

Fixes #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)
