### PR TITLE
[doctor] #1787 #1788: case-insensitive orphan/retire identity + two-tree drift detector aligned to renderer

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -6423,6 +6423,34 @@ run_retire() {
     agent_source="unregistered"
     privilege_class="user"
     home_dir="$BRIDGE_AGENT_HOME_ROOT/$agent"
+
+    # Issue #1787: filesystem-aware identity preflight. `bridge_agent_exists`
+    # is a case-SENSITIVE registry lookup, so on a case-insensitive volume
+    # (macOS APFS default) a case-variant spelling of a LIVE agent's name
+    # (`CRM-TEST-BSH` vs registered `crm-test-bsh`) misses the registry and
+    # lands here as "unregistered" — yet `$BRIDGE_AGENT_HOME_ROOT/$agent` IS
+    # the live agent's directory (same inode). Quarantining it would dangle
+    # the live agent's workdir `settings.json` symlink (the #1766 "Settings
+    # Error" picker class). Before treating this as a retireable orphan,
+    # samefile-compare the resolved home dir against every registered agent's
+    # home + workdir and refuse with a pointer to the real registered name.
+    local _retire_guard="$SCRIPT_DIR/lib/agent-cli-helpers/retire-samefile-guard.py"
+    if [[ -d "$home_dir" && -f "$_retire_guard" ]] \
+        && declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1 \
+        && (( ${#BRIDGE_AGENT_IDS[@]} > 0 )); then
+      local _retire_rows_file _reg_agent _reg_home _reg_workdir _matched_agent
+      _retire_rows_file="$(mktemp "${TMPDIR:-/tmp}/bridge-retire-guard.XXXXXX")"
+      for _reg_agent in "${BRIDGE_AGENT_IDS[@]}"; do
+        _reg_home="$(bridge_agent_default_home "$_reg_agent" 2>/dev/null || printf '')"
+        _reg_workdir="$(bridge_agent_workdir "$_reg_agent" 2>/dev/null || printf '')"
+        printf '%s\t%s\t%s\n' "$_reg_agent" "$_reg_home" "$_reg_workdir" >>"$_retire_rows_file"
+      done
+      _matched_agent="$(python3 "$_retire_guard" "$home_dir" "$_retire_rows_file" 2>/dev/null || printf '')"
+      rm -f "$_retire_rows_file"
+      if [[ -n "$_matched_agent" ]]; then
+        bridge_die "deny: '$agent' resolves to the same directory ($home_dir) as the REGISTERED agent '$_matched_agent' (case-insensitive filesystem). Retiring it would quarantine a live agent's settings tree. Use the registered name '$_matched_agent' with \`agent-bridge agent stop\`/\`delete\` if you really intend to act on that agent."
+      fi
+    fi
   fi
 
   # Step 2: refuse if neither registry nor disk has anything to retire.

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -6438,18 +6438,34 @@ run_retire() {
     if [[ -d "$home_dir" && -f "$_retire_guard" ]] \
         && declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1 \
         && (( ${#BRIDGE_AGENT_IDS[@]} > 0 )); then
-      local _retire_rows_file _reg_agent _reg_home _reg_workdir _matched_agent
+      local _retire_rows_file _reg_agent _reg_home _reg_workdir _guard_verdict
+      local _verdict_kind _matched_agent
       _retire_rows_file="$(mktemp "${TMPDIR:-/tmp}/bridge-retire-guard.XXXXXX")"
       for _reg_agent in "${BRIDGE_AGENT_IDS[@]}"; do
         _reg_home="$(bridge_agent_default_home "$_reg_agent" 2>/dev/null || printf '')"
         _reg_workdir="$(bridge_agent_workdir "$_reg_agent" 2>/dev/null || printf '')"
         printf '%s\t%s\t%s\n' "$_reg_agent" "$_reg_home" "$_reg_workdir" >>"$_retire_rows_file"
       done
-      _matched_agent="$(python3 "$_retire_guard" "$home_dir" "$_retire_rows_file" 2>/dev/null || printf '')"
+      # codex r3: 3-state verdict (`match\t<id>` / `indeterminate` / `no-match`).
+      # An EMPTY/failed read is treated as `indeterminate` — never as "allow" —
+      # so a probe failure fails SAFE (refuse) rather than letting retire mv a
+      # possibly-live tree. Only `no-match` proceeds.
+      _guard_verdict="$(python3 "$_retire_guard" "$home_dir" "$_retire_rows_file" 2>/dev/null | head -n 1 || printf 'indeterminate')"
       rm -f "$_retire_rows_file"
-      if [[ -n "$_matched_agent" ]]; then
-        bridge_die "deny: '$agent' resolves to the same directory ($home_dir) as the REGISTERED agent '$_matched_agent' (case-insensitive filesystem). Retiring it would quarantine a live agent's settings tree. Use the registered name '$_matched_agent' with \`agent-bridge agent stop\`/\`delete\` if you really intend to act on that agent."
-      fi
+      [[ -n "$_guard_verdict" ]] || _guard_verdict="indeterminate"
+      _verdict_kind="${_guard_verdict%%$'\t'*}"
+      case "$_verdict_kind" in
+        match)
+          _matched_agent="${_guard_verdict#*$'\t'}"
+          bridge_die "deny: '$agent' resolves to the same directory ($home_dir) as the REGISTERED agent '$_matched_agent' (case-insensitive filesystem). Retiring it would quarantine a live agent's settings tree. Use the registered name '$_matched_agent' with \`agent-bridge agent stop\`/\`delete\` if you really intend to act on that agent."
+          ;;
+        indeterminate)
+          bridge_die "deny: could not verify whether '$agent' ($home_dir) is a registered agent's directory — a stat/samefile probe failed, so identity is UNPROVEN. Refusing to retire (fail-safe) to avoid quarantining a possibly-live agent's tree. Confirm with \`agent-bridge agent registry --json\` (check whether any registered home/workdir resolves to $home_dir) before retrying."
+          ;;
+        *)
+          : # no-match — genuine orphan, retire may proceed.
+          ;;
+      esac
     fi
   fi
 

--- a/bridge-doctor.py
+++ b/bridge-doctor.py
@@ -18,17 +18,20 @@ Detectors:
 - orphan-agent-dir         : directories under $BRIDGE_AGENT_HOME_ROOT that are not in
                              `agent registry --json` (#598 Track 2). Report-only;
                              emits a manual quarantine recipe in suggested_action.
-- settings-two-tree-drift  : an agent whose home + workdir `settings.json` resolve to
-                             DIFFERENT real files — i.e. the workdir copy is a second
-                             real file instead of a relative symlink back to the home
-                             effective tree (#1455). This inode divergence lets the
-                             preserved-user `enabledPlugins` key drift and was the root
-                             cause of #1453.
-- settings-multi-tree      : an agent whose effective settings file exists as a real
-                             (non-symlink) file in MORE THAN ONE location — both
-                             `home/.claude/` and `workdir/.claude/` (#1455). The
-                             single-tree invariant requires exactly one physical
-                             effective file with every other location a symlink to it.
+- settings-two-tree-drift  : a CLAUDE agent whose home + workdir `settings.json` resolve
+                             to two real files with DIFFERENT CONTENT (#1455). A
+                             preserved-user key like `enabledPlugins` drifting between
+                             the trees was the root cause of #1453. Two distinct inodes
+                             with IDENTICAL content is the renderer's intended dual-render
+                             on shared-mode v2 non-iso hosts and is NOT flagged (#1788);
+                             non-claude engines are skipped (#1788 Note).
+- settings-multi-tree      : a CLAUDE agent whose effective settings file exists as a
+                             real (non-symlink) file in MORE THAN ONE location — both
+                             `home/.claude/` and `workdir/.claude/` — with DIVERGENT
+                             content (#1455). Two byte-identical physical copies is the
+                             renderer's intended dual-render on shared-mode v2 non-iso
+                             hosts and is NOT flagged (#1788); non-claude engines are
+                             skipped (#1788 Note).
 
 Read-only contract: the CLI never mutates queue/state/tmux. `suggested_action`
 is a string the admin agent LLM parses and decides whether to execute. The two
@@ -793,6 +796,79 @@ def _iso_from_epoch(epoch: float | None) -> str:
         return ""
 
 
+def _registered_agent_dirs(registry: list[dict[str, Any]]) -> list[tuple[str, str]]:
+    """Yield (agent_id, dir) for every registered agent's home + workdir.
+
+    The orphan detector and `agent retire` both need the SET of directories
+    that belong to a registered agent so a candidate dir can be checked
+    case-insensitively (macOS APFS) via `os.path.samefile`, not just by a
+    case-sensitive basename string compare. Skips empty paths.
+    """
+    out: list[tuple[str, str]] = []
+    for row in registry:
+        if not isinstance(row, dict):
+            continue
+        agent_id = str(row.get("id") or "").strip()
+        if not agent_id:
+            continue
+        for key in ("home", "workdir"):
+            base = str(row.get(key) or "").strip()
+            if base:
+                out.append((agent_id, base))
+    return out
+
+
+def _samefiles_registered_agent(
+    candidate: Path,
+    registered_dirs: list[tuple[str, str]],
+) -> str | None:
+    """Return the registered agent id whose home/workdir IS `candidate`.
+
+    Filesystem-aware identity (Issue #1787): on a case-insensitive volume
+    (macOS APFS default) `agents/CRM-TEST-BSH` and the registry's
+    `agents/crm-test-bsh` are the SAME directory, so a case-sensitive
+    basename compare wrongly classifies a LIVE agent's dir as an orphan and
+    guides a destructive `mv` / `retire` of its settings tree. Mirror the
+    #1759 self-ref guard idiom: realpath string-compare first, then
+    `os.path.samefile` as the inode-aware fallback against each registered
+    home/workdir. Returns the matching agent id, or None when no registered
+    dir is provably the same file as `candidate`. A stat failure on one
+    registered dir (lazily-scaffolded / absent) is skipped — the exact
+    realpath compare already ruled out a plain string match, so an unstatable
+    registered dir is a genuinely different path, not the case-variant
+    collision being guarded against.
+    """
+    try:
+        cand_real = os.path.realpath(candidate)
+    except OSError:
+        cand_real = str(candidate)
+    for agent_id, base in registered_dirs:
+        reg_path = Path(base).expanduser()
+        try:
+            reg_real = os.path.realpath(reg_path)
+        except OSError:
+            reg_real = str(reg_path)
+        if cand_real == reg_real:
+            return agent_id
+        try:
+            if os.path.samefile(candidate, reg_path):
+                return agent_id
+        except OSError:
+            # samefile raises when EITHER side cannot be statted. A missing
+            # registered dir (agent scaffolded lazily) is benign — the
+            # string compare above already ruled out an exact match, so a
+            # stat failure here means the two are genuinely different paths
+            # OR one is absent; neither is the case-variant collision we
+            # guard against, so do NOT fail-safe to "match" on a plain
+            # absence. Only an EXISTING-but-unstatable candidate that we
+            # cannot prove distinct should be conservative — but the
+            # detector's own OSError handling already skips an unreadable
+            # candidate, so falling through to the next registered dir is
+            # correct here.
+            continue
+    return None
+
+
 def detect_orphan_agent_dir(
     registry: list[dict[str, Any]],
     home_root: Path,
@@ -818,6 +894,12 @@ def detect_orphan_agent_dir(
         agent_id = str(row.get("id") or "").strip()
         if agent_id:
             known.add(agent_id)
+    # Issue #1787: a case-insensitive volume (macOS APFS default) makes
+    # `agents/CRM-TEST-BSH` and the registry's `agents/crm-test-bsh` the SAME
+    # directory, so the basename string compare below is not enough — the
+    # case-variant spelling is not in `known` yet IS a live agent's dir. Build
+    # the registered home/workdir set for an inode-aware samefile fallback.
+    registered_dirs = _registered_agent_dirs(registry)
 
     try:
         entries = sorted(home_root.iterdir(), key=lambda p: p.name)
@@ -836,6 +918,18 @@ def detect_orphan_agent_dir(
         if name in known:
             continue
         if not entry.is_dir():
+            continue
+        # Issue #1787: filesystem-aware identity. Even when the basename is
+        # not a registry id (case differs), the dir may BE a registered
+        # agent's home/workdir on a case-INSENSITIVE fs (macOS APFS), where
+        # `CRM-TEST-BSH` and registered `crm-test-bsh` are the SAME inode.
+        # Use INODE identity (samefile/realpath), never an unconditional
+        # case-fold name match: on a case-SENSITIVE fs those two are DISTINCT
+        # directories and the uppercase one is a genuine orphan that must
+        # still fire. samefile proves same-vs-different correctly on both
+        # filesystem classes, so the detector keeps its teeth on Linux while
+        # not quarantining a live agent's tree on macOS.
+        if _samefiles_registered_agent(entry, registered_dirs) is not None:
             continue
         # Skip symlinks that don't point at an actual agent home (live
         # `shared/` link, stale convenience symlinks). A dir-shaped symlink
@@ -937,13 +1031,15 @@ def _real_settings_target(link_path: Path) -> Path | None:
 
 def _iter_registry_agents(
     registry: list[dict[str, Any]],
-) -> list[tuple[str, str, str]]:
-    """Yield (agent_id, home, workdir) triples from `agent registry --json`.
+) -> list[tuple[str, str, str, str]]:
+    """Yield (agent_id, home, workdir, engine) from `agent registry --json`.
 
     Skips rows missing an id or lacking BOTH a home and a workdir (nothing
     to compare). Mirrors the orphan detector's tolerance for partial rows.
+    `engine` lets a caller scope itself to one runtime (Issue #1788: the
+    settings drift detectors are Claude-tree-specific).
     """
-    out: list[tuple[str, str, str]] = []
+    out: list[tuple[str, str, str, str]] = []
     for row in registry:
         if not isinstance(row, dict):
             continue
@@ -954,37 +1050,85 @@ def _iter_registry_agents(
         workdir = str(row.get("workdir") or "").strip()
         if not home and not workdir:
             continue
-        out.append((agent_id, home, workdir))
+        engine = str(row.get("engine") or "").strip()
+        out.append((agent_id, home, workdir, engine))
     return out
+
+
+def _settings_effective_content(real_path: Path) -> str | None:
+    """Return the text content of a resolved settings.effective.json, or None.
+
+    Issue #1788: the two-tree-drift detector compares the CONTENT of the two
+    rendered effective files, not just their inode identity. On a shared-mode
+    v2 non-isolated host the renderer DELIBERATELY maintains two effective
+    files (workdir-side + launched-config-dir-side, see
+    `bridge_ensure_claude_shared_settings_for_managed_workdir` in
+    lib/bridge-hooks.sh) rendered from the same base+overlay — so two distinct
+    inodes with IDENTICAL content is the intended healthy end state, and only
+    a CONTENT divergence is the #1453 drift hazard. Read-only; any OSError
+    (unreadable iso tree, race) returns None so the caller degrades to
+    skip-this-agent rather than crashing.
+    """
+    try:
+        return real_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    except ValueError:
+        # Undecodable bytes — treat as unreadable for comparison purposes.
+        return None
 
 
 def detect_settings_two_tree_drift(
     registry: list[dict[str, Any]],
     ts: str,
 ) -> list[dict[str, Any]]:
-    """Issue #1455 detector (a): home + workdir `settings.json` diverge.
+    """Issue #1455 detector (a): home + workdir `settings.json` CONTENT diverges.
 
-    For every agent whose registry row carries BOTH a `home` and a
+    For every CLAUDE agent whose registry row carries BOTH a `home` and a
     `workdir`, resolve `<home>/.claude/settings.json` and
     `<workdir>/.claude/settings.json` to their real files and flag the
-    agent when they resolve to DIFFERENT inodes — i.e. the workdir copy is
-    a second real file instead of a relative symlink back at the home
-    effective tree. This is the silent drift that lets a stale
-    `enabledPlugins[X]=false` survive in the workdir copy (#1453 root
-    cause).
+    agent when the two real files have DIFFERENT CONTENT — the silent drift
+    that lets a stale `enabledPlugins[X]=false` survive in one tree (#1453
+    root cause).
+
+    Issue #1788 — aligned to the renderer's intended layout. The renderer
+    (`bridge_ensure_claude_shared_settings_for_managed_workdir`,
+    lib/bridge-hooks.sh) DELIBERATELY maintains two effective files for a
+    shared-mode v2 non-isolated agent: the workdir-side
+    `agents/<a>/.claude/settings.effective.json` AND the launched-config-dir
+    `data/agents/<a>/home/.claude/settings.effective.json` (registry `home`).
+    Both are rendered from the same base+overlay (same channels/class), so on
+    a healthy host they are TWO DISTINCT INODES WITH IDENTICAL CONTENT. The
+    pre-#1788 inode-only compare flagged that intended end state for every
+    Claude agent on v0.16.8 — an always-on false finding the operator could
+    neither execute the recipe for nor converge. Flagging on CONTENT instead
+    of inode keeps the #1453 teeth (a real divergent value still fires) while
+    treating the intended dual-render as healthy.
 
     Cases that are NOT flagged (no false positive):
+      * non-claude engines (codex's vestigial Claude tree; see Issue #1788
+        Note — `agent rerender-settings` refuses codex agents anyway);
       * either tree's `settings.json` missing / not-yet-rendered;
-      * both resolve to the same real file (the healthy symlinked layout);
+      * both resolve to the same real file (the classic single-tree symlink);
+      * both real files exist with byte-identical content (the renderer's
+        intended dual-render on shared-mode v2 non-iso hosts);
       * an agent with only one of {home, workdir} (no second tree to drift
         against — covered by settings-multi-tree if it ever grows one).
 
-    Read-only. `suggested_action` points at `link-shared-settings`; the
-    detector never re-points the symlink itself.
+    Read-only. `suggested_action` points at `agent rerender-settings <a>
+    --apply`; the detector never re-renders or re-points anything itself.
     """
     findings: list[dict[str, Any]] = []
-    for agent_id, home, workdir in _iter_registry_agents(registry):
+    for agent_id, home, workdir, engine in _iter_registry_agents(registry):
         if not home or not workdir:
+            continue
+        # Issue #1788 Note: scope to Claude agents. The settings.effective
+        # tree is a Claude runtime artifact; a codex agent's tree is
+        # vestigial and `agent rerender-settings` refuses it, so a finding
+        # would be unactionable. Empty/unknown engine is treated as claude
+        # (back-compat: a registry that predates the engine column, or a
+        # fixture that omits it, keeps the prior behavior).
+        if engine and engine != "claude":
             continue
         home_paths = _settings_tree_paths(home)
         work_paths = _settings_tree_paths(workdir)
@@ -1000,6 +1144,18 @@ def detect_settings_two_tree_drift(
         if home_real is None or work_real is None:
             continue
         if home_real == work_real:
+            # Same inode (classic single-tree symlink) — healthy.
+            continue
+        # Two distinct real files. Per #1788 this is only drift when their
+        # CONTENT differs; the renderer's intended dual-render produces two
+        # byte-identical files. If EITHER side is unreadable we cannot prove
+        # divergence — fail safe and skip (never flag on an unprovable read).
+        home_content = _settings_effective_content(home_real)
+        work_content = _settings_effective_content(work_real)
+        if home_content is None or work_content is None:
+            continue
+        if home_content == work_content:
+            # Intended dual-render: distinct inodes, identical content.
             continue
         try:
             work_is_symlink = work_link.is_symlink()  # noqa: raw-pathlib-controller-only — read-only evidence probe; OSError-guarded so an iso-tree PermissionError degrades to a null evidence field rather than crashing the diagnostic.
@@ -1011,17 +1167,19 @@ def detect_settings_two_tree_drift(
             "workdir_settings": str(work_link),
             "workdir_resolves_to": str(work_real),
             "workdir_is_symlink": work_is_symlink,
+            "content_diverged": True,
         }
         suggested = (
-            f"Two-tree settings drift for {agent_id}: "
-            f"{work_link} resolves to {work_real} but {home_link} resolves to "
-            f"{home_real} — the workdir settings is a SECOND real file instead "
-            "of a relative symlink to the home effective tree, so "
-            "enabledPlugins can drift (the #1453 signature). Re-point the "
-            "workdir at the home effective file with "
-            f"`bash bridge-hooks.sh link-shared-settings --agent {agent_id}` "
-            "(controller-owned render; never hand-copy). Verify with "
-            f"`realpath {work_link}` == `realpath {home_link}`."
+            f"Two-tree settings CONTENT drift for {agent_id}: "
+            f"{work_link} resolves to {work_real} and {home_link} resolves to "
+            f"{home_real} — two real effective files with DIFFERENT content, so "
+            "a preserved-user key (e.g. enabledPlugins) can drift between the "
+            "trees (the #1453 signature). Re-render and re-link both trees from "
+            "the single source with "
+            f"`agent-bridge agent rerender-settings {agent_id} --apply` "
+            "(controller-owned render; never hand-copy). Verify the finding "
+            "clears on the next `agent-bridge doctor --detectors "
+            "settings-two-tree-drift` run."
         )
         findings.append(
             {
@@ -1039,31 +1197,40 @@ def detect_settings_multi_tree(
     registry: list[dict[str, Any]],
     ts: str,
 ) -> list[dict[str, Any]]:
-    """Issue #1455 detector (b): effective settings exist in >1 real tree.
+    """Issue #1455 detector (b): effective settings physically drift across trees.
 
-    The single-tree invariant says exactly one physical
-    `settings.effective.json` may exist for an agent (canonically under
-    `home/.claude/`); every other location is a symlink to it. This
-    detector flags an agent that has a REAL (non-symlink) effective file
-    under BOTH its `home/.claude/` and its `workdir/.claude/` — two
-    physical copies, guaranteed to drift.
+    Flags a CLAUDE agent that has a REAL (non-symlink) effective file under
+    BOTH its `home/.claude/` and its `workdir/.claude/` whose CONTENTS
+    DIVERGE — two physical copies that have actually drifted apart.
+
+    Issue #1788 — aligned to the renderer's intended layout. On a shared-mode
+    v2 non-isolated host the renderer authors TWO physical effective files
+    (workdir-side + launched-config-dir-side) from the same base+overlay; two
+    byte-identical physical copies is therefore the intended end state, not a
+    violation. The pre-#1788 count-only check flagged that for every Claude
+    agent on v0.16.8 — an always-on false finding with no convergent verb.
+    Flagging on CONTENT divergence keeps the #1453 teeth (a genuinely drifted
+    second copy still fires) while treating the renderer's dual-render as
+    healthy.
 
     Distinct from settings-two-tree-drift: that one compares the
     `settings.json` link resolution; this one counts physical
-    `settings.effective.json` files. An agent can trip (b) even if its
-    `settings.json` links happen to agree, and the two together cover the
+    `settings.effective.json` files. The two together cover the
     promotion-time hazard described in the issue.
 
     Read-only.
     """
     findings: list[dict[str, Any]] = []
-    for agent_id, home, workdir in _iter_registry_agents(registry):
+    for agent_id, home, workdir, engine in _iter_registry_agents(registry):
+        # Issue #1788 Note: scope to Claude agents (see two-tree-drift).
+        if engine and engine != "claude":
+            continue
         # Map distinct PHYSICAL file (realpath) -> a display path. Keying by
         # realpath dedupes the case where `home` and `workdir` resolve to the
         # SAME tree (identical paths, or the workdir's `.claude` parent is a
         # symlink to home's) — there the same `settings.effective.json` would
         # otherwise be counted twice and produce a false multi-tree finding.
-        # Only TWO OR MORE distinct physical files is a real violation.
+        # Only TWO OR MORE distinct physical files is a candidate violation.
         physical: dict[str, str] = {}
         for base in (home, workdir):
             paths = _settings_tree_paths(base)
@@ -1081,22 +1248,36 @@ def detect_settings_multi_tree(
                 continue
         if len(physical) < 2:
             continue
+        # Issue #1788: ≥2 distinct physical files is only a violation when
+        # their CONTENT diverges; the renderer's dual-render produces
+        # byte-identical copies. Read each once; an unreadable file leaves its
+        # content None and is treated as "unknown" — if ANY content is unknown
+        # we cannot prove divergence and fail safe (skip). Otherwise flag only
+        # when more than one DISTINCT content blob exists.
         real_locations = sorted(physical.values())
+        contents = {
+            _settings_effective_content(Path(real)) for real in physical
+        }
+        if None in contents:
+            continue
+        if len(contents) < 2:
+            # All physical copies are byte-identical — the intended
+            # dual-render, not drift.
+            continue
         evidence = {
             "real_effective_files": real_locations,
             "count": len(real_locations),
+            "content_diverged": True,
         }
         suggested = (
-            f"Multi-tree settings for {agent_id}: a real settings.effective.json "
-            f"exists in {len(real_locations)} trees "
-            f"({', '.join(sorted(real_locations))}). The single-tree invariant "
-            "allows exactly one physical effective file (canonically under "
-            "home/.claude/) with every other location a symlink to it. Two "
-            "physical copies drift silently. Re-render the single home tree and "
-            "re-point the workdir with "
-            f"`bash bridge-hooks.sh link-shared-settings --agent {agent_id}`; "
-            "after that there must be ZERO physical settings.effective.json "
-            "under workdir/.claude/."
+            f"Multi-tree settings CONTENT drift for {agent_id}: real "
+            f"settings.effective.json files in {len(real_locations)} trees "
+            f"({', '.join(sorted(real_locations))}) have DIVERGED in content. "
+            "Re-render and re-link both trees from the single source with "
+            f"`agent-bridge agent rerender-settings {agent_id} --apply` "
+            "(controller-owned render; never hand-copy). Verify the finding "
+            "clears on the next `agent-bridge doctor --detectors "
+            "settings-multi-tree` run."
         )
         findings.append(
             {

--- a/bridge-doctor.py
+++ b/bridge-doctor.py
@@ -818,6 +818,32 @@ def _registered_agent_dirs(registry: list[dict[str, Any]]) -> list[tuple[str, st
     return out
 
 
+# Issue #1787 (codex r3): three-state identity result so a samefile that
+# cannot be RESOLVED (stat failure) never silently degrades to "not a
+# registered agent". The orphan detector and `agent retire` both fail SAFE on
+# INDETERMINATE — neither reports an orphan nor proceeds with a destructive
+# retire when identity could not be proven (the #1774/#1771 fail-closed
+# pattern). Distinct from `None` (PROVEN no-match: every registered dir was
+# statable and none is the same file).
+_SAMEFILE_INDETERMINATE = "\0indeterminate\0"
+
+
+def _path_lexists(path: Path) -> bool:
+    """True if `path` exists (incl. a broken symlink), False ONLY when it is
+    provably absent. A permission/other OSError errs toward True so the caller
+    fails SAFE (indeterminate) rather than treating an unreadable registered
+    dir as a clean no-match. `os.lstat` is the `os`-module call, not a
+    pathlib metadata probe — it does not trip the raw-pathlib lint.
+    """
+    try:
+        os.lstat(path)
+        return True
+    except (FileNotFoundError, NotADirectoryError):
+        return False
+    except OSError:
+        return True
+
+
 def _samefiles_registered_agent(
     candidate: Path,
     registered_dirs: list[tuple[str, str]],
@@ -831,41 +857,61 @@ def _samefiles_registered_agent(
     guides a destructive `mv` / `retire` of its settings tree. Mirror the
     #1759 self-ref guard idiom: realpath string-compare first, then
     `os.path.samefile` as the inode-aware fallback against each registered
-    home/workdir. Returns the matching agent id, or None when no registered
-    dir is provably the same file as `candidate`. A stat failure on one
-    registered dir (lazily-scaffolded / absent) is skipped — the exact
-    realpath compare already ruled out a plain string match, so an unstatable
-    registered dir is a genuinely different path, not the case-variant
-    collision being guarded against.
+    home/workdir.
+
+    Three-state return (codex r3 — fail SAFE on indeterminate):
+      * the matching agent id  — `candidate` IS a registered agent's dir;
+      * `_SAMEFILE_INDETERMINATE` — a `samefile()` raised (stat failure on the
+        candidate or a registered dir) and NO confirmed match was found, so we
+        could not PROVE the candidate is unregistered. The caller must NOT
+        report an orphan / must NOT proceed with retire in this state;
+      * `None` — PROVEN no-match: every registered dir resolved cleanly and
+        none is the same file as `candidate`.
+
+    Fail-safe rule (codex r3, the #1774/#1771 fail-closed pattern): a
+    `samefile()` that RAISES must not silently become "no-match". But a
+    registered `home`/`workdir` legitimately may NOT EXIST (a v2 agent's `home`
+    resolves to data/agents/<a>/home, often not on disk; a registry-only agent
+    has no scaffolded tree) — and samefile against a NON-EXISTENT registered
+    dir is a CLEAN no-match for that pair (the existing candidate cannot be a
+    path that does not exist). So `_SAMEFILE_INDETERMINATE` fires only when the
+    probe could be MASKING a real match: (a) the CANDIDATE itself is
+    unstatable, or (b) a registered dir EXISTS yet samefile still raised.
+    Forcing `os.path.samefile` to raise must never yield an orphan report for a
+    LIVE agent's dir. A proven match always wins over indeterminate.
     """
+    indeterminate = False
+    cand_exists = _path_lexists(candidate)
+    if not cand_exists:
+        indeterminate = True
     try:
         cand_real = os.path.realpath(candidate)
     except OSError:
-        cand_real = str(candidate)
+        cand_real = None
     for agent_id, base in registered_dirs:
         reg_path = Path(base).expanduser()
-        try:
-            reg_real = os.path.realpath(reg_path)
-        except OSError:
-            reg_real = str(reg_path)
-        if cand_real == reg_real:
-            return agent_id
+        if cand_real is not None:
+            try:
+                reg_real = os.path.realpath(reg_path)
+            except OSError:
+                reg_real = None
+            if reg_real is not None and cand_real == reg_real:
+                return agent_id
         try:
             if os.path.samefile(candidate, reg_path):
                 return agent_id
         except OSError:
-            # samefile raises when EITHER side cannot be statted. A missing
-            # registered dir (agent scaffolded lazily) is benign — the
-            # string compare above already ruled out an exact match, so a
-            # stat failure here means the two are genuinely different paths
-            # OR one is absent; neither is the case-variant collision we
-            # guard against, so do NOT fail-safe to "match" on a plain
-            # absence. Only an EXISTING-but-unstatable candidate that we
-            # cannot prove distinct should be conservative — but the
-            # detector's own OSError handling already skips an unreadable
-            # candidate, so falling through to the next registered dir is
-            # correct here.
+            # samefile raised. Clean no-match for this pair ONLY when the
+            # registered dir provably does not exist; otherwise the raised
+            # probe could be masking the case-variant collision where samefile
+            # WOULD have matched → fail safe to indeterminate (gated on the
+            # candidate being statable; an unstatable candidate is already
+            # indeterminate above). A later PROVEN match still wins.
+            if cand_exists and _path_lexists(reg_path):
+                indeterminate = True
             continue
+    if indeterminate:
+        return _SAMEFILE_INDETERMINATE
     return None
 
 
@@ -929,7 +975,40 @@ def detect_orphan_agent_dir(
         # still fire. samefile proves same-vs-different correctly on both
         # filesystem classes, so the detector keeps its teeth on Linux while
         # not quarantining a live agent's tree on macOS.
-        if _samefiles_registered_agent(entry, registered_dirs) is not None:
+        identity = _samefiles_registered_agent(entry, registered_dirs)
+        if identity is not None:
+            # Proven match → skip (registered agent's tree, not an orphan).
+            # codex r3: INDETERMINATE (a samefile stat failure left identity
+            # unproven) must ALSO skip the destructive orphan recipe — we
+            # cannot prove this dir is unregistered, so failing safe means
+            # NOT reporting it. Surface a separate info-level note so the
+            # operator can hand-verify rather than silently dropping it.
+            if identity == _SAMEFILE_INDETERMINATE:
+                findings.append(
+                    {
+                        "ts": ts,
+                        "kind": "orphan-agent-dir-unverifiable",
+                        "agent": name,
+                        "evidence": {
+                            "dir": str(entry),
+                            "reason": (
+                                "could not verify against the registry "
+                                "(os.path.samefile stat failure); not reported "
+                                "as an orphan to avoid quarantining a possibly "
+                                "live agent's tree"
+                            ),
+                            "registry_checked": "agent registry --json",
+                        },
+                        "suggested_action": (
+                            f"Could not prove whether {entry} is a registered "
+                            "agent's directory (a stat/samefile probe failed). "
+                            "It is NOT being reported as an orphan (fail-safe). "
+                            "Manually confirm with `agent-bridge agent registry "
+                            "--json` and check whether any registered home/"
+                            f"workdir resolves to {entry} before any cleanup."
+                        ),
+                    }
+                )
             continue
         # Skip symlinks that don't point at an actual agent home (live
         # `shared/` link, stale convenience symlinks). A dir-shaped symlink
@@ -1056,7 +1135,7 @@ def _iter_registry_agents(
 
 
 def _settings_effective_content(real_path: Path) -> str | None:
-    """Return the text content of a resolved settings.effective.json, or None.
+    """Return the text content of a resolved effective settings file, or None.
 
     Issue #1788: the two-tree-drift detector compares the CONTENT of the two
     rendered effective files, not just their inode identity. On a shared-mode
@@ -1094,9 +1173,9 @@ def detect_settings_two_tree_drift(
     Issue #1788 — aligned to the renderer's intended layout. The renderer
     (`bridge_ensure_claude_shared_settings_for_managed_workdir`,
     lib/bridge-hooks.sh) DELIBERATELY maintains two effective files for a
-    shared-mode v2 non-isolated agent: the workdir-side
-    `agents/<a>/.claude/settings.effective.json` AND the launched-config-dir
-    `data/agents/<a>/home/.claude/settings.effective.json` (registry `home`).
+    shared-mode v2 non-isolated agent: the workdir-side effective file under
+    `agents/<a>/.claude/` AND the launched-config-dir effective file under
+    `data/agents/<a>/home/.claude/` (registry `home`).
     Both are rendered from the same base+overlay (same channels/class), so on
     a healthy host they are TWO DISTINCT INODES WITH IDENTICAL CONTENT. The
     pre-#1788 inode-only compare flagged that intended end state for every
@@ -1214,8 +1293,8 @@ def detect_settings_multi_tree(
     healthy.
 
     Distinct from settings-two-tree-drift: that one compares the
-    `settings.json` link resolution; this one counts physical
-    `settings.effective.json` files. The two together cover the
+    `settings.json` link resolution; this one counts physical effective
+    settings files. The two together cover the
     promotion-time hazard described in the issue.
 
     Read-only.
@@ -1271,7 +1350,7 @@ def detect_settings_multi_tree(
         }
         suggested = (
             f"Multi-tree settings CONTENT drift for {agent_id}: real "
-            f"settings.effective.json files in {len(real_locations)} trees "
+            f"effective settings files in {len(real_locations)} trees "
             f"({', '.join(sorted(real_locations))}) have DIVERGED in content. "
             "Re-render and re-link both trees from the single source with "
             f"`agent-bridge agent rerender-settings {agent_id} --apply` "
@@ -1593,6 +1672,16 @@ def main() -> int:
                 evidence = finding.get("evidence") or {}
                 if isinstance(evidence, dict) and evidence.get("detector") in enabled_set:
                     kept.append(finding)
+                continue
+            # Issue #1787: the info-level "orphan-agent-dir-unverifiable" row is
+            # emitted BY the orphan-agent-dir detector (a fail-safe note when
+            # samefile could not prove registration), so it rides the same
+            # allow-list as its parent detector.
+            if (
+                kind == "orphan-agent-dir-unverifiable"
+                and "orphan-agent-dir" in enabled_set
+            ):
+                kept.append(finding)
         findings = kept
 
     if args.json:

--- a/lib/agent-cli-helpers/retire-samefile-guard.py
+++ b/lib/agent-cli-helpers/retire-samefile-guard.py
@@ -9,48 +9,89 @@ classified as "unregistered" and retire would quarantine the live agent's
 settings tree (dangling its workdir `settings.json` symlink — the #1766
 "Settings Error" picker class). This guard runs BEFORE the mv: it checks the
 candidate dir against every registered agent's home + workdir with
-`os.path.samefile` (inode-aware, not a case-sensitive string compare) and, on
-a match, prints the registered agent id so the caller can refuse with a
-pointer to the real name.
+`os.path.samefile` (inode-aware, not a case-sensitive string compare).
 
 Invocation contract:
     sys.argv[1] = candidate directory (the path retire would mv)
     sys.argv[2] = path to a TSV file: one `id<TAB>home<TAB>workdir` row per
                   registered agent (home/workdir may be empty)
 
-Output: the matching registered agent id on stdout (one line) when the
-candidate IS a registered agent's dir; nothing (empty stdout) when it is not.
-Always exits 0 — an indeterminate or unreadable comparison prints nothing
-(the caller's default-allow path keeps retire working for genuine orphans);
-the SAFE direction is enforced positively (only a proven samefile match
-refuses), mirroring the doctor's orphan detector which conversely fails safe
-toward "registered". Here a false "registered" would block a legitimate
-orphan retire, so retire only refuses on a PROVEN match.
+Output — a THREE-STATE verdict on stdout, first line, so an UNPROVABLE
+comparison is never confused with a clean "not a registered agent" (codex r3,
+the #1774/#1771 fail-closed pattern):
+    `match\t<agent_id>` — the candidate IS that registered agent's dir;
+                          retire MUST refuse.
+    `indeterminate`     — a `samefile()`/realpath probe raised (stat failure
+                          on the candidate or a registered dir) and no match
+                          was proven; identity could NOT be established, so
+                          retire MUST refuse and tell the operator to verify.
+    `no-match`          — every registered dir resolved cleanly and none is
+                          the same file; retire may proceed.
+Always exits 0 (the verdict is on stdout). An unreadable rows file or missing
+args yields `indeterminate` — we cannot prove the candidate is unregistered,
+so the safe default is "refuse + ask the operator", never "allow".
 """
 
 import os
 import sys
 
 
-def _realpath(path: str) -> str:
+def _emit(verdict: str) -> int:
+    print(verdict)
+    return 0
+
+
+def _lexists(path: str) -> bool:
+    """Return True if `path` exists (incl. a broken symlink), False ONLY when
+    it is provably absent. A permission/other OSError errs toward True
+    (present/unknown) so the caller fails SAFE (indeterminate) rather than
+    treating an unreadable path as a clean no-match.
+    """
     try:
-        return os.path.realpath(path)
+        os.lstat(path)
+        return True
+    except FileNotFoundError:
+        return False
+    except NotADirectoryError:
+        # A path component is a file — the leaf provably cannot exist.
+        return False
     except OSError:
-        return path
+        # Permission or other error: cannot prove absence → treat as present.
+        return True
 
 
 def main() -> int:
     if len(sys.argv) < 3 or not sys.argv[1]:
-        return 0
+        return _emit("indeterminate")
     candidate = sys.argv[1]
     rows_file = sys.argv[2]
     try:
         with open(rows_file, encoding="utf-8") as fh:
             raw = fh.read()
     except OSError:
-        return 0
+        return _emit("indeterminate")
 
-    cand_real = _realpath(candidate)
+    # Fail-safe rule (codex r3): a `samefile()` that RAISES must not silently
+    # become "no-match". But registered `home`/`workdir` paths legitimately may
+    # NOT EXIST yet (a v2 agent's `home` resolves to data/agents/<a>/home,
+    # which is often not on disk; a registry-only agent has no scaffolded tree)
+    # — and a samefile against a NON-EXISTENT registered dir is a CLEAN
+    # no-match for that pair (an existing candidate cannot be a path that does
+    # not exist). So `indeterminate` fires only when the probe could be MASKING
+    # a real match: (a) the CANDIDATE itself is unstatable, or (b) a registered
+    # dir EXISTS yet samefile still raised. A proven match always wins.
+    indeterminate = False
+    cand_exists = _lexists(candidate)
+    if not cand_exists:
+        # Cannot prove the candidate is NOT a live agent's dir if we cannot
+        # even stat it. (run_retire only calls this for an existing home_dir,
+        # but guard against a race/unreadable candidate anyway.)
+        indeterminate = True
+    try:
+        cand_real = os.path.realpath(candidate)
+    except OSError:
+        cand_real = None
+
     for line in raw.splitlines():
         if not line.strip():
             continue
@@ -63,21 +104,28 @@ def main() -> int:
             if not base:
                 continue
             base = os.path.expanduser(base)
-            if cand_real == _realpath(base):
-                print(agent_id)
-                return 0
+            if cand_real is not None:
+                try:
+                    base_real = os.path.realpath(base)
+                except OSError:
+                    base_real = None
+                if base_real is not None and cand_real == base_real:
+                    return _emit(f"match\t{agent_id}")
             try:
                 if os.path.samefile(candidate, base):
-                    print(agent_id)
-                    return 0
+                    return _emit(f"match\t{agent_id}")
             except OSError:
-                # Either side unstatable (a registered dir scaffolded lazily,
-                # or the candidate is absent). The exact-realpath compare
-                # above already ruled out a string match, so a stat failure
-                # here is a genuine "different or missing path", not the
-                # case-variant collision we guard against. Try the next dir.
+                # samefile raised. Clean no-match for this pair ONLY when the
+                # registered dir provably does not exist; otherwise the raised
+                # probe could be masking the case-variant collision → fail safe
+                # to indeterminate (but only if the candidate is statable —
+                # an unstatable candidate is already indeterminate above).
+                if cand_exists and _lexists(base):
+                    indeterminate = True
                 continue
-    return 0
+    if indeterminate:
+        return _emit("indeterminate")
+    return _emit("no-match")
 
 
 if __name__ == "__main__":

--- a/lib/agent-cli-helpers/retire-samefile-guard.py
+++ b/lib/agent-cli-helpers/retire-samefile-guard.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""retire-samefile-guard.py — Issue #1787 filesystem-aware retire preflight.
+
+`agent retire <name>` resolves an unregistered name to a directory under the
+agent home root and plans an `mv` of it. On a case-insensitive volume (macOS
+APFS default) `agents/CRM-TEST-BSH` and the registry's `agents/crm-test-bsh`
+are the SAME directory, so a case-variant spelling of a LIVE agent's name is
+classified as "unregistered" and retire would quarantine the live agent's
+settings tree (dangling its workdir `settings.json` symlink — the #1766
+"Settings Error" picker class). This guard runs BEFORE the mv: it checks the
+candidate dir against every registered agent's home + workdir with
+`os.path.samefile` (inode-aware, not a case-sensitive string compare) and, on
+a match, prints the registered agent id so the caller can refuse with a
+pointer to the real name.
+
+Invocation contract:
+    sys.argv[1] = candidate directory (the path retire would mv)
+    sys.argv[2] = path to a TSV file: one `id<TAB>home<TAB>workdir` row per
+                  registered agent (home/workdir may be empty)
+
+Output: the matching registered agent id on stdout (one line) when the
+candidate IS a registered agent's dir; nothing (empty stdout) when it is not.
+Always exits 0 — an indeterminate or unreadable comparison prints nothing
+(the caller's default-allow path keeps retire working for genuine orphans);
+the SAFE direction is enforced positively (only a proven samefile match
+refuses), mirroring the doctor's orphan detector which conversely fails safe
+toward "registered". Here a false "registered" would block a legitimate
+orphan retire, so retire only refuses on a PROVEN match.
+"""
+
+import os
+import sys
+
+
+def _realpath(path: str) -> str:
+    try:
+        return os.path.realpath(path)
+    except OSError:
+        return path
+
+
+def main() -> int:
+    if len(sys.argv) < 3 or not sys.argv[1]:
+        return 0
+    candidate = sys.argv[1]
+    rows_file = sys.argv[2]
+    try:
+        with open(rows_file, encoding="utf-8") as fh:
+            raw = fh.read()
+    except OSError:
+        return 0
+
+    cand_real = _realpath(candidate)
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        agent_id = parts[0].strip() if parts else ""
+        if not agent_id:
+            continue
+        for base in parts[1:3]:
+            base = base.strip()
+            if not base:
+                continue
+            base = os.path.expanduser(base)
+            if cand_real == _realpath(base):
+                print(agent_id)
+                return 0
+            try:
+                if os.path.samefile(candidate, base):
+                    print(agent_id)
+                    return 0
+            except OSError:
+                # Either side unstatable (a registered dir scaffolded lazily,
+                # or the candidate is absent). The exact-realpath compare
+                # above already ruled out a string match, so a stat failure
+                # here is a genuine "different or missing path", not the
+                # case-variant collision we guard against. Try the next dir.
+                continue
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/1455-settings-two-tree-doctor.sh
+++ b/scripts/smoke/1455-settings-two-tree-doctor.sh
@@ -162,20 +162,21 @@ make_same_tree() {
 
 # make_dual_render_identical <agent> — Issue #1788: the renderer's INTENDED
 # shape on a shared-mode v2 non-isolated host. home + workdir each have their
-# OWN real settings.effective.json (distinct inodes), each rendered from the
+# OWN real effective file (distinct inodes), each rendered from the
 # same base+overlay so their CONTENT is byte-identical, and each tree's
 # settings.json symlinks to its OWN effective file. This is healthy — the
-# content-aware detectors must NOT flag it.
+# content-aware detectors must NOT flag it. The writes below are LOCAL mktemp
+# test fixtures, not controller->isolated boundary writes (iso-helper-ratchet).
 make_dual_render_identical() {
   local agent="$1"
   local home="$AGENTS_ROOT/$agent/home"
   local workdir="$AGENTS_ROOT/$agent/workdir"
   mkdir -p "$home/.claude" "$workdir/.claude"
   local payload='{"enabledPlugins":{"teams":true}}'
-  printf '%s\n' "$payload" >"$home/.claude/settings.effective.json"
-  printf '%s\n' "$payload" >"$workdir/.claude/settings.effective.json"
-  ln -s "settings.effective.json" "$home/.claude/settings.json"
-  ln -s "settings.effective.json" "$workdir/.claude/settings.json"
+  printf '%s\n' "$payload" >"$home/.claude/settings.effective.json"  # noqa: iso-helper-boundary — local mktemp fixture, no controller->iso boundary
+  printf '%s\n' "$payload" >"$workdir/.claude/settings.effective.json"  # noqa: iso-helper-boundary — local mktemp fixture, no controller->iso boundary
+  ln -s "settings.effective.json" "$home/.claude/settings.json"  # noqa: iso-helper-boundary — local mktemp fixture symlink
+  ln -s "settings.effective.json" "$workdir/.claude/settings.json"  # noqa: iso-helper-boundary — local mktemp fixture symlink
 }
 
 # write_registry <agent...> — emit `agent registry --json`-shaped rows with

--- a/scripts/smoke/1455-settings-two-tree-doctor.sh
+++ b/scripts/smoke/1455-settings-two-tree-doctor.sh
@@ -160,6 +160,24 @@ make_same_tree() {
   ln -s "../home/.claude" "$workdir/.claude"
 }
 
+# make_dual_render_identical <agent> — Issue #1788: the renderer's INTENDED
+# shape on a shared-mode v2 non-isolated host. home + workdir each have their
+# OWN real settings.effective.json (distinct inodes), each rendered from the
+# same base+overlay so their CONTENT is byte-identical, and each tree's
+# settings.json symlinks to its OWN effective file. This is healthy — the
+# content-aware detectors must NOT flag it.
+make_dual_render_identical() {
+  local agent="$1"
+  local home="$AGENTS_ROOT/$agent/home"
+  local workdir="$AGENTS_ROOT/$agent/workdir"
+  mkdir -p "$home/.claude" "$workdir/.claude"
+  local payload='{"enabledPlugins":{"teams":true}}'
+  printf '%s\n' "$payload" >"$home/.claude/settings.effective.json"
+  printf '%s\n' "$payload" >"$workdir/.claude/settings.effective.json"
+  ln -s "settings.effective.json" "$home/.claude/settings.json"
+  ln -s "settings.effective.json" "$workdir/.claude/settings.json"
+}
+
 # write_registry <agent...> — emit `agent registry --json`-shaped rows with
 # the home + workdir columns the settings detectors consume.
 write_registry() {
@@ -170,6 +188,23 @@ write_registry() {
       if (( first )); then first=0; else printf ','; fi
       printf '{"id":"%s","class":"dynamic","home":"%s/%s/home","workdir":"%s/%s/workdir","engine":"claude"}' \
         "$agent" "$AGENTS_ROOT" "$agent" "$AGENTS_ROOT" "$agent"
+    done
+    printf ']\n'
+  } >"$REGISTRY"
+}
+
+# write_registry_engine <engine> <agent...> — same as write_registry but with
+# a caller-chosen engine column (Issue #1788: the settings detectors skip
+# non-claude engines).
+write_registry_engine() {
+  local engine="$1"; shift
+  local first=1 agent
+  {
+    printf '['
+    for agent in "$@"; do
+      if (( first )); then first=0; else printf ','; fi
+      printf '{"id":"%s","class":"dynamic","home":"%s/%s/home","workdir":"%s/%s/workdir","engine":"%s"}' \
+        "$agent" "$AGENTS_ROOT" "$agent" "$AGENTS_ROOT" "$agent" "$engine"
     done
     printf ']\n'
   } >"$REGISTRY"
@@ -332,6 +367,76 @@ test_same_tree_no_false_positive() {
 }
 
 # ---------------------------------------------------------------------------
+# T8 — Issue #1788: the renderer's intended dual-render (two distinct real
+# effective files with IDENTICAL content) is HEALTHY — NEITHER detector flags
+# it. This is the all-fleet false-positive #1788 reports on v0.16.8.
+# ---------------------------------------------------------------------------
+test_dual_render_identical_clean() {
+  reset_agents_root
+  make_dual_render_identical "dualok"
+  write_registry "dualok"
+  run_doctor "settings-two-tree-drift,settings-multi-tree"
+
+  smoke_assert_eq "0" "$(h_count settings-two-tree-drift)" \
+    "T8 dual-render identical content: zero two-tree-drift findings (#1788)"
+  smoke_assert_eq "0" "$(h_count settings-multi-tree)" \
+    "T8 dual-render identical content: zero multi-tree findings (#1788)"
+  smoke_assert_eq "no" "$(h_traceback)" "T8 no traceback"
+}
+
+# ---------------------------------------------------------------------------
+# T9 — Issue #1788: the corrected suggested_action names a REAL verb
+# (`agent rerender-settings`), never the non-existent `bash bridge-hooks.sh`.
+# Genuine content drift still fires (teeth intact).
+# ---------------------------------------------------------------------------
+test_corrected_recipe_text() {
+  reset_agents_root
+  make_drift "draftee"   # divergent content → genuine drift
+  make_multi "twins"     # two physical files, divergent content
+  write_registry "draftee" "twins"
+  run_doctor "settings-two-tree-drift,settings-multi-tree"
+
+  # Detector teeth: genuine divergent content still fires. Both fixtures have
+  # divergent content across their two trees, so both are legitimate
+  # two-tree-drift cases (h_agents returns a comma-sorted id list).
+  smoke_assert_eq "draftee,twins" "$(h_agents settings-two-tree-drift)" \
+    "T9 genuine content drift still fires two-tree-drift for both"
+
+  local recipe_a recipe_b
+  recipe_a="$(h_field settings-two-tree-drift draftee suggested_action)"
+  smoke_assert_contains "$recipe_a" "agent rerender-settings draftee --apply" \
+    "T9 (a) two-tree-drift recipe names the real rerender verb (#1788)"
+  if printf '%s' "$recipe_a" | grep -q "bash bridge-hooks.sh"; then
+    smoke_fail "T9 (a) recipe must NOT reference the non-existent bridge-hooks.sh"
+  fi
+
+  recipe_b="$(h_field settings-multi-tree twins suggested_action)"
+  smoke_assert_contains "$recipe_b" "agent rerender-settings twins --apply" \
+    "T9 (b) multi-tree recipe names the real rerender verb (#1788)"
+  if printf '%s' "$recipe_b" | grep -q "bash bridge-hooks.sh"; then
+    smoke_fail "T9 (b) recipe must NOT reference the non-existent bridge-hooks.sh"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# T10 — Issue #1788 Note: non-claude engines are SKIPPED. A codex agent's
+# vestigial Claude tree (even with divergent content) must not produce a
+# finding (`agent rerender-settings` refuses codex agents anyway).
+# ---------------------------------------------------------------------------
+test_non_claude_engine_skipped() {
+  reset_agents_root
+  make_drift "codexpair"   # divergent content — WOULD fire if it were claude
+  make_multi "codexmulti"
+  write_registry_engine "codex" "codexpair" "codexmulti"
+  run_doctor "settings-two-tree-drift,settings-multi-tree"
+
+  smoke_assert_eq "0" "$(h_count settings-two-tree-drift)" \
+    "T10 codex engine: two-tree-drift skipped (#1788 Note)"
+  smoke_assert_eq "0" "$(h_count settings-multi-tree)" \
+    "T10 codex engine: multi-tree skipped (#1788 Note)"
+}
+
+# ---------------------------------------------------------------------------
 # Drive cases.
 # ---------------------------------------------------------------------------
 smoke_run "T1 invariant assertion (correct layout)" test_invariant_assertion
@@ -341,5 +446,8 @@ smoke_run "T4 multi-tree fires (b)" test_multi_fires_multi_tree
 smoke_run "T5 no false positives" test_no_false_positives
 smoke_run "T6 evidence shape + no traceback" test_evidence_shape
 smoke_run "T7 same-tree no false positive" test_same_tree_no_false_positive
+smoke_run "T8 dual-render identical content clean (#1788)" test_dual_render_identical_clean
+smoke_run "T9 corrected recipe text (#1788)" test_corrected_recipe_text
+smoke_run "T10 non-claude engine skipped (#1788)" test_non_claude_engine_skipped
 
 smoke_log "all 1455 settings single-tree detector cases passed"

--- a/scripts/smoke/agent-retire.sh
+++ b/scripts/smoke/agent-retire.sh
@@ -31,9 +31,14 @@ SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$SCRIPT_DIR/lib.sh"
 
 cleanup() {
+  # Restore any chmod 000 we set (T10 locks a parent dir) so rm -rf can clear.
+  if [[ -n "${RETIRE_LOCKED_DIR:-}" && -e "$RETIRE_LOCKED_DIR" ]]; then
+    chmod -R u+rwX "$RETIRE_LOCKED_DIR" 2>/dev/null || true
+  fi
   smoke_cleanup_temp_root
 }
 trap cleanup EXIT
+RETIRE_LOCKED_DIR=""
 
 smoke_setup_bridge_home "agent-retire"
 
@@ -405,16 +410,81 @@ test_refuse_case_variant_of_registered() {
     smoke_fail "T9 no quarantine dir should have been created for the case-variant"
   fi
 
-  # (c) A genuinely unrelated orphan in the SAME run still retires (teeth intact).
+  # (c) A genuinely unrelated orphan in the SAME run still retires (teeth
+  # intact). Assert via a substring check on the JSON (no python here-string —
+  # lint-heredoc-ban H3) so this new test adds no heredoc/here-string site.
   local orphan_home
   orphan_home="$(make_home_dir "genuine-orphan-xyz")"
   local rc2=0 out2
   out2="$(agent_retire genuine-orphan-xyz --json 2>&1)" || rc2=$?
   (( rc2 == 0 )) || smoke_fail "T9 genuine orphan retire should still succeed (rc=$rc2, out=$out2)"
-  local status2
-  status2="$("$PY_BIN" -c 'import json,sys; print(json.loads(sys.stdin.read())["status"])' <<<"$out2")"
-  smoke_assert_eq "retired" "$status2" "T9 genuine orphan still retired (detector teeth intact)"
+  smoke_assert_contains "$out2" '"status": "retired"' \
+    "T9 genuine orphan still retired (detector teeth intact)"
   [[ ! -d "$orphan_home" ]] || smoke_fail "T9 genuine orphan home should be moved away"
+}
+
+# ---------------------------------------------------------------------------
+# T10 — Issue #1787 (codex r3, SAFETY): when the samefile preflight CANNOT be
+#       resolved (a registered agent's home is unstatable), retire must REFUSE
+#       (fail-safe), never proceed — identity is unproven, so an mv could
+#       quarantine a live agent's tree. We make a registered home unstatable by
+#       chmod-000'ing its parent (samefile raises EACCES, lexists reports it
+#       present) and assert `agent retire <orphan>` is refused with the
+#       "could not verify" message and touches nothing.
+# ---------------------------------------------------------------------------
+test_refuse_indeterminate_identity() {
+  reset_state
+  # Registered agent `locked` whose home lives under a soon-unreadable parent.
+  local locked_parent="$SMOKE_TMP_ROOT/retire-locked-parent"
+  local reg_home="$locked_parent/locked-home"
+  mkdir -p "$reg_home"
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "locked"
+BRIDGE_AGENT_ENGINE["locked"]="claude"
+BRIDGE_AGENT_SESSION["locked"]="locked"
+BRIDGE_AGENT_WORKDIR["locked"]="$reg_home"
+# Resolve locked's home to the unreadable tree so the samefile preflight
+# against it raises EACCES (the indeterminate trigger).
+bridge_agent_default_home() {
+  if [[ "\$1" == "locked" ]]; then
+    printf '%s' "$reg_home"
+    return 0
+  fi
+  printf '%s/%s' "\$BRIDGE_AGENT_HOME_ROOT" "\$1"
+}
+EOF
+
+  # A genuine orphan dir on disk we ask to retire.
+  local orphan_home
+  orphan_home="$(make_home_dir "indeterminate-orphan")"
+
+  # Lock the registered home's parent so samefile() against reg_home raises.
+  chmod 000 "$locked_parent"
+  RETIRE_LOCKED_DIR="$locked_parent"
+
+  local rc=0 out
+  out="$(agent_retire indeterminate-orphan --dry-run 2>&1)" || rc=$?
+
+  # Restore perms before assertions / further tests.
+  chmod 755 "$locked_parent"
+  RETIRE_LOCKED_DIR=""
+
+  # If the probe stayed statable (e.g. running as root), the indeterminate
+  # path is not exercised — skip rather than false-fail.
+  if (( rc == 0 )); then
+    smoke_log "T10 skip: samefile preflight stayed resolvable (likely root) — indeterminate not reproducible"
+    return 0
+  fi
+
+  smoke_assert_contains "$out" "could not verify" \
+    "T10 indeterminate identity is refused with a verify-first message"
+  # Nothing was moved/quarantined.
+  smoke_assert_file_exists "$orphan_home/marker.txt" \
+    "T10 orphan home untouched under indeterminate refusal"
+  if [[ -d "$BRIDGE_HOME/archive/retired-agents" ]] \
+      && find "$BRIDGE_HOME/archive/retired-agents" -maxdepth 1 -name '*indeterminate-orphan*' 2>/dev/null | grep -q .; then
+    smoke_fail "T10 no quarantine dir should have been created under indeterminate refusal"
+  fi
 }
 
 smoke_run "T1 quarantine dynamic"             test_quarantine_dynamic
@@ -426,5 +496,6 @@ smoke_run "T6 orphan quarantine"              test_orphan_quarantine
 smoke_run "T7 dry-run is no-op"               test_dry_run
 smoke_run "T8 refuse out-of-root home"        test_refuse_out_of_root
 smoke_run "T9 refuse case-variant of registered" test_refuse_case_variant_of_registered
+smoke_run "T10 refuse indeterminate identity" test_refuse_indeterminate_identity
 
 smoke_log "all checks passed"

--- a/scripts/smoke/agent-retire.sh
+++ b/scripts/smoke/agent-retire.sh
@@ -365,6 +365,58 @@ EOF
     "T8 out-of-root refusal must not touch the path"
 }
 
+# ---------------------------------------------------------------------------
+# T9 — Issue #1787: case-variant of a REGISTERED agent name must NOT be
+#      retireable on a case-insensitive filesystem. `agent retire CRM-TEST-BSH`
+#      where the registry holds `crm-test-bsh` (same dir on APFS) must REFUSE
+#      with a pointer to the real name and plan NOTHING destructive — even
+#      under --dry-run.
+# ---------------------------------------------------------------------------
+test_refuse_case_variant_of_registered() {
+  reset_state
+  # Register the agent at its canonical lowercase spelling.
+  write_dynamic_active_env "crm-test-bsh"
+  local home
+  home="$(make_home_dir "crm-test-bsh")"
+
+  # Gate on case-insensitivity: only when the uppercase spelling reaches the
+  # SAME directory is the #1787 collision reproducible (a Linux case-sensitive
+  # fs makes them distinct dirs — nothing to guard there). Mirrors the
+  # #1759 smoke's `case_variant.exists()` APFS gate.
+  local variant_dir="$BRIDGE_AGENT_HOME_ROOT/CRM-TEST-BSH"
+  if [[ ! -d "$variant_dir" ]] || ! [[ "$variant_dir" -ef "$home" ]]; then
+    smoke_log "T9 skip: case-sensitive filesystem — case-variant collision not reproducible here"
+    return 0
+  fi
+
+  # (a) --dry-run must REFUSE (non-zero) and name the real registered agent.
+  local rc=0 out
+  out="$(agent_retire CRM-TEST-BSH --dry-run 2>&1)" || rc=$?
+  (( rc != 0 )) || smoke_fail "T9 case-variant retire --dry-run should have been refused (rc=$rc, out=$out)"
+  smoke_assert_contains "$out" "crm-test-bsh" "T9 refusal points at the registered name"
+  smoke_assert_contains "$out" "same directory" "T9 refusal explains the samefile collision"
+
+  # (b) The live agent's home + its marker are untouched (no mv/quarantine planned).
+  smoke_assert_file_exists "$home/marker.txt" "T9 live agent home must be untouched"
+  [[ -d "$home" ]] || smoke_fail "T9 live agent home should still exist: $home"
+  # No quarantine dir was created.
+  if [[ -d "$BRIDGE_HOME/archive/retired-agents" ]] \
+      && find "$BRIDGE_HOME/archive/retired-agents" -maxdepth 1 -name '*CRM-TEST-BSH*' 2>/dev/null | grep -q .; then
+    smoke_fail "T9 no quarantine dir should have been created for the case-variant"
+  fi
+
+  # (c) A genuinely unrelated orphan in the SAME run still retires (teeth intact).
+  local orphan_home
+  orphan_home="$(make_home_dir "genuine-orphan-xyz")"
+  local rc2=0 out2
+  out2="$(agent_retire genuine-orphan-xyz --json 2>&1)" || rc2=$?
+  (( rc2 == 0 )) || smoke_fail "T9 genuine orphan retire should still succeed (rc=$rc2, out=$out2)"
+  local status2
+  status2="$("$PY_BIN" -c 'import json,sys; print(json.loads(sys.stdin.read())["status"])' <<<"$out2")"
+  smoke_assert_eq "retired" "$status2" "T9 genuine orphan still retired (detector teeth intact)"
+  [[ ! -d "$orphan_home" ]] || smoke_fail "T9 genuine orphan home should be moved away"
+}
+
 smoke_run "T1 quarantine dynamic"             test_quarantine_dynamic
 smoke_run "T2 purge dynamic"                  test_purge_dynamic
 smoke_run "T3 refuse static-class"            test_refuse_static
@@ -373,5 +425,6 @@ smoke_run "T5 refuse unknown agent"           test_refuse_unknown
 smoke_run "T6 orphan quarantine"              test_orphan_quarantine
 smoke_run "T7 dry-run is no-op"               test_dry_run
 smoke_run "T8 refuse out-of-root home"        test_refuse_out_of_root
+smoke_run "T9 refuse case-variant of registered" test_refuse_case_variant_of_registered
 
 smoke_log "all checks passed"

--- a/scripts/smoke/orphan-agent-dir.sh
+++ b/scripts/smoke/orphan-agent-dir.sh
@@ -121,6 +121,20 @@ print(sum(1 for r in data if r.get("kind") == "orphan-agent-dir"))
 ' <<<"$payload"
 }
 
+# Return the count of findings of an arbitrary kind (e.g. the #1787 fail-safe
+# `orphan-agent-dir-unverifiable` info note). Uses a pipe (not a here-string)
+# so this new helper adds no lint-heredoc-ban H3 site.
+kind_count() {
+  local payload="$1"
+  local kind="$2"
+  printf '%s' "$payload" | "$PY_BIN" -c '
+import json, sys
+kind = sys.argv[1]
+data = json.loads(sys.stdin.read() or "[]")
+print(sum(1 for r in data if r.get("kind") == kind))
+' "$kind"
+}
+
 # Return JSON list of orphan-agent-dir findings only (drops detector-error
 # noise so per-test JSON inspection stays simple).
 findings_only() {
@@ -421,6 +435,71 @@ test_case_folding_but_distinct_inode_still_flagged() {
 }
 
 # ---------------------------------------------------------------------------
+# T10 — Issue #1787 (codex r3, SAFETY): a samefile probe that CANNOT be
+#       resolved (the registered dir exists but is unreadable) must NOT report
+#       the candidate as an orphan — identity is UNPROVEN, so failing safe
+#       means holding it back. We make the registered home unstatable by
+#       chmod-000'ing its PARENT (samefile raises EACCES, lexists still
+#       reports the path as present), so the detector cannot prove the
+#       candidate is unregistered and must surface the fail-safe
+#       `orphan-agent-dir-unverifiable` info note INSTEAD of an orphan finding.
+# ---------------------------------------------------------------------------
+test_indeterminate_failsafe_no_orphan() {
+  reset_home_root
+  # Registered agent `locked` whose home is under a soon-to-be-unreadable dir.
+  local locked_parent="$SMOKE_TMP_ROOT/locked-parent"
+  local reg_home="$locked_parent/locked-home"
+  mkdir -p "$reg_home"
+  # Candidate under the home root whose basename is NOT the registered id (so
+  # it falls through to the samefile probe) — the probe will raise EACCES.
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/LOCKED-CANDIDATE"
+
+  local registry="$SMOKE_TMP_ROOT/registry.t10.json"
+  printf '[{"id":"locked","class":"dynamic","agent_source":"dynamic","privilege_class":"user","home":"%s","workdir":"%s","engine":"claude","is_alive":true,"source":"dynamic-active-env"}]\n' \
+    "$reg_home" "$reg_home" >"$registry"
+
+  # Make the registered home unstatable: chmod 000 the parent so a samefile()
+  # against reg_home raises EACCES (but lexists reports it present).
+  chmod 000 "$locked_parent"
+  ORPHAN_LOCKED_DIR="$locked_parent"
+
+  local out
+  out="$(run_doctor_orphan "$registry")"
+
+  # Restore perms immediately so later tests / cleanup are unaffected.
+  chmod 755 "$locked_parent"
+  ORPHAN_LOCKED_DIR=""
+
+  # If this fs/uid did not actually make samefile raise (e.g. running as root),
+  # the indeterminate path is not exercised — skip rather than false-fail.
+  local unverifiable
+  unverifiable="$(kind_count "$out" "orphan-agent-dir-unverifiable")"
+  if [[ "$unverifiable" == "0" ]]; then
+    smoke_log "T10 skip: registered home stayed statable (likely root/uid) — indeterminate not reproducible"
+    return 0
+  fi
+
+  # The candidate is NOT reported as a destructive orphan (fail-safe).
+  local cand_orphan
+  cand_orphan="$(finding_field "$out" "LOCKED-CANDIDATE" "dir")"
+  smoke_assert_eq "__MISSING__" "$cand_orphan" \
+    "T10 indeterminate candidate is NOT reported as an orphan (fail-safe)"
+
+  # Zero orphan-agent-dir findings; the only signal is the info-level note.
+  local orphan_count
+  orphan_count="$(findings_count "$out")"
+  smoke_assert_eq "0" "$orphan_count" \
+    "T10 no orphan-agent-dir finding when identity is unprovable"
+  smoke_assert_eq "1" "$unverifiable" \
+    "T10 a single orphan-agent-dir-unverifiable info note is surfaced"
+
+  # Pipe (not a here-string) so this check adds no lint-heredoc-ban H3 site.
+  if printf '%s' "$out" | grep -q 'Traceback'; then
+    smoke_fail "T10 doctor output contains a Python traceback: $out"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Drive cases.
 # ---------------------------------------------------------------------------
 ORPHAN_LOCKED_DIR=""
@@ -433,5 +512,6 @@ smoke_run "T6 unreadable subdir partial finding" test_unreadable_subdir_partial_
 smoke_run "T7 *-repro-<digits> suffix" test_repro_suffix_artifact
 smoke_run "T8 case-variant registered not flagged" test_case_variant_registered_not_flagged
 smoke_run "T9 distinct-inode case-fold still flagged" test_case_folding_but_distinct_inode_still_flagged
+smoke_run "T10 indeterminate fail-safe (no orphan)" test_indeterminate_failsafe_no_orphan
 
 smoke_log "all orphan-agent-dir cases passed"

--- a/scripts/smoke/orphan-agent-dir.sh
+++ b/scripts/smoke/orphan-agent-dir.sh
@@ -324,6 +324,103 @@ test_repro_suffix_artifact() {
 }
 
 # ---------------------------------------------------------------------------
+# T8 — Issue #1787: a case-variant spelling of a REGISTERED agent's dir is NOT
+#      flagged as an orphan on a case-insensitive filesystem. The registry
+#      holds `crm-test-bsh`; the on-disk dir was created `CRM-TEST-BSH` (same
+#      dir on APFS). The detector must samefile-match it to the registered
+#      agent and skip — never recommend a destructive quarantine of a live
+#      agent's settings tree. A genuinely unregistered dir in the same run
+#      still fires (detector teeth intact).
+# ---------------------------------------------------------------------------
+test_case_variant_registered_not_flagged() {
+  reset_home_root
+  # Create the dir with the UPPERCASE spelling; register the LOWERCASE name.
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/CRM-TEST-BSH"
+  printf 'live\n' >"$BRIDGE_AGENT_HOME_ROOT/CRM-TEST-BSH/marker.txt"
+
+  # Gate on case-insensitivity: only reproducible when the lowercase spelling
+  # reaches the SAME dir (mirrors the #1759 smoke's APFS gate). On a
+  # case-sensitive fs the two are distinct dirs and the collision can't occur.
+  local lower_dir="$BRIDGE_AGENT_HOME_ROOT/crm-test-bsh"
+  if ! [[ -d "$lower_dir" ]] || ! [[ "$lower_dir" -ef "$BRIDGE_AGENT_HOME_ROOT/CRM-TEST-BSH" ]]; then
+    smoke_log "T8 skip: case-sensitive filesystem — case-variant collision not reproducible here"
+    return 0
+  fi
+
+  # Also drop a genuinely unregistered dir so the teeth-intact control runs.
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/genuine-orphan-zzz"
+
+  local registry="$SMOKE_TMP_ROOT/registry.t8.json"
+  # write_registry stores home as $BRIDGE_AGENT_HOME_ROOT/<id> — i.e.
+  # $BRIDGE_AGENT_HOME_ROOT/crm-test-bsh, the lowercase (registered) spelling.
+  write_registry "$registry" "crm-test-bsh"
+
+  local out
+  out="$(run_doctor_orphan "$registry")"
+
+  # The case-variant dir is NOT flagged (samefile match to the registered home).
+  local cv_dir
+  cv_dir="$(finding_field "$out" "CRM-TEST-BSH" "dir")"
+  smoke_assert_eq "__MISSING__" "$cv_dir" \
+    "T8 case-variant of a registered agent is NOT flagged as orphan"
+
+  # The genuine orphan IS still flagged.
+  local orphan_dir
+  orphan_dir="$(finding_field "$out" "genuine-orphan-zzz" "dir")"
+  smoke_assert_contains "$orphan_dir" "genuine-orphan-zzz" \
+    "T8 genuinely unregistered dir still fires (detector teeth intact)"
+
+  local count
+  count="$(findings_count "$out")"
+  smoke_assert_eq "1" "$count" \
+    "T8 exactly one finding (genuine orphan only; case-variant skipped)"
+}
+
+# ---------------------------------------------------------------------------
+# T9 — Issue #1787 (codex r1): the skip is INODE identity, NOT an unconditional
+#      case-fold. A dir whose basename only case-DIFFERS from a registered id
+#      but is a PHYSICALLY DISTINCT directory (different inode) MUST still be
+#      flagged — otherwise the detector loses its teeth on a case-sensitive fs
+#      (Linux), where `CRM-TEST-BSH` and `crm-test-bsh` are separate dirs and
+#      the uppercase one is a genuine orphan. We reproduce the distinct-inode
+#      case on ANY fs (incl. case-insensitive APFS) by registering the agent's
+#      home at a SEPARATE physical location, so the case-folding on-disk dir is
+#      provably NOT the same file as the registered home.
+# ---------------------------------------------------------------------------
+test_case_folding_but_distinct_inode_still_flagged() {
+  reset_home_root
+  # Registered agent `widget` whose home lives OUTSIDE the home root, in a
+  # dedicated physical dir — so the same-named on-disk dir below is a
+  # genuinely different inode even on a case-insensitive volume.
+  local real_home="$SMOKE_TMP_ROOT/widget-real-home"
+  mkdir -p "$real_home"
+  # On-disk dir under the home root whose basename case-folds to `widget` but
+  # is NOT the registered home (different inode). On a case-sensitive fs this
+  # is the canonical "uppercase variant is a separate orphan" shape.
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/WIDGET"
+
+  # Custom registry: home points at the dedicated dir, not $HOME_ROOT/widget.
+  local registry="$SMOKE_TMP_ROOT/registry.t9.json"
+  printf '[{"id":"widget","class":"dynamic","agent_source":"dynamic","privilege_class":"user","home":"%s","workdir":"%s","engine":"claude","is_alive":true,"source":"dynamic-active-env"}]\n' \
+    "$real_home" "$real_home" >"$registry"
+
+  local out
+  out="$(run_doctor_orphan "$registry")"
+
+  # `WIDGET` is a distinct inode from the registered home → still flagged
+  # (the case-fold collision must NOT suppress a genuine orphan).
+  local orphan_dir
+  orphan_dir="$(finding_field "$out" "WIDGET" "dir")"
+  smoke_assert_contains "$orphan_dir" "WIDGET" \
+    "T9 a distinct-inode case-folding dir is STILL flagged (no false negative)"
+
+  local count
+  count="$(findings_count "$out")"
+  smoke_assert_eq "1" "$count" \
+    "T9 exactly one finding (the distinct-inode orphan)"
+}
+
+# ---------------------------------------------------------------------------
 # Drive cases.
 # ---------------------------------------------------------------------------
 ORPHAN_LOCKED_DIR=""
@@ -334,5 +431,7 @@ smoke_run "T4 registered agent not flagged" test_registered_agent_not_flagged
 smoke_run "T5 _template/shared skipped" test_template_and_shared_skipped
 smoke_run "T6 unreadable subdir partial finding" test_unreadable_subdir_partial_finding
 smoke_run "T7 *-repro-<digits> suffix" test_repro_suffix_artifact
+smoke_run "T8 case-variant registered not flagged" test_case_variant_registered_not_flagged
+smoke_run "T9 distinct-inode case-fold still flagged" test_case_folding_but_distinct_inode_still_flagged
 
 smoke_log "all orphan-agent-dir cases passed"


### PR DESCRIPTION
Fixes two doctor false-positives reported on **v0.16.8** (macOS APFS, shared-mode non-iso host) by the same reporter. Same surface, overlapping files — bundled into one PR to avoid same-file conflicts.

## #1787 — orphan-agent-dir + `agent retire`: case-insensitive identity (macOS APFS)

On a case-insensitive volume `agents/CRM-TEST-BSH` and the registry's `agents/crm-test-bsh` are the **same directory**. The orphan detector compared basenames case-**sensitively**, so it reported a **live** agent's dir as an unregistered orphan with a destructive `mv` quarantine recipe; `agent retire CRM-TEST-BSH` resolved the unregistered name to the live home and planned an mv of the live agent's settings tree — dangling its workdir `settings.json` symlink (the #1766 "Settings Error" picker class).

**Fix** — identity is now filesystem-aware via **inode identity** (`os.path.realpath` + `os.path.samefile`, reusing the #1759 self-ref idiom), never an unconditional case-fold:

- `detect_orphan_agent_dir` skips a candidate dir that samefiles any registered agent's home/workdir.
- `agent retire`, when a name resolves to "unregistered", samefile-compares the candidate home dir against every registered agent's home+workdir (`lib/agent-cli-helpers/retire-samefile-guard.py`, file-as-argv — no heredoc-stdin, footgun #11 safe) and **refuses with a pointer to the real registered name** on a proven match.

Inode identity (not case-fold) is deliberate: on a **case-sensitive** fs (Linux) `crm-test-bsh` and `CRM-TEST-BSH` are distinct dirs and the uppercase one is a genuine orphan that must **still fire**. Retire refuses **only on a proven samefile match**, so a genuine orphan still retires.

## #1788 — settings-two-tree-drift / settings-multi-tree: aligned to renderer; recipe fixed

Two problems, both fixed:

1. **Recipe entry point did not exist.** `bash bridge-hooks.sh link-shared-settings --agent <a>` — there is no root `bridge-hooks.sh`. Corrected to the real verb `agent-bridge agent rerender-settings <a> --apply` (in both the two-tree-drift and multi-tree recipes).
2. **Detector disagreed with the renderer.** `bridge_ensure_claude_shared_settings_for_managed_workdir` (lib/bridge-hooks.sh) **deliberately** renders two effective files for a shared-mode v2 non-iso agent, both from the same base+overlay. Two distinct inodes with identical content is the intended healthy end state — but the inode/count-only detectors flagged it for **every Claude agent** on v0.16.8 (always-on false finding, no convergent verb). The renderer just shipped through the #1455/#1495/#1689 review chains, so it is canonical; the detectors are aligned to it.

**Fix** — both detectors now flag only when the two effective files' **CONTENT diverges** (the real #1453 hazard); an identical-content dual-render is healthy. **Non-claude engines are skipped** (codex's vestigial Claude tree — `rerender-settings` refuses codex agents anyway, per the issue Note).

### Per-layout expected shape (what the detectors treat as healthy)

| Layout class | `home` (registry) → effective | `workdir` (registry) → effective | Healthy invariant | Flagged when |
|---|---|---|---|---|
| **shared-v2 single-tree** (workdir `.claude` symlinks into home) | `<home>/.claude/settings.effective.json` (real) | resolves to the **same inode** as home | `realpath(workdir)==realpath(home)` | n/a (same inode) |
| **shared-v2 non-iso dual-render** (this issue) | `data/agents/<a>/home/.claude/settings.effective.json` (real) | `agents/<a>/.claude/settings.effective.json` (real, distinct inode) | two distinct inodes, **identical content** (both rendered from base+overlay) | the two real files' **content diverges** |
| **iso v2** | iso UID home effective (rendered by `cmd_render_isolated_home_settings`) | — | single canonical iso tree | content diverges (when both sides resolvable) |
| **legacy / promotion hazard** | one real effective under home | workdir is a **second real file** (#1453) | should be a relative symlink to home | content diverges between the two real files |
| **non-claude (codex)** | vestigial Claude tree | vestigial | n/a | never (engine-skipped, #1788 Note) |

## Reproduction (before)

```bash
# #1787 (macOS APFS, agent registered crm-test-bsh, dir stored CRM-TEST-BSH)
agent-bridge doctor --json            # → orphan-agent-dir for CRM-TEST-BSH (FALSE)
agent-bridge agent retire CRM-TEST-BSH --dry-run   # → would-retire, plans mv of the LIVE tree (DANGEROUS)
# #1788 (v0.16.8 shared-mode macOS host)
agent-bridge doctor --json            # → settings-two-tree-drift for every claude agent (FALSE)
# recipe: bash bridge-hooks.sh link-shared-settings --agent <a>  → No such file or directory
```

## Verification (after)

```bash
# Lints + compile
bash -n bridge-agent.sh scripts/smoke/*.sh
shellcheck bridge-agent.sh scripts/smoke/agent-retire.sh scripts/smoke/orphan-agent-dir.sh scripts/smoke/1455-settings-two-tree-doctor.sh
python3 -c "import py_compile; py_compile.compile('bridge-doctor.py', doraise=True)"
bash scripts/lint-raw-pathlib-on-isolated.sh   # bridge-doctor.py count==ceiling (no new flagged probe)

# Smokes (extended)
bash scripts/smoke/orphan-agent-dir.sh             # T8 case-variant skip + T9 distinct-inode teeth
bash scripts/smoke/1455-settings-two-tree-doctor.sh # T8 dual-render clean + T9 corrected recipe + T10 codex-skip
bash scripts/smoke/agent-retire.sh                  # T9 case-variant refused / live tree untouched / genuine orphan still retires
bash scripts/smoke/agent-doctor.sh                  # doctor framework regression
```

## Notes for the reviewer / orchestrator

- **Internal codex review**: 1 round caught a BLOCKING (an unconditional `casefold()` skip would have hidden a genuine distinct-inode orphan on a case-sensitive fs); fixed by relying solely on inode identity + added the T9 teeth control; re-review returned **implement-ok**.
- **`agent-retire.sh` T1 pre-existing failure (macOS)**: the existing `agent-retire` smoke is **not registered in ci-select / smoke-test.sh** and its T1 fails on **pristine main** (independent of this PR) due to a v2-layout fixture mismatch (the smoke writes the home under `$BRIDGE_AGENT_HOME_ROOT` but the v2 resolver reads `$BRIDGE_AGENT_ROOT_V2`). I did **not** register it into CI to avoid importing that pre-existing red; the new T9 was verified to pass via a standalone driver. If the orchestrator wants the retire coverage in CI, the T1 layout mismatch should be triaged separately first.
- No VERSION/CHANGELOG bump (per stabilization policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
