### PR TITLE
fix(auth): limit-window-aware token rotation — stop cycling a saturated pool (#1789)

### DIFF
--- a/.lint-heredoc-baseline.tsv
+++ b/.lint-heredoc-baseline.tsv
@@ -56,7 +56,7 @@ bridge-cron.sh	991	C3	f8fb9fe483d3ac0c38ced0173139a79e612c6ab535249af3209b7f9940
 bridge-cron.sh	1610	C3	e922c8981a5dc87928344cdc8dc56501cf7cfdad8d360c59e7754c66f1600478	interpreter heredoc, no capture	patch	Phase 3 PR C
 bridge-daemon.sh	800	H3	f1c1630f31d4bc24ae47602958be739975b927a70ec87c7bf819402ad94b9b0f	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 bridge-daemon.sh	1022	H3	16a961e912bc1612646a256a1b085d41178d7b1c282775a10dc8f83244b92ea8	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
-bridge-daemon.sh	1908	H3	23c0313bf8a6711cc33242c92c06468b8b19bc33e2b16b421f3bc60de187a677	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
+bridge-daemon.sh	2219	H3	7d4684195b1f8f572d489dc3b77c5a2803f24b2ff7f68c72526bb7952eb0eb03	here-string/procsub, non-interpreter consumer	patch	PR #1790 (#1789): same read-into-vars here-string, read list gained rotation_soonest_reset; supersedes 23c0313b
 bridge-daemon.sh	2186	H3	16ff48070939ced82df89c9c5a5aee6d60abfa8ce48e66cbc1affbe12e89db37	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 bridge-daemon.sh	3027	H3	257b2ce4f7caaf094cf6907c8feb0e4a062b7814511498ba862c60690873b494	here-string/procsub, non-interpreter consumer	claude	beta3-5 wave (baseline housekeeping)
 bridge-daemon.sh	3036	H3	f423c7e06b3b4c0cddc08ab8d3564f61837e3c8ad7db470ce969c038eeecfea9	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)

--- a/.lint-heredoc-baseline.tsv
+++ b/.lint-heredoc-baseline.tsv
@@ -712,6 +712,8 @@ tests/admin-gateway-refactor/smoke.sh	441	C3	a85b1ae54fbb817d47075fcaa60163001b1
 tests/bootstrap-cron-schedules/smoke.sh	196	H3	ed787beec5de04a63cc901b168c263c9d2fe457e9c4f0e3852d96e4e0a88326c	here-string/procsub, non-interpreter consumer	patch-dev	Phase 6 PR F
 tests/claude-token-rotation/smoke.sh	1015	C1	8b40ac1ae47b8dc42bb883423f199a472e4eb3d6b3a9ba31fc107d6cd14f1de7	heredoc in capture	patch-dev	Phase 6 PR F
 tests/claude-token-rotation/smoke.sh	1030	H3	8983fa977b37ee4a8f50f74ce401778bd9fc69d94937f3b220a18c888cba466d	here-string/procsub, non-interpreter consumer	patch-dev	Phase 6 PR F
+tests/claude-token-rotation/smoke.sh	1037	H3	2f68e4299e7ee194f1c4b787b80da5c7a89673feb0ba4025634a079dd034618d	here-string deliberately mirrors daemon IFS=tab decode (sentinel roundtrip, r3 BLOCKING 1)	patch	PR #1790 r3
+tests/claude-token-rotation/smoke.sh	1045	H3	6a820dd9da757c37e8ed54119691e4323c7a343963d14cdf7d58988ba35f448a	here-string deliberately mirrors daemon IFS=tab decode (sentinel roundtrip, r3 BLOCKING 1)	patch	PR #1790 r3
 tests/claude-token-rotation/smoke.sh	1321	C1	a1ec58846ebb8c166b188950304e0a83104b808b1c2c0658cd83914d60c1fc2e	heredoc in capture	patch-dev	Phase 6 PR F
 tests/claude-token-rotation/smoke.sh	1326	C1	9d15df02bcce12d28b50326fe3ff2b343dd51b8d690332a8ab77a0c6922e8701	heredoc in capture	patch-dev	Phase 6 PR F
 tests/claude-token-rotation/smoke.sh	1381	C1	02b9e43da015ed1103f7703be26584f4adcc3b3d1d46e1f52e82a7187bab688f	heredoc in capture	patch-dev	Phase 6 PR F

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1565,11 +1565,24 @@ agent-bridge auth claude-token activate claude-b --sync
 To enable automatic rotation, register at least two enabled tokens and set
 the threshold. The daemon reuses the existing Claude usage monitor signal
 from `bridge-usage.py`; when a Claude usage window reaches the rotation
-threshold once per reset cycle, it runs `rotate --if-auto-enabled --sync`.
+threshold once per reset cycle, it runs `rotate --if-auto-enabled --sync
+--limited-until <reset_at>`.
 Sync keeps only a non-secret `CLAUDE_CONFIG_DIR=` pointer in the legacy
 `credentials/launch-secrets.env` file and removes any stale
 `CLAUDE_CODE_OAUTH_TOKEN=` entry, so the active OAuth token is not inherited
 by Bash/tool subprocesses.
+
+Rotation is limit-window aware (#1789): the rotating-away token's known
+429 reset time (`--limited-until`, an ISO timestamp — never a token value)
+is recorded on its registry row as `limited_until`, and selection skips any
+candidate whose own `limited_until` is still in the future (an expired or
+absent stamp keeps the token eligible, and the stamp is cleared when the
+token is activated again). When **every** enabled alternate is still inside
+a limit window, rotate returns `skipped/all_tokens_limited` with the pool's
+`soonest_reset` instead of cycling a saturated pool; the daemon then sends
+one urgent "claude token pool exhausted" notification on a cooldown latch
+(`BRIDGE_CLAUDE_POOL_EXHAUSTED_NOTICE_INTERVAL_SECONDS`, default 1800)
+rather than re-alerting on every monitor pass.
 
 The credential write path is hardened against two specific failure
 modes (see PR #799 r2-of-Path-A):

--- a/bridge-auth.py
+++ b/bridge-auth.py
@@ -950,6 +950,11 @@ def cmd_activate(args: argparse.Namespace) -> int:
                 raise ValueError(f"token id is disabled: {args.id}")
             registry["active_token_id"] = args.id
             row["last_activated_at"] = now_iso()
+            # #1789 (PR #1790 r2): explicit activation is an operator
+            # override — drop any limit-window stamp so the token is not
+            # hiddenly skipped by future rotations until the old timestamp
+            # expires. Mirrors the rotate-path cleanup.
+            row.pop("limited_until", None)
             save_registry(registry_path, registry)
     except Exception as exc:
         return fail(str(exc), json_mode)

--- a/bridge-auth.py
+++ b/bridge-auth.py
@@ -615,6 +615,17 @@ def enabled_token_ids(registry: dict[str, Any]) -> list[str]:
     return [token_id for token_id in ids if token_id]
 
 
+def token_limited_until(row: dict[str, Any]) -> datetime | None:
+    """Parse a token row's ``limited_until`` stamp (#1789).
+
+    The stamp is the 429-derived ``reset_at`` recorded when the token was
+    rotated away at-limit — an ISO timestamp, never token bytes. Returns None
+    when absent or unparseable (an unreadable stamp must never strand a token
+    as permanently ineligible).
+    """
+    return iso_to_utc(str(row.get("limited_until") or ""))
+
+
 def redact_token(text: str, token: str) -> str:
     if not text or not token:
         return text
@@ -977,23 +988,74 @@ def cmd_rotate(args: argparse.Namespace) -> int:
                     }
                 else:
                     old_id = str(registry.get("active_token_id") or "")
-                    if old_id not in ids:
-                        new_id = ids[0]
+                    # #1789: persist the rotating-away token's known limit
+                    # window so future selections can avoid still-limited
+                    # tokens. The caller (daemon usage monitor) passes the
+                    # 429-derived reset_at it already holds.
+                    registry_dirty = False
+                    if args.limited_until and old_id:
+                        old_row = find_token(registry, old_id)
+                        if old_row is not None and iso_to_utc(args.limited_until) is not None:
+                            old_row["limited_until"] = args.limited_until
+                            registry_dirty = True
+                    # Ring order after the active token (legacy round-robin),
+                    # but skip candidates still inside a known limit window —
+                    # rotating into one buys nothing and thrashes the pool
+                    # (#1789: median same-token return was 1.2h vs a 5h
+                    # window). An expired or absent stamp keeps the token
+                    # eligible.
+                    if old_id in ids:
+                        start = ids.index(old_id) + 1
+                        ring = [ids[(start + i) % len(ids)] for i in range(len(ids) - 1)]
                     else:
-                        new_id = ids[(ids.index(old_id) + 1) % len(ids)]
-                    row = find_token(registry, new_id)
-                    if row is None:
-                        raise ValueError(f"rotation selected missing token id: {new_id}")
-                    timestamp = now_iso()
-                    registry["active_token_id"] = new_id
-                    row["last_activated_at"] = timestamp
-                    registry["last_rotation"] = {
-                        "rotated_at": timestamp,
-                        "from": old_id,
-                        "to": new_id,
-                        "reason": args.reason or "",
-                    }
-                    save_registry(registry_path, registry)
+                        ring = list(ids)
+                    now = now_utc()
+                    new_id = ""
+                    soonest_reset: datetime | None = None
+                    for candidate in ring:
+                        candidate_row = find_token(registry, candidate)
+                        limited = token_limited_until(candidate_row or {})
+                        if limited is not None and limited > now:
+                            if soonest_reset is None or limited < soonest_reset:
+                                soonest_reset = limited
+                            continue
+                        new_id = candidate
+                        break
+                    if not new_id:
+                        # Every alternate is still rate-limited: refusing is
+                        # the truthful outcome. The caller surfaces ONE
+                        # actionable state instead of a saturated-pool
+                        # musical-chairs loop.
+                        skipped_payload = {
+                            "status": "skipped",
+                            "reason": "all_tokens_limited",
+                            "active_token_id": old_id,
+                            "soonest_reset": (
+                                soonest_reset.isoformat(timespec="seconds")
+                                if soonest_reset is not None
+                                else ""
+                            ),
+                        }
+                        if registry_dirty:
+                            save_registry(registry_path, registry)
+                    else:
+                        row = find_token(registry, new_id)
+                        if row is None:
+                            raise ValueError(f"rotation selected missing token id: {new_id}")
+                        # The selected token's window (if any) has expired —
+                        # drop the stale stamp so list/status output stays
+                        # truthful.
+                        row.pop("limited_until", None)
+                        timestamp = now_iso()
+                        registry["active_token_id"] = new_id
+                        row["last_activated_at"] = timestamp
+                        registry["last_rotation"] = {
+                            "rotated_at": timestamp,
+                            "from": old_id,
+                            "to": new_id,
+                            "reason": args.reason or "",
+                        }
+                        save_registry(registry_path, registry)
     except Exception as exc:
         return fail(str(exc), json_mode)
 
@@ -3457,6 +3519,10 @@ def build_parser() -> argparse.ArgumentParser:
     rotate_parser = sub.add_parser("rotate")
     rotate_parser.add_argument("--if-auto-enabled", action="store_true")
     rotate_parser.add_argument("--reason", default="")
+    # #1789: ISO reset_at of the rotating-away token's 429 limit window.
+    # Recorded as the old row's `limited_until` so selection can skip
+    # still-limited tokens. Timestamp only — never token bytes.
+    rotate_parser.add_argument("--limited-until", default="")
     rotate_parser.add_argument("--sync", action="store_true", help=argparse.SUPPRESS)
     rotate_parser.add_argument("--agents", help=argparse.SUPPRESS)
     rotate_parser.add_argument("--json", action="store_true")

--- a/bridge-daemon-helpers.py
+++ b/bridge-daemon-helpers.py
@@ -942,7 +942,9 @@ def cmd_rotation_status_parse(args: argparse.Namespace) -> int:
 
     Parses the bridge-auth.sh claude-token rotate --json envelope. Output (a
     single row):
-      status \\t reason \\t old_active_token_id \\t active_token_id \\t sync_status
+      status \\t reason \\t old_active_token_id \\t active_token_id \\t sync_status \\t soonest_reset
+    ``soonest_reset`` (#1789) is only populated on the ``all_tokens_limited``
+    skip — the nearest known limit-window expiry across the enabled pool.
     JSON-parse error degrades to ``error\\tinvalid_rotation_output\\t...`` so
     the downstream ``case "$rotation_status:$rotation_reason"`` branch can
     classify it under ``error:*``.
@@ -960,6 +962,7 @@ def cmd_rotation_status_parse(args: argparse.Namespace) -> int:
                 str(payload.get("old_active_token_id", "")),
                 str(payload.get("active_token_id", "")),
                 str(sync.get("status", "")),
+                str(payload.get("soonest_reset", "")),
             ]
         )
     )
@@ -1498,7 +1501,7 @@ SUBCOMMANDS = {
     "rotation-status-parse": (
         cmd_rotation_status_parse,
         [("rotate_json", "JSON envelope from bridge-auth.sh claude-token rotate --json")],
-        "Single-row rotation outcome: status / reason / from / to / sync_status (5 cols).",
+        "Single-row rotation outcome: status / reason / from / to / sync_status / soonest_reset (6 cols).",
     ),
     # Issue #1468: classify a native usage-probe --json result for an audit row.
     "usage-probe-result-parse": (

--- a/bridge-daemon-helpers.py
+++ b/bridge-daemon-helpers.py
@@ -945,6 +945,12 @@ def cmd_rotation_status_parse(args: argparse.Namespace) -> int:
       status \\t reason \\t old_active_token_id \\t active_token_id \\t sync_status \\t soonest_reset
     ``soonest_reset`` (#1789) is only populated on the ``all_tokens_limited``
     skip — the nearest known limit-window expiry across the enabled pool.
+    EMPTY columns are emitted as the sentinel ``-`` (PR #1790 r3 BLOCKING 1):
+    the consumer decodes with ``IFS=$'\\t' read`` and bash treats tab as IFS
+    *whitespace*, so consecutive tabs collapse into one delimiter and every
+    empty field silently shifts the columns to its right (an
+    ``all_tokens_limited`` row put ``soonest_reset`` into ``rotation_from``).
+    The bash callsite maps ``-`` back to the empty string per field.
     JSON-parse error degrades to ``error\\tinvalid_rotation_output\\t...`` so
     the downstream ``case "$rotation_status:$rotation_reason"`` branch can
     classify it under ``error:*``.
@@ -954,18 +960,15 @@ def cmd_rotation_status_parse(args: argparse.Namespace) -> int:
     except Exception:
         payload = {"status": "error", "reason": "invalid_rotation_output"}
     sync = payload.get("sync") if isinstance(payload.get("sync"), dict) else {}
-    print(
-        "\t".join(
-            [
-                str(payload.get("status", "")),
-                str(payload.get("reason", "")),
-                str(payload.get("old_active_token_id", "")),
-                str(payload.get("active_token_id", "")),
-                str(sync.get("status", "")),
-                str(payload.get("soonest_reset", "")),
-            ]
-        )
-    )
+    columns = [
+        str(payload.get("status", "")),
+        str(payload.get("reason", "")),
+        str(payload.get("old_active_token_id", "")),
+        str(payload.get("active_token_id", "")),
+        str(sync.get("status", "")),
+        str(payload.get("soonest_reset", "")),
+    ]
+    print("\t".join(col if col else "-" for col in columns))
     return 0
 
 

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2217,6 +2217,16 @@ process_usage_monitor() {
     # downstream ``case`` statement routes through the ``error:*`` branch.
     rotation_status_row="$(bridge_with_timeout 5 rotation_status_parse python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" rotation-status-parse "$rotate_json" || true)"
     IFS=$'\t' read -r rotation_status rotation_reason rotation_from rotation_to rotation_sync_status rotation_soonest_reset <<<"$rotation_status_row"
+    # PR #1790 r3 BLOCKING 1: the helper emits `-` for EMPTY columns because
+    # bash treats tab as IFS whitespace — consecutive tabs collapse and every
+    # empty field would shift the columns after it (the all_tokens_limited
+    # row landed soonest_reset in rotation_from). Decode the sentinel here.
+    [[ "$rotation_status" == "-" ]] && rotation_status=""
+    [[ "$rotation_reason" == "-" ]] && rotation_reason=""
+    [[ "$rotation_from" == "-" ]] && rotation_from=""
+    [[ "$rotation_to" == "-" ]] && rotation_to=""
+    [[ "$rotation_sync_status" == "-" ]] && rotation_sync_status=""
+    [[ "$rotation_soonest_reset" == "-" ]] && rotation_soonest_reset=""
     # Issue #831: record `worst_case_agent` — the agent whose usage actually
     # crossed the rotation threshold this pass. Empty for legacy single-cache
     # rows. Distinct from `agent_scope` (the rotation fanout target).

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2104,6 +2104,7 @@ process_usage_monitor() {
   local rotation_from=""
   local rotation_to=""
   local rotation_sync_status=""
+  local rotation_soonest_reset=""
   # Footgun #11 (refs #815 Wave B): route the alert_rows / rotation_rows
   # loops through tempfiles to avoid `done <<<` heredoc_write wedges.
   local _alert_tmp="" _rotation_tmp=""
@@ -2198,11 +2199,16 @@ process_usage_monitor() {
     # Rotate only once per monitor pass; bridge-usage.py already latches each
     # provider/account/window candidate once per usage reset cycle.
     (( rotation_count > 0 )) && continue
+    # #1789: hand the rotating-away token's reset window (already on this
+    # candidate row) to the rotator so it can stamp `limited_until` on the
+    # old token and stop round-robining into tokens that are themselves
+    # still rate-limited.
     rotate_json="$(bridge_with_timeout 20 daemon_auth_token_rotate "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-auth.sh" claude-token rotate \
       --if-auto-enabled \
       --sync \
       --agents "$rotation_agent_scope" \
       --reason "usage:${window}:${used_percent}" \
+      --limited-until "$reset_at" \
       --json 2>/dev/null || true)"
     # Issue #800 regression follow-up: rotation outcome parser moved out of
     # heredoc-stdin into the helper subcommand. 5s ceiling — pure JSON
@@ -2210,7 +2216,7 @@ process_usage_monitor() {
     # subsequent ``IFS=$'\t' read`` decodes to empty fields, which the
     # downstream ``case`` statement routes through the ``error:*`` branch.
     rotation_status_row="$(bridge_with_timeout 5 rotation_status_parse python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" rotation-status-parse "$rotate_json" || true)"
-    IFS=$'\t' read -r rotation_status rotation_reason rotation_from rotation_to rotation_sync_status <<<"$rotation_status_row"
+    IFS=$'\t' read -r rotation_status rotation_reason rotation_from rotation_to rotation_sync_status rotation_soonest_reset <<<"$rotation_status_row"
     # Issue #831: record `worst_case_agent` — the agent whose usage actually
     # crossed the rotation threshold this pass. Empty for legacy single-cache
     # rows. Distinct from `agent_scope` (the rotation fanout target).
@@ -2227,12 +2233,27 @@ process_usage_monitor() {
       --detail to="$rotation_to" \
       --detail sync_status="$rotation_sync_status" \
       --detail agent_scope="$rotation_agent_scope" \
-      --detail worst_case_agent="$worst_case_agent"
+      --detail worst_case_agent="$worst_case_agent" \
+      --detail soonest_reset="$rotation_soonest_reset"
     case "$rotation_status:$rotation_reason" in
       rotated:*)
         title="claude token rotated"
         body="Claude token rotated after ${window} usage reached ${used_percent}%. active_token=${rotation_to}; sync=${rotation_sync_status:-unknown}."
         priority="high"
+        ;;
+      skipped:all_tokens_limited)
+        # #1789: every enabled token is inside a known 429 limit window —
+        # rotating would re-enter a saturated token, so the rotator refused.
+        # This is one continuous condition, not a per-pass event: notify on a
+        # cooldown latch (bridge_daemon_pass_due doubles as the latch — it
+        # stamps when due), never once per 300s monitor pass.
+        if bridge_daemon_pass_due claude_pool_exhausted_notice "${BRIDGE_CLAUDE_POOL_EXHAUSTED_NOTICE_INTERVAL_SECONDS:-1800}"; then
+          title="claude token pool exhausted"
+          body="All enabled Claude tokens are rate-limited; rotation is paused instead of cycling a saturated pool (#1789). soonest_reset=${rotation_soonest_reset:-unknown}. Sessions may hit limit errors until a window resets."
+          priority="urgent"
+        else
+          title=""
+        fi
         ;;
       skipped:no_alternate_token|error:*)
         title="claude token rotation needs attention"

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -5328,8 +5328,8 @@ def _is_admin_credential_routine(text: str, agent: str) -> bool:
       (:func:`_validate_auth_add_args`) — boolean
       ``--stdin/--activate/--replace/--sync/--enable-auto-rotate/
       --if-auto-enabled/--json`` plus value flags
-      ``--id/--agents/--threshold/--token-file/--reason`` with their
-      per-flag safety predicates.
+      ``--id/--agents/--threshold/--token-file/--reason/--limited-until``
+      with their per-flag safety predicates.
 
     Returns False (NOT raising) on any malformed shape so the substring
     deny stays in force. Skipping the deny on a malformed shape would
@@ -5838,7 +5838,17 @@ _AUTH_FLAGS_SLUG = frozenset(
     }
 )
 _AUTH_FLAGS_REASON = frozenset({"--reason"})
-_AUTH_FLAGS_VALUE = _AUTH_FLAGS_PATH | _AUTH_FLAGS_SLUG | _AUTH_FLAGS_REASON
+# `rotate --limited-until <ISO>` (#1789 / PR #1790): the rotating-away
+# token's 429 reset time. Timestamp only — `_safe_slug_arg` rejects the
+# `:`/`+` an ISO offset carries, so it gets its own strict shape check
+# (date-time with optional fraction and Z / ±HH:MM offset, nothing else).
+_AUTH_FLAGS_ISO = frozenset({"--limited-until"})
+_AUTH_ISO_TS_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$"
+)
+_AUTH_FLAGS_VALUE = (
+    _AUTH_FLAGS_PATH | _AUTH_FLAGS_SLUG | _AUTH_FLAGS_REASON | _AUTH_FLAGS_ISO
+)
 
 
 def _validate_auth_add_args(tokens: list[str]) -> bool:
@@ -5891,6 +5901,8 @@ def _validate_auth_flag_value(flag: str, value: str) -> bool:
         return _safe_path_arg(value)
     if flag in _AUTH_FLAGS_SLUG:
         return _safe_slug_arg(value)
+    if flag in _AUTH_FLAGS_ISO:
+        return bool(_AUTH_ISO_TS_RE.match(value))
     if flag in _AUTH_FLAGS_REASON:
         # Free-text reason: only reject shell metacharacters.
         if not value:

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -1719,6 +1719,14 @@ select_for_path() {
       # revert to the stale-drop-on-failure shape (which silently suppressed a
       # legitimately-queued task's nudge on a transient IO/env glitch) is caught.
       add_required 1631-nudge-helper-db-guard
+      # PR #1790 (#1789, r3 BLOCKING 1): bridge-daemon.sh's
+      # process_usage_monitor decodes the rotation-status TSV with
+      # IFS=$'\t' read and maps the helper's `-` empty-column sentinel
+      # back to "" per field. Pull the rotation suite on every
+      # bridge-daemon.sh move so a future edit that drops the sentinel
+      # decode (re-collapsing empty columns and shifting soonest_reset
+      # into rotation_from) is caught by the encode/decode roundtrip case.
+      add_required 1789-rotation-limited-until
       # v0.15.0-beta5-2 Lane η (#1314, CRITICAL/security):
       # bridge-daemon.sh's `cmd_run_cron_worker` now gates shell-cron
       # dispatch on `bridge_cron_uid_drop_preflight`. The new gate emits
@@ -3621,7 +3629,20 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # canary-absence from transcript/audit), the token-free request,
       # and the negative guard shapes. Pull it on every auth move so a
       # future refactor cannot regress the sealed-paste contract.
-      add_required F-beta4-oauth-bootstrap daemon-periodic-token-sync 1358-admin-credential-routine-exempt 1367-auth-sealed-paste 1470-engine-auth-seam 1470-codex-fleet-sync
+      # PR #1790 (#1789 D1/D2): rotate is now limit-window aware
+      # (--limited-until stamp, future-limited candidate skip,
+      # all_tokens_limited refusal + sentinel-encoded TSV). The
+      # 1789-rotation-limited-until wrapper runs the canonical
+      # tests/claude-token-rotation suite so every auth move re-proves the
+      # rotation contract end-to-end (r3 P1: previously dangling in tests/
+      # with no CI mapping).
+      add_required F-beta4-oauth-bootstrap daemon-periodic-token-sync 1358-admin-credential-routine-exempt 1367-auth-sealed-paste 1470-engine-auth-seam 1470-codex-fleet-sync 1789-rotation-limited-until
+      add_integration integration-minimal
+      ;;
+
+    tests/claude-token-rotation/*)
+      # PR #1790 (#1789): edits to the rotation suite itself must re-run it.
+      add_required 1789-rotation-limited-until
       add_integration integration-minimal
       ;;
 
@@ -3671,6 +3692,10 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # exercises it (TSV fields + absent-peer empty) so a helper refactor
       # cannot regress the enriched alert contract.
       add_required F-beta4-oauth-bootstrap daemon-periodic-token-sync daemon queue I-beta4-a2a-3-gaps mcp-liveness-giveup-auto-clear 1563-pr8-a2a-diag-recovery
+      # PR #1790 r3 BLOCKING 1: rotation-status-parse now sentinel-encodes
+      # empty TSV columns (`-`) so the daemon's IFS=$'\t' read cannot
+      # collapse them. The rotation suite pins the encode/decode roundtrip.
+      add_required 1789-rotation-limited-until
       # Issue #1732 (Lane B): bridge-daemon-helpers.py's ``a2a-stuck-decide`` is
       # now class-aware — it suppresses the [A2A] outbox stuck admin alarm for
       # transient peers (alarm_on_unreachable=False) and honors a per-peer longer

--- a/scripts/smoke/1358-admin-credential-routine-exempt.sh
+++ b/scripts/smoke/1358-admin-credential-routine-exempt.sh
@@ -921,6 +921,37 @@ main() {
     smoke_log "ok: T18 sweep — no 'sweep-canary-1358' survives in any audit row (class closed)"
   fi
 
+  # T19 — PR #1790 r3 BLOCKING 2 (#1789): the daemon's limit-window-aware
+  # rotate carries `--limited-until <ISO>` and the flag must be on the auth
+  # allowlist or an admin agent mirroring the daemon's rotation is denied at
+  # the hook. The validated surface is the anchored `agb`/`agent-bridge`
+  # verb dispatcher (`auth claude-token rotate` → `_validate_auth_flags`);
+  # the `bash bridge-auth.sh` spelling has no rotate carve-out and is out of
+  # scope here. ISO values carry `:` and `+` which `_safe_slug_arg` rejects,
+  # so the flag has its own strict timestamp predicate — verify the ALLOW
+  # for the daemon-equivalent shape and the DENY for non-timestamp values
+  # (the predicate must not become a free-text hole).
+  assert_hook_verdict \
+    "T19 rotate --limited-until ISO value" \
+    admin-1358 \
+    "agb auth claude-token rotate --if-auto-enabled --sync --reason usage:weekly:97 --limited-until 2099-01-02T03:04:05+09:00 --json" \
+    "ALLOW"
+  assert_hook_verdict \
+    "T19 rotate --limited-until Z suffix" \
+    admin-1358 \
+    "agb auth claude-token rotate --limited-until 2099-01-02T03:04:05Z --json" \
+    "ALLOW"
+  assert_hook_verdict \
+    "T19 rotate --limited-until date-only value denied" \
+    admin-1358 \
+    "agb auth claude-token rotate --limited-until 2099-01-02 --json" \
+    "DENY"
+  assert_hook_verdict \
+    "T19 rotate --limited-until free text denied" \
+    admin-1358 \
+    "agb auth claude-token rotate --limited-until tomorrow --json" \
+    "DENY"
+
   smoke_log "passed"
 }
 

--- a/scripts/smoke/1789-rotation-limited-until.sh
+++ b/scripts/smoke/1789-rotation-limited-until.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# scripts/smoke/1789-rotation-limited-until.sh — PR #1790 (#1789 D1/D2).
+#
+# Thin CI registration wrapper (PR #1790 r3 P1: the canonical rotation suite
+# lived dangling under tests/ with no ci-select-smoke.sh mapping, so changes
+# to the rotation surface never re-ran it in CI).
+#
+# The suite itself is tests/claude-token-rotation/smoke.sh — an isolated
+# BRIDGE_HOME fixture covering the keychain-free auth path end-to-end plus
+# the #1789 limit-window block: rotate --limited-until stamps the
+# rotating-away token, ring selection skips future-limited candidates,
+# all_tokens_limited refusal carries soonest_reset (sentinel-encoded TSV,
+# r3 BLOCKING 1), an expired stamp re-admits the token, and explicit
+# activate clears a pending stamp (r2 finding).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+exec bash "$REPO_ROOT/tests/claude-token-rotation/smoke.sh"

--- a/tests/claude-token-rotation/smoke.sh
+++ b/tests/claude-token-rotation/smoke.sh
@@ -914,6 +914,73 @@ ENABLED_JSON="$("$REPO_ROOT/agent-bridge" auth claude-token auto-rotate enable -
 json_assert "auto enable" "$ENABLED_JSON" "payload['status'] == 'ok' and payload['auto_rotate_enabled'] is True and payload['rotation_threshold'] == 99.0"
 pass "auto-rotate gate is registry controlled"
 
+# #1789 — rotate must record the rotating-away token's 429 reset window
+# (--limited-until) and refuse to rotate INTO a token still inside its own
+# window. Without this the daemon round-robins a saturated pool (observed:
+# median same-token return 1.2h vs 5h reset windows, 223 rotations/3 days).
+# Fixture state here: tokens first+second, active=second.
+LIMIT_FUTURE_ISO="$("$PYTHON" -c 'import datetime; print((datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=2)).isoformat(timespec="seconds"))')"
+LIMIT_PAST_ISO="$("$PYTHON" -c 'import datetime; print((datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2)).isoformat(timespec="seconds"))')"
+
+LIMITED_ROTATE_JSON="$("$REPO_ROOT/agent-bridge" auth claude-token rotate --reason smoke-1789 --limited-until "$LIMIT_FUTURE_ISO" --json)"
+[[ "$LIMITED_ROTATE_JSON" != *"$TOKEN_A"* && "$LIMITED_ROTATE_JSON" != *"$TOKEN_B"* ]] || fail "limited rotate output leaked token"
+json_assert "limited rotate" "$LIMITED_ROTATE_JSON" "payload['status'] == 'rotated' and payload['old_active_token_id'] == 'second' and payload['active_token_id'] == 'first'"
+"$PYTHON" - "$BRIDGE_CLAUDE_TOKEN_REGISTRY" "$LIMIT_FUTURE_ISO" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+registry = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+rows = {row.get("id"): row for row in registry.get("tokens", [])}
+if rows["second"].get("limited_until") != sys.argv[2]:
+    raise SystemExit(f"rotated-away token missing limited_until stamp: {rows['second'].get('limited_until')!r}")
+if "limited_until" in rows["first"]:
+    raise SystemExit("selected token unexpectedly carries a limited_until stamp")
+PY
+[[ $? -eq 0 ]] || fail "rotate --limited-until did not stamp the rotated-away token"
+pass "rotate --limited-until stamps the rotated-away token's reset window"
+
+POOL_EXHAUSTED_JSON="$("$REPO_ROOT/agent-bridge" auth claude-token rotate --reason smoke-1789-exhausted --json)"
+json_assert "pool exhausted" "$POOL_EXHAUSTED_JSON" "payload['status'] == 'skipped' and payload['reason'] == 'all_tokens_limited' and payload['active_token_id'] == 'first' and payload['soonest_reset'] != ''"
+"$PYTHON" - "$BRIDGE_CLAUDE_TOKEN_REGISTRY" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+registry = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if registry.get("active_token_id") != "first":
+    raise SystemExit(f"all_tokens_limited mutated active token: {registry.get('active_token_id')!r}")
+PY
+[[ $? -eq 0 ]] || fail "all_tokens_limited skip mutated the active token"
+pass "rotate refuses a fully limited pool instead of cycling it"
+
+"$PYTHON" - "$BRIDGE_CLAUDE_TOKEN_REGISTRY" "$LIMIT_PAST_ISO" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+registry = json.loads(path.read_text(encoding="utf-8"))
+for row in registry.get("tokens", []):
+    if row.get("id") == "second":
+        row["limited_until"] = sys.argv[2]
+path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+PY
+EXPIRED_ROTATE_JSON="$("$REPO_ROOT/agent-bridge" auth claude-token rotate --reason smoke-1789-expired --sync --json)"
+json_assert "expired stamp rotate" "$EXPIRED_ROTATE_JSON" "payload['status'] == 'rotated' and payload['old_active_token_id'] == 'first' and payload['active_token_id'] == 'second' and payload['sync']['status'] == 'ok'"
+"$PYTHON" - "$BRIDGE_CLAUDE_TOKEN_REGISTRY" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+registry = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+rows = {row.get("id"): row for row in registry.get("tokens", [])}
+if "limited_until" in rows["second"]:
+    raise SystemExit("expired limited_until stamp survived activation")
+PY
+[[ $? -eq 0 ]] || fail "expired limited_until stamp was not cleared on activation"
+pass "expired limit window re-admits the token and clears the stale stamp"
+
 ADD_QUOTA_JSON="$(printf '%s' "$TOKEN_C" | "$REPO_ROOT/agent-bridge" auth claude-token add --id quota --stdin --json)"
 [[ "$ADD_QUOTA_JSON" != *"$TOKEN_C"* ]] || fail "quota add output leaked token"
 CHECK_QUOTA_JSON="$(

--- a/tests/claude-token-rotation/smoke.sh
+++ b/tests/claude-token-rotation/smoke.sh
@@ -1014,6 +1014,40 @@ ACTIVATE_RESTORE_JSON="$("$REPO_ROOT/agent-bridge" auth claude-token activate se
 json_assert "activate restore" "$ACTIVATE_RESTORE_JSON" "payload['status'] == 'activated' and payload['active_token_id'] == 'second'"
 pass "explicit activate clears a pending limit-window stamp (operator override)"
 
+# PR #1790 r3 BLOCKING 1 — the daemon decodes the rotation-status-parse row
+# with `IFS=$'\t' read`, and bash treats tab as IFS WHITESPACE: consecutive
+# tabs collapse into one delimiter, so any empty column silently shifts every
+# column to its right (an all_tokens_limited row put soonest_reset into
+# rotation_from). The helper now emits `-` for empty columns and the daemon
+# maps `-` back to "". Pin the encode + the bash decode roundtrip.
+SENTINEL_ISO="2099-01-02T03:04:05+09:00"
+LIMITED_ROW="$("$PYTHON" "$REPO_ROOT/bridge-daemon-helpers.py" rotation-status-parse \
+  "{\"status\":\"skipped\",\"reason\":\"all_tokens_limited\",\"active_token_id\":\"first\",\"soonest_reset\":\"$SENTINEL_ISO\"}")"
+"$PYTHON" - "$LIMITED_ROW" "$SENTINEL_ISO" <<'PY'
+import sys
+
+cols = sys.argv[1].split("\t")
+if len(cols) != 6:
+    raise SystemExit(f"expected 6 sentinel-encoded columns, got {len(cols)}: {cols!r}")
+expect = ["skipped", "all_tokens_limited", "-", "first", "-", sys.argv[2]]
+if cols != expect:
+    raise SystemExit(f"sentinel encoding mismatch: {cols!r} != {expect!r}")
+PY
+[[ $? -eq 0 ]] || fail "rotation-status-parse did not sentinel-encode empty columns"
+IFS=$'\t' read -r SR_STATUS SR_REASON SR_FROM SR_TO SR_SYNC SR_SOONEST <<<"$LIMITED_ROW"
+[[ "$SR_FROM" == "-" ]] && SR_FROM=""
+[[ "$SR_SYNC" == "-" ]] && SR_SYNC=""
+[[ "$SR_SOONEST" == "-" ]] && SR_SOONEST=""
+[[ "$SR_STATUS" == "skipped" && "$SR_REASON" == "all_tokens_limited" && -z "$SR_FROM" && "$SR_TO" == "first" && -z "$SR_SYNC" && "$SR_SOONEST" == "$SENTINEL_ISO" ]] \
+  || fail "bash IFS decode misaligned sentinel row: status=$SR_STATUS reason=$SR_REASON from=$SR_FROM to=$SR_TO sync=$SR_SYNC soonest=$SR_SOONEST"
+ROTATED_ROW="$("$PYTHON" "$REPO_ROOT/bridge-daemon-helpers.py" rotation-status-parse \
+  '{"status":"rotated","old_active_token_id":"a","active_token_id":"b","reason":"usage:weekly:97","sync":{"status":"ok"}}')"
+IFS=$'\t' read -r SR_STATUS SR_REASON SR_FROM SR_TO SR_SYNC SR_SOONEST <<<"$ROTATED_ROW"
+[[ "$SR_SOONEST" == "-" ]] && SR_SOONEST=""
+[[ "$SR_STATUS" == "rotated" && "$SR_FROM" == "a" && "$SR_TO" == "b" && "$SR_SYNC" == "ok" && -z "$SR_SOONEST" ]] \
+  || fail "rotated row decode regressed under sentinel encoding: $ROTATED_ROW"
+pass "rotation-status-parse sentinel encoding survives the daemon's IFS=tab decode"
+
 ADD_QUOTA_JSON="$(printf '%s' "$TOKEN_C" | "$REPO_ROOT/agent-bridge" auth claude-token add --id quota --stdin --json)"
 [[ "$ADD_QUOTA_JSON" != *"$TOKEN_C"* ]] || fail "quota add output leaked token"
 CHECK_QUOTA_JSON="$(

--- a/tests/claude-token-rotation/smoke.sh
+++ b/tests/claude-token-rotation/smoke.sh
@@ -981,6 +981,39 @@ PY
 [[ $? -eq 0 ]] || fail "expired limited_until stamp was not cleared on activation"
 pass "expired limit window re-admits the token and clears the stale stamp"
 
+# PR #1790 r2 codex finding — explicit `activate` is an operator override and
+# must also drop a pending limit-window stamp; otherwise a manually
+# reactivated token stays hiddenly ineligible for future rotation until the
+# stale timestamp expires.
+"$PYTHON" - "$BRIDGE_CLAUDE_TOKEN_REGISTRY" "$LIMIT_FUTURE_ISO" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+registry = json.loads(path.read_text(encoding="utf-8"))
+for row in registry.get("tokens", []):
+    if row.get("id") == "first":
+        row["limited_until"] = sys.argv[2]
+path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+PY
+ACTIVATE_STAMPED_JSON="$("$REPO_ROOT/agent-bridge" auth claude-token activate first --json)"
+json_assert "activate stamped" "$ACTIVATE_STAMPED_JSON" "payload['status'] == 'activated' and payload['active_token_id'] == 'first'"
+"$PYTHON" - "$BRIDGE_CLAUDE_TOKEN_REGISTRY" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+registry = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+rows = {row.get("id"): row for row in registry.get("tokens", [])}
+if "limited_until" in rows["first"]:
+    raise SystemExit("explicit activate left the limited_until stamp in place")
+PY
+[[ $? -eq 0 ]] || fail "explicit activate did not clear the limited_until stamp"
+ACTIVATE_RESTORE_JSON="$("$REPO_ROOT/agent-bridge" auth claude-token activate second --json)"
+json_assert "activate restore" "$ACTIVATE_RESTORE_JSON" "payload['status'] == 'activated' and payload['active_token_id'] == 'second'"
+pass "explicit activate clears a pending limit-window stamp (operator override)"
+
 ADD_QUOTA_JSON="$(printf '%s' "$TOKEN_C" | "$REPO_ROOT/agent-bridge" auth claude-token add --id quota --stdin --json)"
 [[ "$ADD_QUOTA_JSON" != *"$TOKEN_C"* ]] || fail "quota add output leaked token"
 CHECK_QUOTA_JSON="$(


### PR DESCRIPTION
Fixes #1789.

## Problem

The daemon's usage-monitor rotation (`rotate --if-auto-enabled --sync`) is a pure ring round-robin: on a 429/limit signal it advances to the next enabled token without checking whether that token is itself still inside a known rate-limit window. The registry keeps no per-token limit memory, so on a saturated pool the rotator plays musical chairs:

- Field data (2 installs sharing one 5-token pool, 3-day window): **223 rotations**, median same-token return interval **~1.2h** against ~5h observed reset windows — tokens were re-activated mid-window and immediately re-429'd.
- Each pass also emitted a high-priority "token rotated" notification, turning one continuous condition (pool exhausted) into notification spam.

This is defect **D1/D2** from the #1789 report; the cross-host/sentinel aspects (D3–D5) are intentionally out of scope here — per the issue discussion, the durable fix direction is server-side-truth-driven decisions, and this PR lands the local-decision half that is correct regardless of where the usage signal comes from.

## Fix

**`bridge-auth.py` `rotate`** — new `--limited-until <ISO>` (timestamp only, never token bytes):

- Stamps the rotating-away token's registry row with `limited_until` (the 429-derived `reset_at` the daemon already holds on the usage candidate row).
- Selection keeps the legacy ring order after the active token, but **skips candidates whose own `limited_until` is still in the future**. An absent, expired, or unparseable stamp keeps the token eligible — a bad stamp must never strand a token as permanently ineligible. The stamp is popped when the token is activated again, so `list`/`status` output stays truthful.
- If **every** alternate is still limited, rotate returns `{"status":"skipped","reason":"all_tokens_limited","soonest_reset":...}` instead of rotating — refusing is the truthful outcome; the registry still persists the new stamp.

**`bridge-daemon.sh` `process_usage_monitor`**:

- Passes `--limited-until "$reset_at"` on the rotate call.
- Reads the new 6th `soonest_reset` column from `rotation-status-parse` and records it in the audit row.
- Maps `skipped:all_tokens_limited` to **one urgent "claude token pool exhausted" notification on a cooldown latch** (`bridge_daemon_pass_due`, interval `BRIDGE_CLAUDE_POOL_EXHAUSTED_NOTICE_INTERVAL_SECONDS`, default 1800s) instead of a high alert on every 300s monitor pass.

**`bridge-daemon-helpers.py` `rotation-status-parse`** — emits the 6-column row (appends `soonest_reset`); JSON-error degrade path unchanged (empty 6th field).

**`OPERATIONS.md`** — auto-rotation section documents the new semantics.

No new heredoc-stdin was added to the daemon path (footgun #11); the rotate flag rides the existing `bridge_with_timeout ... bridge-auth.sh` argv, and `bridge-auth.sh` already forwards `"$@"` to the Python rotate, so no wrapper change was needed.

## Compatibility

- `--limited-until` defaults to empty → manual `rotate` calls and older callers behave exactly as before (no stamp, legacy ring selection).
- Registries without `limited_until` keys are unaffected; the key appears only after a daemon-triggered rotation and disappears on re-activation.
- Existing skip reasons (`auto_rotate_disabled`, `no_alternate_token`) and the rotated payload shape are unchanged; `all_tokens_limited` is a new additive reason, and the daemon `case` falls through to the existing `error:*`/default branches for unknown rows as before.

## Tests

`tests/claude-token-rotation/smoke.sh` — 3 new cases appended after the auto-rotate gate test (isolated `BRIDGE_*` fixture, 2-token registry):

1. `rotate --limited-until <future>` → rotated; old row stamped, selected row clean.
2. Next rotate → `skipped/all_tokens_limited`, `soonest_reset` populated, `active_token_id` untouched.
3. Stamp rewritten to the past → rotate `--sync` re-admits the token, `sync.status == ok`, and the stale stamp is cleared on activation.

## Validation (manual verification notes — queue/daemon high-risk surface)

```
python3 -m py_compile bridge-auth.py bridge-daemon-helpers.py   # clean
bash -n bridge-daemon.sh bridge-auth.sh tests/claude-token-rotation/smoke.sh   # clean
shellcheck -S warning bridge-daemon.sh bridge-auth.sh tests/claude-token-rotation/smoke.sh   # clean
bash tests/claude-token-rotation/smoke.sh   # exit 0, 40 passes (incl. the 3 new #1789 cases; all pre-existing rotate/sync/recovery assertions green)
```

Repro for reviewers: run the smoke from the repo root on any host with `python3` + `bash 4+`; it builds its own isolated `BRIDGE_HOME`/registry fixture and does not touch live bridge state. The daemon-side branch can be exercised by feeding `rotation-status-parse` a `{"status":"skipped","reason":"all_tokens_limited","soonest_reset":"..."}` envelope and observing the audit row + single urgent notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
