### PR TITLE
usage: classify CDN edge blocks, per-token probe backoff, alert isolation (Closes #1824)

### DIFF
--- a/bridge-daemon-helpers.py
+++ b/bridge-daemon-helpers.py
@@ -895,13 +895,23 @@ def cmd_usage_probe_result_parse(args: argparse.Namespace) -> int:
     probe --json`. Output: a SINGLE tab-separated row IFF the outcome is
     NOTEWORTHY (worth an audit row) — empty stdout otherwise (so the daemon /
     wrapper emits nothing on the common fresh/written/cooldown ticks):
-      status \\t reset_at \\t retry_after \\t http_status
+      status \\t reset_at \\t retry_after \\t http_status \\t detail
+
+    Empty columns are emitted as the `-` sentinel: the consuming bash
+    ``IFS=$'\\t' read`` treats tab as IFS whitespace and COLLAPSES adjacent
+    separators, so an empty middle field would shift every later field left
+    (http_status used to land in the reset_at slot). The consumer decodes
+    `-` back to empty — same producer/consumer contract as the rotation TSV
+    sentinel and the mcp-miss-queue drain rows.
 
     Noteworthy statuses:
       - rate-limited-signal     — a genuine 429 → proactive near-limit signal
                                   persisted (the #1468 catch-22 break).
       - rate-limited-suppressed — a genuine 429 already signalled this window
                                   (idempotent; no re-rotate).
+      - edge-blocked            — the CDN edge blocked the poll (Server:
+                                  cloudflare / no anthropic origin headers);
+                                  NOT an account signal, probe backing off.
       - degraded / scope-degraded / no-token — a probe FAILURE (was silent
                                   best-effort; now observable per #1468 §5).
 
@@ -918,19 +928,26 @@ def cmd_usage_probe_result_parse(args: argparse.Namespace) -> int:
     noteworthy = {
         "rate-limited-signal",
         "rate-limited-suppressed",
+        "edge-blocked",
         "degraded",
         "scope-degraded",
         "no-token",
     }
     if status not in noteworthy:
         return 0
+
+    def _col(value: object) -> str:
+        text = _tsv_clean(value)
+        return text if text else "-"
+
     print(
         "\t".join(
             [
                 status,
-                str(payload.get("reset_at") or ""),
-                str(payload.get("retry_after") if payload.get("retry_after") is not None else ""),
-                str(payload.get("http_status") if payload.get("http_status") is not None else ""),
+                _col(payload.get("reset_at")),
+                _col(payload.get("retry_after") if payload.get("retry_after") is not None else ""),
+                _col(payload.get("http_status") if payload.get("http_status") is not None else ""),
+                _col(payload.get("detail")),
             ]
         )
     )
@@ -1504,7 +1521,8 @@ SUBCOMMANDS = {
     "usage-probe-result-parse": (
         cmd_usage_probe_result_parse,
         [("probe_json", "JSON result from bridge-usage-probe.py probe --json")],
-        "Single noteworthy-outcome row (status/reset_at/retry_after/http_status) or empty.",
+        "Single noteworthy-outcome row (status/reset_at/retry_after/http_status/"
+        "detail, `-` for empty cols) or empty.",
     ),
     "recovery-status-parse": (
         cmd_recovery_status_parse,

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -2957,7 +2957,14 @@ def cmd_ensure_hud_usage_tap(args: argparse.Namespace) -> int:
     Reads the current statusLine.command from settings.json.  If it is a
     HUD command but does not yet include the tap, rewrites it in-place to
     prepend `python3 <bridge_home>/scripts/hud-usage-tap.py |` before the
-    bun/node exec call.  Idempotent: re-running after patching is a no-op.
+    bun/node exec call.  When NO statusLine is configured at all (absent key,
+    empty dict, or empty command) the tap is installed STANDALONE: its
+    passthrough output is discarded (`> /dev/null`) so the status line stays
+    visually blank exactly as before, while every live Claude Code session
+    still produces the real measured `.usage-cache.json` the rotation monitor
+    reads (real tap data beats probing a rate-limited/edge-blockable
+    endpoint).  A present-but-foreign (non-HUD, non-empty) statusLine is never
+    clobbered.  Idempotent: re-running after patching/installing is a no-op.
     """
     bridge_home = Path(args.bridge_home).expanduser()
     tap_path = str(bridge_home / "scripts" / "hud-usage-tap.py")
@@ -2965,33 +2972,13 @@ def cmd_ensure_hud_usage_tap(args: argparse.Namespace) -> int:
     settings = ensure_settings_root(settings_path)
 
     sl = settings.get("statusLine")
-    if not isinstance(sl, dict):
-        payload = {
-            "HOOK_SETTINGS_FILE": str(settings_path),
-            "HOOK_STATUS": "no-hud",
-            "HOOK_STOP_HOOK": "",
-            "HOOK_PROMPT_HOOK": "",
-            "HOOK_COMMAND": "",
-        }
-        print_payload(payload, args.format)
-        if args.format != "shell":
-            print("hud_usage_tap: no-hud (statusLine not present or not a dict)")
-        return 1
+    sl_is_dict = isinstance(sl, dict)
+    raw_cmd = sl.get("command", "") if sl_is_dict else ""
+    cmd = raw_cmd if isinstance(raw_cmd, str) else ""
 
-    cmd = sl.get("command", "")
-    if not isinstance(cmd, str) or not _is_hud_status_line(cmd):
-        payload = {
-            "HOOK_SETTINGS_FILE": str(settings_path),
-            "HOOK_STATUS": "no-hud",
-            "HOOK_STOP_HOOK": "",
-            "HOOK_PROMPT_HOOK": "",
-            "HOOK_COMMAND": cmd,
-        }
-        print_payload(payload, args.format)
-        if args.format != "shell":
-            print("hud_usage_tap: no-hud (statusLine.command is not a HUD command)")
-        return 1
-
+    # Tap already wired (either piped into a HUD command or installed
+    # standalone) → idempotent no-op. Checked FIRST so a standalone tap
+    # command (which is not HUD-shaped) does not fall into the no-hud branch.
     if _hud_tap_present(cmd):
         payload = {
             "HOOK_SETTINGS_FILE": str(settings_path),
@@ -3004,6 +2991,40 @@ def cmd_ensure_hud_usage_tap(args: argparse.Namespace) -> int:
         if args.format != "shell":
             print("hud_usage_tap: present")
         return 0
+
+    # Empty statusLine slot (absent / {} / empty command): install the tap
+    # standalone. Only a genuinely EMPTY slot qualifies — a non-dict
+    # statusLine or a non-string command is unknown config we must not
+    # clobber (handled by the no-hud branch below).
+    if sl is None or (sl_is_dict and isinstance(raw_cmd, str) and not cmd.strip()):
+        python_bin = getattr(args, "python_bin", None) or "python3"
+        installed = f"{python_bin} {shlex.quote(tap_path)} > /dev/null"
+        settings["statusLine"] = {"type": "command", "command": installed}
+        save_json(settings_path, settings)
+        payload = {
+            "HOOK_SETTINGS_FILE": str(settings_path),
+            "HOOK_STATUS": "installed",
+            "HOOK_STOP_HOOK": "",
+            "HOOK_PROMPT_HOOK": "",
+            "HOOK_COMMAND": installed,
+        }
+        print_payload(payload, args.format)
+        if args.format != "shell":
+            print("hud_usage_tap: installed (statusLine was empty; tap installed standalone)")
+        return 0
+
+    if not sl_is_dict or not isinstance(raw_cmd, str) or not _is_hud_status_line(cmd):
+        payload = {
+            "HOOK_SETTINGS_FILE": str(settings_path),
+            "HOOK_STATUS": "no-hud",
+            "HOOK_STOP_HOOK": "",
+            "HOOK_PROMPT_HOOK": "",
+            "HOOK_COMMAND": cmd,
+        }
+        print_payload(payload, args.format)
+        if args.format != "shell":
+            print("hud_usage_tap: no-hud (statusLine is not a HUD command; left untouched)")
+        return 1
 
     patched = _patch_hud_command(cmd, tap_path)
     settings["statusLine"]["command"] = patched
@@ -3028,12 +3049,16 @@ def cmd_status_hud_usage_tap(args: argparse.Namespace) -> int:
 
     sl = settings.get("statusLine")
     cmd = (sl or {}).get("command", "") if isinstance(sl, dict) else ""
-    if not cmd or not _is_hud_status_line(cmd):
-        status = "no-hud"
-        rc = 1
-    elif _hud_tap_present(cmd):
+    if not isinstance(cmd, str):
+        cmd = ""
+    # Tap-presence first: a STANDALONE tap install (empty-statusLine path in
+    # cmd_ensure_hud_usage_tap) is not HUD-shaped but is very much present.
+    if _hud_tap_present(cmd):
         status = "present"
         rc = 0
+    elif not cmd or not _is_hud_status_line(cmd):
+        status = "no-hud"
+        rc = 1
     else:
         status = "missing"
         rc = 1

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -642,8 +642,10 @@ if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
   fi
   # Ensure HUD stdin tap is in place before the sudo-wrap so that linux-user
   # isolated agents get their isolated-home settings rendered from controller
-  # context. bridge_ensure_hud_usage_tap is a no-op when no HUD statusLine is
-  # configured or when the tap is already present.
+  # context. bridge_ensure_hud_usage_tap installs the tap standalone when the
+  # statusLine slot is empty, patches a HUD statusLine to pipe through the
+  # tap, and is a no-op when the tap is already present (a foreign non-HUD
+  # statusLine is left untouched).
   bridge_ensure_hud_usage_tap "$WORK_DIR" "$AGENT_LAUNCH_CMD" "$AGENT" >/dev/null 2>&1 || true
   if ! bridge_disable_claude_webhook_channel "$AGENT" "$WORK_DIR" >/dev/null 2>&1; then
     bridge_warn "Claude backlog webhook channel cleanup skipped: $WORK_DIR"

--- a/bridge-usage-probe.py
+++ b/bridge-usage-probe.py
@@ -259,7 +259,13 @@ class ProbeHTTPError(Exception):
 
     ``status`` is the HTTP status code; ``retry_after`` is the parsed
     Retry-After header in seconds (or None); ``body`` is the response body
-    text (token-free — it is the server's error JSON).
+    text (token-free — it is the server's error JSON). ``headers`` carries the
+    RESPONSE headers (token-free; the request Authorization header is never
+    echoed back) so the caller can distinguish an anthropic-origin error
+    (``request-id`` / ``anthropic-*`` present) from a CDN edge block
+    (``Server: cloudflare``, no origin headers). ``None`` means the seam did
+    not supply headers (legacy/back-compat callers) — classification then
+    falls back to body-only semantics.
     """
 
     def __init__(
@@ -267,11 +273,13 @@ class ProbeHTTPError(Exception):
         status: int,
         body: str = "",
         retry_after: float | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         super().__init__(f"usage probe HTTP {status}")
         self.status = status
         self.body = body
         self.retry_after = retry_after
+        self.headers = headers
 
 
 def _parse_retry_after(value: str | None) -> float | None:
@@ -310,7 +318,18 @@ def _http_get_usage(
             body = exc.read().decode("utf-8", errors="replace")
         except Exception:
             body = ""
-        raise ProbeHTTPError(exc.code, body=body, retry_after=retry_after) from None
+        # Carry the RESPONSE headers (token-free) so the error classifier can
+        # tell an anthropic-origin error from a CDN edge block. Defensive: a
+        # header iteration failure must never mask the original HTTP error.
+        headers_map: dict[str, str] = {}
+        try:
+            if exc.headers is not None:
+                headers_map = {str(k): str(v) for k, v in exc.headers.items()}
+        except Exception:
+            headers_map = {}
+        raise ProbeHTTPError(
+            exc.code, body=body, retry_after=retry_after, headers=headers_map
+        ) from None
 
 
 def _user_agent(version: str | None) -> str:
@@ -355,7 +374,7 @@ def _window_reset(window: Any) -> str | None:
     return None
 
 
-def map_payload_to_cache(payload: Any) -> dict[str, Any] | None:
+def map_payload_to_cache(payload: Any, token_digest: str = "") -> dict[str, Any] | None:
     """Map a raw ``api/oauth/usage`` response to the `.usage-cache.json` shape.
 
     Returns None when neither the five_hour nor the seven_day window carries
@@ -364,6 +383,12 @@ def map_payload_to_cache(payload: Any) -> dict[str, Any] | None:
     genuine 0% usage. Returning None lets the caller degrade and log a scope
     hint rather than spuriously writing a 0% cache (which could mask a real
     rotation trigger).
+
+    ``token_digest`` (optional) is the one-way SHA-256 prefix of the OAT that
+    produced this reading (NO token bytes — same digest as
+    ``_token_signal_digest``). Persisted as ``_token_digest`` so the freshness
+    gate and the monitor can detect a cache attributed to a PREVIOUSLY-active
+    token after a rotation (stale-attribution guard).
     """
     if not isinstance(payload, dict):
         return None
@@ -379,7 +404,7 @@ def map_payload_to_cache(payload: Any) -> dict[str, Any] | None:
     if fh is None and sd is None:
         return None
 
-    return {
+    cache: dict[str, Any] = {
         "data": {
             "planName": "subscription",
             "fiveHour": fh,
@@ -390,27 +415,43 @@ def map_payload_to_cache(payload: Any) -> dict[str, Any] | None:
         "_source": CACHE_SOURCE,
         "_written_at": datetime.now(timezone.utc).isoformat(),
     }
+    if token_digest:
+        cache["_token_digest"] = token_digest
+    return cache
 
 
 # --------------------------------------------------------------------------- #
 # Issue #1468 — usage-endpoint 429 as a POSITIVE near-limit rotation signal
+# 429/403 3-way classification — account quota vs CDN edge block vs failure
 # --------------------------------------------------------------------------- #
-def is_rate_limit_429(exc: "ProbeHTTPError") -> bool:
-    """True only for a GENUINE rate-limit 429 we should act on as near-limit.
+# A 429/403 served by the CDN EDGE (observed: ``Server: cloudflare`` and NO
+# anthropic origin headers — no ``request-id``, no ``anthropic-*``; Retry-After
+# pinned at exactly 3600; the same token flapping 403<->429 minute to minute
+# while live sessions on the SAME account run fine) is an infrastructure block
+# of the POLL, not evidence about the account's quota. Treating it as an
+# account-quota signal fabricates a synthetic at-limit cache for an account
+# that is NOT limited → usage-alert storms + rotation ping-pong. Classify it
+# as ``edge-blocked`` instead: never write a synthetic cache, audit the
+# outcome, and back off per-token (see record_token_cooldown) so the probe
+# stops refreshing the edge ban window.
+CLASSIFICATION_ACCOUNT_RATE_LIMIT = "account-rate-limit"
+CLASSIFICATION_EDGE_BLOCKED = "edge-blocked"
+CLASSIFICATION_FAILURE = "failure"
+# Probe result status emitted for an edge-blocked response (also the audit
+# status string the wrapper records).
+EDGE_BLOCKED_STATUS = "edge-blocked"
+# Cap on the response body snippet carried into the result/audit detail.
+ERROR_DETAIL_MAX_CHARS = 200
 
-    We always send the mandatory User-Agent, so a 429 whose body is the
-    endpoint's ``error.type == rate_limit_error`` is a real rate-limit (the
-    account is near/at its limit) — NOT the missing-UA / malformed 429 the
-    helper docstring warns about. A 401, a 429 with a non-rate-limit body, or a
-    body we cannot parse is a probe FAILURE (audited but NOT a rotation signal),
-    so this returns False there and the caller degrades / serves stale.
+
+def _body_is_rate_limit_error(exc: "ProbeHTTPError") -> bool:
+    """True when the error body parses to ``error.type == rate_limit_error``.
+
+    An empty body is indistinguishable from a malformed / missing-UA reject —
+    do NOT treat it as a rate-limit body.
     """
-    if exc.status != 429:
-        return False
     body = exc.body or ""
     if not body.strip():
-        # A 429 with an empty body is indistinguishable from a malformed /
-        # missing-UA reject — do NOT treat it as a near-limit signal.
         return False
     try:
         payload = json.loads(body)
@@ -422,6 +463,84 @@ def is_rate_limit_429(exc: "ProbeHTTPError") -> bool:
     if not isinstance(error, dict):
         return False
     return str(error.get("type") or "") == RATE_LIMIT_ERROR_TYPE
+
+
+def _normalized_error_headers(exc: "ProbeHTTPError") -> dict[str, str] | None:
+    """Lower-cased response-header map from the exception, or None.
+
+    None means the seam did not supply headers at all (a legacy caller built
+    the exception without them) — the classifier then falls back to the
+    pre-headers body-only behavior instead of guessing.
+    """
+    headers = getattr(exc, "headers", None)
+    if headers is None:
+        return None
+    if not isinstance(headers, dict):
+        return None
+    return {str(k).lower(): str(v) for k, v in headers.items()}
+
+
+def _has_anthropic_origin_headers(headers: dict[str, str]) -> bool:
+    """True when the response demonstrably came from the anthropic origin.
+
+    Origin responses carry ``request-id`` and/or ``anthropic-*`` headers; an
+    edge block strips them (the edge answers before the request reaches the
+    origin).
+    """
+    for key in headers:
+        if key == "request-id" or key.startswith("anthropic-"):
+            return True
+    return False
+
+
+def classify_probe_http_error(exc: "ProbeHTTPError") -> str:
+    """3-way classify a probe HTTP error: account quota / edge block / failure.
+
+    - ``account-rate-limit``: a 429 whose body is the endpoint's
+      ``error.type == rate_limit_error`` AND whose response headers prove the
+      anthropic ORIGIN answered (``request-id`` / ``anthropic-*`` present).
+      This is the genuine #1468 near-limit signal (synthetic cache path).
+    - ``edge-blocked``: a 429/403 WITHOUT any anthropic origin header — the
+      CDN edge answered before the request reached the origin. NOT an account
+      signal; the caller must never fabricate a synthetic cache here.
+      Note: ``Server: cloudflare`` alone is deliberately NOT the
+      discriminator — GENUINE origin responses also transit Cloudflare and
+      carry that header; the decisive edge evidence is the ABSENCE of the
+      origin headers (field-observed: edge blocks carry ``Server:
+      cloudflare`` and nothing else).
+    - ``failure``: everything else (401, an origin-served 403, a 429 whose
+      body is not a rate-limit error, ...) — the existing degrade path.
+
+    Back-compat: when the exception carries NO header information at all
+    (``headers is None`` — a legacy seam), fall back to the pre-headers
+    body-only rule: a 429 ``rate_limit_error`` is an account signal.
+    """
+    if exc.status not in (429, 403):
+        return CLASSIFICATION_FAILURE
+    headers = _normalized_error_headers(exc)
+    if headers is None:
+        if exc.status == 429 and _body_is_rate_limit_error(exc):
+            return CLASSIFICATION_ACCOUNT_RATE_LIMIT
+        return CLASSIFICATION_FAILURE
+    anthropic_origin = _has_anthropic_origin_headers(headers)
+    if anthropic_origin and exc.status == 429 and _body_is_rate_limit_error(exc):
+        return CLASSIFICATION_ACCOUNT_RATE_LIMIT
+    if not anthropic_origin:
+        return CLASSIFICATION_EDGE_BLOCKED
+    return CLASSIFICATION_FAILURE
+
+
+def is_rate_limit_429(exc: "ProbeHTTPError") -> bool:
+    """True only for a GENUINE account rate-limit 429 we act on as near-limit.
+
+    We always send the mandatory User-Agent, so a 429 whose body is the
+    endpoint's ``error.type == rate_limit_error`` AND whose headers prove the
+    anthropic origin answered is a real rate-limit (the account is near/at its
+    limit). A 401, a 429 with a non-rate-limit body, a body we cannot parse,
+    or a CDN edge block (see classify_probe_http_error) is NOT a rotation
+    signal, so this returns False there and the caller degrades / serves stale.
+    """
+    return classify_probe_http_error(exc) == CLASSIFICATION_ACCOUNT_RATE_LIMIT
 
 
 def _token_signal_digest(token: str) -> str:
@@ -479,6 +598,10 @@ def build_rate_limit_signal_cache(reset_at: str, token_digest: str = "") -> dict
         "_source": CACHE_SOURCE,
         "_signal": SIGNAL_MARKER,
         "_signal_token": token_digest,
+        # Uniform attribution field (mirrors _signal_token): lets the
+        # freshness gate + monitor stale-check read ONE field for both real
+        # readings and 429-signal caches.
+        "_token_digest": token_digest,
         "_written_at": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -510,12 +633,38 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
 # --------------------------------------------------------------------------- #
 # Cache freshness + cooldown bookkeeping (no token ever written here)
 # --------------------------------------------------------------------------- #
-def cache_is_fresh(cache_path: Path, max_age_seconds: float, now: float) -> bool:
-    """True when a native-sourced cache exists and is younger than max_age.
+# The statusLine tap (scripts/hud-usage-tap.py) writes the SAME cache shape
+# with this source marker. A tap reading is a REAL measurement straight from
+# Claude Code's own rate_limits stdin — strictly better data than a probe of
+# the (rate-limited, edge-blockable) usage endpoint. A FRESH tap cache (age <
+# max_age, i.e. a statusLine is live RIGHT NOW) therefore satisfies the probe's
+# freshness gate so the probe never overwrites live tap data. The headless
+# concern the original guard targeted (a tap cache from a PREVIOUS statusLine
+# run suppressing the probe forever) is handled by the age gate: a leftover
+# tap cache goes stale within max_age and the probe takes over.
+TAP_CACHE_SOURCE = "stdin-tap"
+FRESH_CACHE_SOURCES = (CACHE_SOURCE, TAP_CACHE_SOURCE)
 
-    Only a cache WE wrote (``_source == native-oauth-probe``) counts toward
-    freshness — a stdin-tap cache from a previous statusLine run must not
-    suppress the native probe on a headless host.
+
+def cache_is_fresh(
+    cache_path: Path,
+    max_age_seconds: float,
+    now: float,
+    active_token_digest: str = "",
+) -> bool:
+    """True when a bridge-sourced cache exists and is younger than max_age.
+
+    Only a cache written by the native probe (``_source == native-oauth-probe``)
+    or by the live statusLine tap (``_source == stdin-tap``) counts toward
+    freshness — any other/foreign cache never suppresses the probe.
+
+    ``active_token_digest`` (optional): when the cache carries a token
+    attribution (``_token_digest`` / ``_signal_token``) that does NOT match the
+    currently-active token, the cache is STALE regardless of age — a token
+    rotated in moments ago must not inherit the previous token's reading
+    (especially a synthetic near-limit signal, which would instantly re-rotate
+    the fresh token: the rotation ping-pong bug). Tap caches carry no digest
+    and are unaffected.
     """
     try:
         st = cache_path.stat()
@@ -531,7 +680,19 @@ def cache_is_fresh(cache_path: Path, max_age_seconds: float, now: float) -> bool
         payload = json.loads(cache_path.read_text(encoding="utf-8"))
     except Exception:
         return False
-    return isinstance(payload, dict) and payload.get("_source") == CACHE_SOURCE
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("_source") not in FRESH_CACHE_SOURCES:
+        return False
+    if active_token_digest:
+        cache_digest = payload.get("_token_digest") or payload.get("_signal_token")
+        if (
+            isinstance(cache_digest, str)
+            and cache_digest
+            and cache_digest != active_token_digest
+        ):
+            return False
+    return True
 
 
 def _probe_state_path(cache_path: Path) -> Path:
@@ -547,22 +708,16 @@ def _read_probe_state(cache_path: Path) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _read_last_attempt(cache_path: Path) -> float | None:
-    ts = _read_probe_state(cache_path).get("last_attempt_epoch")
-    try:
-        return float(ts)
-    except (TypeError, ValueError):
-        return None
-
-
 def _record_attempt(cache_path: Path, now: float, outcome: str) -> None:
-    """Persist the last-attempt epoch (success or failure) for cooldown.
+    """Persist the last-attempt epoch (success or failure) for observability.
 
     Token-free: stores only an epoch + a coarse outcome string. The 429-signal
-    idempotence block (``signal_429``, see _read_signal_state) is PRESERVED
-    across attempts so a success/failure does not erase the per-window dedupe —
-    a successful probe on the NEW token after rotation clears it explicitly via
-    _clear_signal_state, not as a side effect of recording the attempt.
+    idempotence block (``signal_429``, see _read_signal_state) and the
+    per-token cooldown map (``token_cooldowns``) are PRESERVED across attempts
+    so a success/failure does not erase the per-window dedupe or another
+    token's backoff — a successful probe on the NEW token after rotation
+    clears its own entries explicitly, not as a side effect of recording the
+    attempt.
     """
     state = _read_probe_state(cache_path)
     state["last_attempt_epoch"] = now
@@ -571,6 +726,131 @@ def _record_attempt(cache_path: Path, now: float, outcome: str) -> None:
         _atomic_write_json(_probe_state_path(cache_path), state)
     except Exception:
         pass
+
+
+# --------------------------------------------------------------------------- #
+# Per-token cooldown / exponential backoff (token-free, on the sidecar)
+# --------------------------------------------------------------------------- #
+# State shape: ``token_cooldowns: {<token_digest>: {until, streak, outcome}}``.
+# The old FIXED last-attempt cooldown re-probed every (cooldown + max_age)
+# ≈ 6 minutes regardless of what the server said — inside a CDN edge ban
+# window that cadence permanently RENEWS the ban (every strike restarts the
+# Retry-After=3600 clock). The replacement is per-token:
+#   - edge-blocked / rate-limited responses honor min(Retry-After, cap) AND an
+#     exponential consecutive-failure backoff (5min → 15min → 60min cap),
+#     whichever is LONGER, so the probe goes quiet for the whole ban window;
+#   - generic failures keep the operator's fixed cooldown knob
+#     (BRIDGE_USAGE_PROBE_COOLDOWN, default 60s) as before;
+#   - the map is keyed by the one-way token digest, so a freshly rotated-in
+#     token has NO entry and probes immediately (rotation stays responsive).
+TOKEN_COOLDOWN_STATE_KEY = "token_cooldowns"
+EDGE_BACKOFF_SCHEDULE_SECONDS = (300.0, 900.0, 3600.0)  # 5min → 15min → 60min cap
+EDGE_RETRY_AFTER_CAP_SECONDS = 3600.0
+# Entries whose cooldown elapsed more than this long ago are pruned on write
+# (bounds the map to the recent pool; an entry inside the grace keeps its
+# streak so consecutive edge failures escalate across elapsed cooldowns).
+COOLDOWN_PRUNE_GRACE_SECONDS = 7200.0
+
+
+def _token_cooldowns(cache_path: Path) -> dict[str, Any]:
+    block = _read_probe_state(cache_path).get(TOKEN_COOLDOWN_STATE_KEY)
+    return block if isinstance(block, dict) else {}
+
+
+def token_cooldown_until(cache_path: Path, token_digest: str) -> float:
+    """Epoch until which THIS token's probing is paused; 0.0 when none."""
+    entry = _token_cooldowns(cache_path).get(token_digest)
+    if not isinstance(entry, dict):
+        return 0.0
+    try:
+        return float(entry.get("until"))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def token_in_cooldown(cache_path: Path, token_digest: str, now: float) -> bool:
+    if not token_digest:
+        return False
+    return now < token_cooldown_until(cache_path, token_digest)
+
+
+def record_token_cooldown(
+    cache_path: Path,
+    token_digest: str,
+    now: float,
+    *,
+    outcome: str,
+    retry_after: float | None = None,
+    base_seconds: float = 0.0,
+    escalate: bool = False,
+) -> float:
+    """Record a cooldown window for THIS token; returns the applied span.
+
+    ``escalate=True`` (edge-blocked / limited responses) bumps the token's
+    consecutive-failure streak and applies
+    ``max(backoff_schedule[streak], min(Retry-After, cap))`` so a server-stated
+    ban window is honored in full and repeat offenders back off exponentially.
+    ``escalate=False`` (generic failures) applies the fixed ``base_seconds``
+    without touching the streak. Token-free: only the one-way digest is keyed.
+    """
+    if not token_digest:
+        return 0.0
+    state = _read_probe_state(cache_path)
+    raw = state.get(TOKEN_COOLDOWN_STATE_KEY)
+    cooldowns: dict[str, Any] = dict(raw) if isinstance(raw, dict) else {}
+    # Prune entries long past their window (keeps the map ≤ recent pool size).
+    pruned: dict[str, Any] = {}
+    for digest, entry in cooldowns.items():
+        if not isinstance(entry, dict):
+            continue
+        try:
+            until = float(entry.get("until"))
+        except (TypeError, ValueError):
+            continue
+        if (now - until) > COOLDOWN_PRUNE_GRACE_SECONDS:
+            continue
+        pruned[digest] = entry
+    cooldowns = pruned
+    prev = cooldowns.get(token_digest)
+    streak = 0
+    if isinstance(prev, dict):
+        try:
+            streak = max(int(prev.get("streak") or 0), 0)
+        except (TypeError, ValueError):
+            streak = 0
+    if escalate:
+        streak += 1
+        backoff = EDGE_BACKOFF_SCHEDULE_SECONDS[
+            min(streak, len(EDGE_BACKOFF_SCHEDULE_SECONDS)) - 1
+        ]
+        capped_retry = 0.0
+        if retry_after is not None and retry_after > 0:
+            capped_retry = min(float(retry_after), EDGE_RETRY_AFTER_CAP_SECONDS)
+        span = max(backoff, capped_retry)
+    else:
+        span = max(float(base_seconds or 0.0), 0.0)
+    cooldowns[token_digest] = {"until": now + span, "streak": streak, "outcome": outcome}
+    state[TOKEN_COOLDOWN_STATE_KEY] = cooldowns
+    try:
+        _atomic_write_json(_probe_state_path(cache_path), state)
+    except Exception:
+        pass
+    return span
+
+
+def clear_token_cooldown(cache_path: Path, token_digest: str) -> None:
+    """Drop THIS token's cooldown entry (called after a clean reading)."""
+    if not token_digest:
+        return
+    state = _read_probe_state(cache_path)
+    cooldowns = state.get(TOKEN_COOLDOWN_STATE_KEY)
+    if isinstance(cooldowns, dict) and token_digest in cooldowns:
+        cooldowns.pop(token_digest, None)
+        state[TOKEN_COOLDOWN_STATE_KEY] = cooldowns
+        try:
+            _atomic_write_json(_probe_state_path(cache_path), state)
+        except Exception:
+            pass
 
 
 # --------------------------------------------------------------------------- #
@@ -685,13 +965,6 @@ def _clear_signal_state(cache_path: Path) -> None:
             pass
 
 
-def in_cooldown(cache_path: Path, cooldown_seconds: float, now: float) -> bool:
-    last = _read_last_attempt(cache_path)
-    if last is None:
-        return False
-    return (now - last) < cooldown_seconds
-
-
 # --------------------------------------------------------------------------- #
 # Orchestration
 # --------------------------------------------------------------------------- #
@@ -716,10 +989,11 @@ def run_probe(
 
     Returns a token-free result dict describing what happened (``status`` ∈
     fresh/written/cooldown/degraded/no-token/scope-degraded/rate-limited-signal/
-    rate-limited-suppressed). NEVER raises into the caller — every failure path
-    degrades and returns. The existing cache is only ever REPLACED on a
-    successful, parseable probe OR a genuine 429 near-limit signal (#1468); any
-    other failure leaves whatever cache is on disk untouched (serve stale).
+    rate-limited-suppressed/edge-blocked). NEVER raises into the caller — every
+    failure path degrades and returns. The existing cache is only ever REPLACED
+    on a successful, parseable probe OR a genuine 429 near-limit signal (#1468);
+    any other failure — including a CDN edge block — leaves whatever cache is
+    on disk untouched (serve stale).
     """
     now = time.time() if now is None else now
 
@@ -727,20 +1001,35 @@ def run_probe(
         if log is not None:
             log(msg)
 
-    # 1. Freshness gate — within CACHE_MAX_AGE, do NOT re-probe.
-    if cache_is_fresh(cache_path, max_age_seconds, now):
-        return {"status": "fresh", "cache_path": str(cache_path)}
-
-    # 2. Cooldown gate — a recent failure means serve stale, don't hammer.
-    if in_cooldown(cache_path, cooldown_seconds, now):
-        _log("[usage-probe] in cooldown after recent failure; serving stale cache")
-        return {"status": "cooldown", "cache_path": str(cache_path)}
-
-    # 3. Token (read-only; never logged).
+    # 0. Token (read-only; never logged). Resolved BEFORE the freshness gate so
+    #    the gate can compare the cache's token attribution against the
+    #    CURRENTLY-active token — a cache written for a previously-active token
+    #    is stale regardless of age (rotation ping-pong guard).
     token = resolve_active_token(
         registry_path, credentials_path, token_file,
         token_fd=token_fd, allow_env=allow_env,
     )
+    active_digest = _token_signal_digest(token) if token else ""
+
+    # 1. Freshness gate — within CACHE_MAX_AGE (and attributed to the active
+    #    token, when attributable), do NOT re-probe. A fresh statusLine-tap
+    #    cache also satisfies this gate: live tap data is a real measurement
+    #    and the probe must not overwrite it.
+    if cache_is_fresh(cache_path, max_age_seconds, now, active_token_digest=active_digest):
+        return {"status": "fresh", "cache_path": str(cache_path)}
+
+    # 2. Per-token cooldown gate — a recent failure for THIS token means serve
+    #    stale, don't hammer (and never keep refreshing a CDN edge ban window).
+    #    A freshly rotated-in token has no entry and probes immediately.
+    if token and token_in_cooldown(cache_path, active_digest, now):
+        _log("[usage-probe] active token in cooldown after recent failure; serving stale cache")
+        return {
+            "status": "cooldown",
+            "cache_path": str(cache_path),
+            "cooldown_until": token_cooldown_until(cache_path, active_digest),
+        }
+
+    # 3. No token → degrade.
     if not token:
         _log("[usage-probe] no active OAT available; native probe degraded")
         return {"status": "no-token", "cache_path": str(cache_path)}
@@ -780,15 +1069,27 @@ def run_probe(
         body = None
 
     if body is None:
-        # #1468: a GENUINE rate_limit 429 (valid request, UA present) is a
-        # POSITIVE near-limit signal — the catch-22 break. Persist a synthetic
-        # near-limit cache so proactive rotation fires, instead of going blind.
-        # Idempotent per (active-token, window): rotate AT MOST once per token
-        # per limit window (no pool-loop). A non-rate-limit 429, a 401, or a
-        # transport error is a probe FAILURE — audited, but NOT a rotation
-        # signal — so we fall through to the degrade path below.
-        if last_http_error is not None and is_rate_limit_429(last_http_error):
-            token_digest = _token_signal_digest(token)
+        classification = (
+            classify_probe_http_error(last_http_error)
+            if last_http_error is not None
+            else CLASSIFICATION_FAILURE
+        )
+        # #1468: a GENUINE rate_limit 429 (valid request, UA present, anthropic
+        # origin headers) is a POSITIVE near-limit signal — the catch-22 break.
+        # Persist a synthetic near-limit cache so proactive rotation fires,
+        # instead of going blind. Idempotent per (active-token, window): rotate
+        # AT MOST once per token per limit window (no pool-loop). A CDN edge
+        # block, a non-rate-limit 429, a 401, or a transport error is NOT a
+        # rotation signal — handled below.
+        if classification == CLASSIFICATION_ACCOUNT_RATE_LIMIT:
+            token_digest = active_digest
+            # The account told us it is limited — pause THIS token's probing for
+            # the operator cooldown (the synthetic cache also stays fresh for
+            # max_age, so this is belt-and-suspenders pacing, not new policy).
+            record_token_cooldown(
+                cache_path, token_digest, now,
+                outcome="rate-limited", base_seconds=cooldown_seconds,
+            )
             # Suppress if THIS token already has a still-future signal window:
             # rotate this token at most once per incident, and stop on a pool
             # loop-back (codex r1+r2). A DISTINCT (rotated-to) token has no
@@ -833,12 +1134,45 @@ def run_probe(
                 "retry_after": last_http_error.retry_after,
                 "reset_at": reset_at,
             }
+        if classification == CLASSIFICATION_EDGE_BLOCKED:
+            # The CDN edge blocked the POLL itself (Server: cloudflare / no
+            # anthropic origin headers). This says NOTHING about the account's
+            # quota: never fabricate a synthetic near-limit cache (that caused
+            # usage-alert storms + rotation ping-pong while live sessions on
+            # the same account ran fine). Back off per-token — honoring the
+            # edge's Retry-After up to the cap, escalating on consecutive
+            # blocks — so the probe stops refreshing the edge ban window.
+            span = record_token_cooldown(
+                cache_path, active_digest, now,
+                outcome=EDGE_BLOCKED_STATUS,
+                retry_after=last_http_error.retry_after,
+                escalate=True,
+            )
+            _record_attempt(cache_path, now, "edge_blocked")
+            _log(
+                f"[usage-probe] HTTP {last_http_error.status} blocked at the CDN "
+                "edge (no anthropic origin headers) — NOT an account-quota "
+                f"signal; backing off {span:g}s for this token and serving stale"
+            )
+            return {
+                "status": EDGE_BLOCKED_STATUS,
+                "cache_path": str(cache_path),
+                "http_status": last_http_error.status,
+                "retry_after": last_http_error.retry_after,
+                "cooldown_seconds": span,
+                "detail": (last_http_error.body or "")[:ERROR_DETAIL_MAX_CHARS],
+            }
         # Not a near-limit signal: a malformed/missing-UA 429, a 401, or a
         # transport error → probe FAILURE. Audited by the wrapper; serve stale.
         _record_attempt(cache_path, now, "failure")
+        record_token_cooldown(
+            cache_path, active_digest, now,
+            outcome="failure", base_seconds=cooldown_seconds,
+        )
         result: dict[str, Any] = {"status": "degraded", "cache_path": str(cache_path)}
         if last_http_error is not None:
             result["http_status"] = last_http_error.status
+            result["detail"] = (last_http_error.body or "")[:ERROR_DETAIL_MAX_CHARS]
         return result
 
     # 5. Parse + map defensively.
@@ -846,14 +1180,22 @@ def run_probe(
         payload = json.loads(body)
     except Exception:
         _record_attempt(cache_path, now, "failure")
+        record_token_cooldown(
+            cache_path, active_digest, now,
+            outcome="failure", base_seconds=cooldown_seconds,
+        )
         _log("[usage-probe] response was not JSON; serving stale cache")
         return {"status": "degraded", "cache_path": str(cache_path)}
 
-    cache = map_payload_to_cache(payload)
+    cache = map_payload_to_cache(payload, token_digest=active_digest)
     if cache is None:
         # Likely a token without the user:profile scope (empty/null windows),
         # NOT a real outage. Degrade with a clear hint; do not write a 0% cache.
         _record_attempt(cache_path, now, "scope")
+        record_token_cooldown(
+            cache_path, active_digest, now,
+            outcome="scope", base_seconds=cooldown_seconds,
+        )
         _log(
             "[usage-probe] usage windows empty/null — the active OAT likely "
             "lacks the 'user:profile' scope; native probe degraded (no rotation "
@@ -866,13 +1208,19 @@ def run_probe(
         _atomic_write_json(cache_path, cache)
     except Exception:
         _record_attempt(cache_path, now, "failure")
+        record_token_cooldown(
+            cache_path, active_digest, now,
+            outcome="failure", base_seconds=cooldown_seconds,
+        )
         _log("[usage-probe] cache write failed; serving stale cache")
         return {"status": "degraded", "cache_path": str(cache_path)}
 
     _record_attempt(cache_path, now, "success")
     # #1468: a clean reading means the active token is NOT limited → drop the
-    # per-window 429-signal dedupe so a later genuine limit window can re-signal.
+    # per-window 429-signal dedupe so a later genuine limit window can re-signal,
+    # and clear this token's cooldown/backoff streak (it is healthy again).
     _clear_signal_state(cache_path)
+    clear_token_cooldown(cache_path, active_digest)
     return {
         "status": "written",
         "cache_path": str(cache_path),
@@ -917,6 +1265,18 @@ def build_parser() -> argparse.ArgumentParser:
     probe.add_argument("--http-timeout", type=float, default=None)
     probe.add_argument("--json", action="store_true")
     probe.set_defaults(handler=cmd_probe)
+
+    # Stale-attribution guard: print the token-FREE one-way digest (SHA-256
+    # hex prefix — NO token bytes) of the rotation registry's ACTIVE token so
+    # the wrapper can tell the monitor which token is current. Registry-only on
+    # purpose: the rotation lane this guard protects only exists on registry
+    # installs, and a registry-only read never touches env/credential sources.
+    digest = sub.add_parser(
+        "active-token-digest",
+        help="print the one-way digest of the rotation registry's active OAT",
+    )
+    digest.add_argument("--registry-path", required=True)
+    digest.set_defaults(handler=cmd_active_token_digest)
 
     return parser
 
@@ -968,6 +1328,20 @@ def cmd_probe(args: argparse.Namespace) -> int:
         print(json.dumps(result, ensure_ascii=True))
     # Always exit 0: the probe is best-effort and must never block/crash the
     # daemon's usage pass (graceful degrade). The status field carries detail.
+    return 0
+
+
+def cmd_active_token_digest(args: argparse.Namespace) -> int:
+    """Print the one-way digest of the registry's active token (or nothing).
+
+    The token itself is read in-process and NEVER printed/logged — only the
+    SHA-256 hex prefix (the same digest persisted as ``_token_digest`` /
+    ``_signal_token``) lands on stdout. Always exits 0 (best-effort: an absent
+    or unreadable registry prints nothing and the caller skips the guard).
+    """
+    token = _read_active_token_from_registry(Path(args.registry_path).expanduser())
+    if token:
+        print(_token_signal_digest(token))
     return 0
 
 

--- a/bridge-usage-probe.py
+++ b/bridge-usage-probe.py
@@ -1022,6 +1022,22 @@ def run_probe(
     #    stale, don't hammer (and never keep refreshing a CDN edge ban window).
     #    A freshly rotated-in token has no entry and probes immediately.
     if token and token_in_cooldown(cache_path, active_digest, now):
+        # An account-quota 429 now arms the SAME backoff window as an edge block
+        # (escalate=True, Retry-After-bounded). The very next daemon tick lands
+        # inside that window, so this gate — not the rate-limit branch below —
+        # is what suppresses the re-emit for an already-signalled token. When a
+        # still-future 429 signal window exists for THIS token, report the #1468
+        # suppression contract (status + the stable window reset_at) so the
+        # over-rotation guard is observably unchanged; otherwise this is a plain
+        # edge/failure cooldown.
+        if signal_already_emitted(cache_path, active_digest, now):
+            _log("[usage-probe] active token in cooldown with a live near-limit signal window; suppressing re-emit, serving stale")
+            return {
+                "status": "rate-limited-suppressed",
+                "cache_path": str(cache_path),
+                "reset_at": _signal_windows(cache_path).get(active_digest, ""),
+                "cooldown_until": token_cooldown_until(cache_path, active_digest),
+            }
         _log("[usage-probe] active token in cooldown after recent failure; serving stale cache")
         return {
             "status": "cooldown",
@@ -1083,12 +1099,18 @@ def run_probe(
         # rotation signal — handled below.
         if classification == CLASSIFICATION_ACCOUNT_RATE_LIMIT:
             token_digest = active_digest
-            # The account told us it is limited — pause THIS token's probing for
-            # the operator cooldown (the synthetic cache also stays fresh for
-            # max_age, so this is belt-and-suspenders pacing, not new policy).
+            # The account told us it is limited — back off THIS token on the SAME
+            # window contract as an edge block (300/900/3600 escalation + the
+            # server-stated Retry-After up to the cap). An account-quota 429 means
+            # the token is unusable for the reset window; honoring only the fixed
+            # base_seconds cooldown would let the probe re-hammer a limited token
+            # after the 5-minute cache-freshness window and leave measurement
+            # thrash, so escalate the streak and respect Retry-After here too.
             record_token_cooldown(
                 cache_path, token_digest, now,
-                outcome="rate-limited", base_seconds=cooldown_seconds,
+                outcome="rate-limited",
+                retry_after=last_http_error.retry_after,
+                escalate=True,
             )
             # Suppress if THIS token already has a still-future signal window:
             # rotate this token at most once per incident, and stop on a pool

--- a/bridge-usage.py
+++ b/bridge-usage.py
@@ -140,6 +140,7 @@ def _claude_snapshots_from_payload(
     critical: float,
     elevated: float | None,
     agent: str | None,
+    active_token_digest: str | None = None,
 ) -> list[dict[str, Any]]:
     """Shared body for claude_snapshots() and the per-agent collector."""
     if not isinstance(payload, dict):
@@ -147,6 +148,31 @@ def _claude_snapshots_from_payload(
     data = payload.get("data") or payload.get("lastGoodData") or {}
     if not isinstance(data, dict):
         return []
+
+    # Synthetic 429-signal marker (`_signal == rate_limit_429`): the cache is a
+    # probe-fabricated near-limit SIGNAL, not a real reading. Carried into each
+    # snapshot (``signal`` field) so the monitor can route it to the rotation
+    # lane WITHOUT firing operator usage alerts (a synthetic 100% is a rotation
+    # instruction, not a usage fact worth an alert storm).
+    signal_marker = payload.get("_signal")
+    signal_marker = (
+        str(signal_marker) if isinstance(signal_marker, str) and signal_marker else None
+    )
+
+    # Stale-attribution guard: a SYNTHETIC signal cache attributed to a token
+    # that is NO LONGER active is stale — after a rotation the freshly-active
+    # token must not inherit the previous token's near-limit signal (that
+    # re-trips the monitor and ping-pongs the pool). Real readings (no _signal)
+    # are not dropped here. Fail-open: the guard only applies when BOTH the
+    # cache attribution and the caller-supplied active digest are present.
+    if signal_marker is not None and active_token_digest:
+        payload_digest = payload.get("_token_digest") or payload.get("_signal_token")
+        if (
+            isinstance(payload_digest, str)
+            and payload_digest
+            and payload_digest != active_token_digest
+        ):
+            return []
 
     snapshots: list[dict[str, Any]] = []
     plan = data.get("planName") or "subscription"
@@ -181,6 +207,8 @@ def _claude_snapshots_from_payload(
             entry["agent"] = agent
         if signal_token is not None:
             entry["signal_token"] = signal_token
+        if signal_marker is not None:
+            entry["signal"] = signal_marker
         snapshots.append(entry)
     return snapshots
 
@@ -190,6 +218,7 @@ def claude_snapshots(
     warn: float,
     critical: float,
     elevated: float | None = None,
+    active_token_digest: str | None = None,
 ) -> list[dict[str, Any]]:
     if not path.is_file():
         return []
@@ -198,7 +227,8 @@ def claude_snapshots(
     except Exception:
         return []
     return _claude_snapshots_from_payload(
-        payload, str(path), warn, critical, elevated, agent=None
+        payload, str(path), warn, critical, elevated, agent=None,
+        active_token_digest=active_token_digest,
     )
 
 
@@ -224,6 +254,7 @@ def claude_snapshots_per_agent(
     warn: float,
     critical: float,
     elevated: float | None = None,
+    active_token_digest: str | None = None,
 ) -> list[dict[str, Any]]:
     """Issue #831: read the per-agent cache payload array (built by
     bridge-usage.sh) and emit one snapshot set per agent. Each snapshot is
@@ -251,7 +282,8 @@ def claude_snapshots_per_agent(
         source = str(entry.get("path") or "")
         snapshots.extend(
             _claude_snapshots_from_payload(
-                payload, source, warn, critical, elevated, agent=agent
+                payload, source, warn, critical, elevated, agent=agent,
+                active_token_digest=active_token_digest,
             )
         )
     return snapshots
@@ -368,6 +400,7 @@ def native_snapshots(
     warn: float,
     critical: float,
     elevated: float | None = None,
+    active_token_digest: str | None = None,
 ) -> list[dict[str, Any]]:
     """Read the native-probe controller cache and tag it as the native source.
 
@@ -380,7 +413,10 @@ def native_snapshots(
     """
     if not _cache_is_native_probe(path):
         return []
-    snaps = claude_snapshots(path, warn, critical, elevated=elevated)
+    snaps = claude_snapshots(
+        path, warn, critical, elevated=elevated,
+        active_token_digest=active_token_digest,
+    )
     for snap in snaps:
         snap["agent"] = NATIVE_PROBE_AGENT
         snap["source"] = NATIVE_PROBE_SOURCE
@@ -392,6 +428,12 @@ def collect_snapshots(args: argparse.Namespace) -> list[dict[str, Any]]:
     critical = float(args.critical_threshold)
     elevated = _parse_elevated(args, warn, critical)
     snapshots: list[dict[str, Any]] = []
+
+    # Stale-attribution guard input: the one-way digest of the CURRENTLY-active
+    # rotation-registry token (supplied by bridge-usage.sh on registry
+    # installs). A synthetic 429-signal cache attributed to a DIFFERENT token
+    # is dropped at parse time — see _claude_snapshots_from_payload.
+    active_token_digest = getattr(args, "active_token_digest", None) or None
 
     # Issue #831: when --per-agent-cache-json is supplied, the caller is in
     # explicit per-agent mode. Per-agent mode latches on flag presence + a
@@ -411,7 +453,8 @@ def collect_snapshots(args: argparse.Namespace) -> list[dict[str, Any]]:
         per_agent_mode_active = _per_agent_payload_is_present(per_agent_path)
         if per_agent_mode_active:
             per_agent_snaps = claude_snapshots_per_agent(
-                per_agent_path, warn, critical, elevated=elevated
+                per_agent_path, warn, critical, elevated=elevated,
+                active_token_digest=active_token_digest,
             )
             snapshots.extend(per_agent_snaps)
             per_agent_resolved_paths = _per_agent_cache_paths(per_agent_path)
@@ -424,7 +467,10 @@ def collect_snapshots(args: argparse.Namespace) -> list[dict[str, Any]]:
         # probe wrote, so #1437's native signal flows without extra wiring.
         legacy_raw = getattr(args, "legacy_single_path", None) or args.claude_usage_cache
         snapshots.extend(
-            claude_snapshots(Path(legacy_raw).expanduser(), warn, critical, elevated=elevated)
+            claude_snapshots(
+                Path(legacy_raw).expanduser(), warn, critical, elevated=elevated,
+                active_token_digest=active_token_digest,
+            )
         )
 
     # Issue #1437 PRIMARY: in per-agent mode the controller/native cache is
@@ -440,7 +486,10 @@ def collect_snapshots(args: argparse.Namespace) -> list[dict[str, Any]]:
         native_path = Path(native_raw).expanduser()
         if _resolve_str(native_path) not in per_agent_resolved_paths:
             snapshots.extend(
-                native_snapshots(native_path, warn, critical, elevated=elevated)
+                native_snapshots(
+                    native_path, warn, critical, elevated=elevated,
+                    active_token_digest=active_token_digest,
+                )
             )
 
     snapshots.extend(
@@ -621,6 +670,17 @@ def cmd_monitor(args: argparse.Namespace) -> int:
             ]
         )
         bucket = bucket_for_snapshot(snapshot, warn, critical, elevated=elevated)
+        # Synthetic 429-signal snapshots (`signal` set by the cache parser) are
+        # a ROTATION instruction, not a usage fact: route them to their own
+        # `signal` bucket class so the operator-alert ladder below never fires
+        # on them (a probe-fabricated 100% used to emit a full warn/elevated/
+        # crit alert storm every tick) while the rotation-candidate lane —
+        # which keys on used_percent, not bucket — still sees them. `signal`
+        # is absent from _BUCKET_RANK (rank 0), so it can never out-rank a
+        # latch, and it is neither "ok" nor "unknown", so it never clears or
+        # advances the alert latch either.
+        if snapshot.get("signal"):
+            bucket = "signal"
         reset_at = snapshot.get("reset_at")
         used_percent = snapshot.get("used_percent")
         previous = entries.get(key, {}) if isinstance(entries.get(key), dict) else {}
@@ -825,6 +885,13 @@ def build_parser() -> argparse.ArgumentParser:
         # additively in per-agent mode (deduped against per-agent paths) so the
         # native usage signal reaches rotation in the default daemon path.
         cmd.add_argument("--native-usage-cache", default=None, **common_kwargs)
+        # Stale-attribution guard: one-way digest of the currently-active
+        # rotation-registry token. When set, a synthetic 429-signal cache
+        # attributed to a DIFFERENT token is treated as stale (dropped) so a
+        # freshly rotated-in token never inherits the previous token's
+        # near-limit signal (rotation ping-pong guard). Optional; absent →
+        # no attribution check (back-compat).
+        cmd.add_argument("--active-token-digest", default=None, **common_kwargs)
 
     status_parser = sub.add_parser("status")
     add_source_args(status_parser)

--- a/bridge-usage.sh
+++ b/bridge-usage.sh
@@ -571,6 +571,20 @@ run_python() {
   if [[ "${BRIDGE_USAGE_PROBE_ENABLED:-1}" == "1" ]]; then
     base_args+=(--native-usage-cache "$claude_usage_cache")
   fi
+  # Stale-attribution guard (rotation ping-pong): tell the monitor which
+  # token is CURRENTLY active (token-FREE one-way digest — never the token
+  # itself) so a synthetic 429-signal cache written for a PREVIOUSLY-active
+  # token is treated as stale instead of instantly re-rotating the freshly
+  # activated token. Registry installs only — without a rotation registry
+  # there is no rotation lane to protect, and the helper prints nothing.
+  if [[ "${BRIDGE_USAGE_PROBE_ENABLED:-1}" == "1" && -f "$claude_token_registry" ]]; then
+    local _active_digest=""
+    _active_digest="$(command python3 "$SCRIPT_DIR/bridge-usage-probe.py" active-token-digest \
+      --registry-path "$claude_token_registry" 2>/dev/null || builtin true)"
+    if [[ -n "$_active_digest" ]]; then
+      base_args+=(--active-token-digest "$_active_digest")
+    fi
+  fi
   base_args+=("$@")
   python3 "$SCRIPT_DIR/bridge-usage.py" "${base_args[@]}"
 }
@@ -729,22 +743,33 @@ bridge_usage_probe_audit() {
   local row=""
   row="$(command python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" usage-probe-result-parse "$probe_json" 2>/dev/null || builtin true)"
   [[ -n "$row" ]] || return 0
-  local p_status p_reset p_retry p_http
+  local p_status p_reset p_retry p_http p_detail
   # #1468: split the tab-separated probe row WITHOUT a here-string (footgun #11
-  # / lint-heredoc-ban H3). The row is token-free (status/reset/retry/http) and
-  # we read it back from a temp file so `read`'s field semantics are preserved
-  # exactly (verified byte-identical to the prior here-string parse).
+  # / lint-heredoc-ban H3). The row is token-free (status/reset/retry/http/
+  # detail) and we read it back from a temp file so `read`'s field semantics
+  # are preserved exactly (verified byte-identical to the prior here-string
+  # parse).
   local _row_tmp=""
   _row_tmp="$(command mktemp "${TMPDIR:-/tmp}/agb-usage-probe-row.XXXXXX" 2>/dev/null)" || return 0
   printf '%s\n' "$row" >"$_row_tmp" 2>/dev/null || { command rm -f "$_row_tmp"; return 0; }
-  IFS=$'\t' read -r p_status p_reset p_retry p_http <"$_row_tmp"
+  IFS=$'\t' read -r p_status p_reset p_retry p_http p_detail <"$_row_tmp"
   command rm -f "$_row_tmp"
   [[ -n "$p_status" ]] || return 0
+  # Decode the `-` sentinel back to empty: the python helper writes `-` for
+  # empty columns so bash `read -r` cannot collapse adjacent IFS=$'\t'
+  # separators (tab is IFS whitespace; an empty middle field used to shift
+  # http_status into the reset_at slot). Same producer/consumer contract as
+  # the mcp-miss-queue drain rows.
+  [[ "$p_reset" == "-" ]] && p_reset=""
+  [[ "$p_retry" == "-" ]] && p_retry=""
+  [[ "$p_http" == "-" ]] && p_http=""
+  [[ "$p_detail" == "-" ]] && p_detail=""
   bridge_audit_log daemon usage_probe "$admin_agent" \
     --detail status="$p_status" \
     --detail reset_at="$p_reset" \
     --detail retry_after="$p_retry" \
     --detail http_status="$p_http" \
+    --detail detail="$p_detail" \
     --detail source="native-oauth-probe" >/dev/null 2>&1 || builtin true
 }
 

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -527,9 +527,12 @@ bridge_ensure_claude_pre_compact_hook() {
 
 # Patch the HUD statusLine command to pipe through hud-usage-tap.py so
 # bridge-usage.py keeps receiving .usage-cache.json data even after
-# claude-hud v0.0.12+ removed background OAuth polling.  No-op when:
-# (a) no statusLine is configured, (b) the statusLine is not a HUD
-# command, or (c) the tap is already present.  Idempotent.
+# claude-hud v0.0.12+ removed background OAuth polling.  When the
+# statusLine slot is EMPTY (absent / {} / empty command) the tap is
+# installed standalone so live sessions still produce the real measured
+# usage cache.  No-op when: (a) the statusLine is a foreign non-HUD
+# command (never clobbered), or (b) the tap is already present.
+# Idempotent.
 bridge_ensure_hud_usage_tap() {
   local workdir="$1"
   local launch_cmd="${2-}"

--- a/scripts/smoke/1437-native-usage-probe-helper.py
+++ b/scripts/smoke/1437-native-usage-probe-helper.py
@@ -226,8 +226,12 @@ def main() -> int:
             return "{}"
 
         res2 = _run(tmp, http_get=_should_not_run, registry=reg, now=2030.0, max_age=0.0, cooldown=60.0)
-        check(res2["status"] == "cooldown", "second probe within cooldown is suppressed")
-        check(marker["called"] is False, "cooldown prevented a second network call")
+        # The account-quota 429 now arms the same Retry-After-bounded backoff as
+        # an edge block AND leaves a live near-limit signal window, so the next
+        # in-window tick is reported with the #1468 suppression status (it still
+        # serves stale and makes NO network call — the property under test).
+        check(res2["status"] == "rate-limited-suppressed", "second probe within the backoff window is suppressed (live signal window)")
+        check(marker["called"] is False, "the in-window tick prevented a second network call")
 
     # ---- (d2) 429 WITH a short Retry-After → single capped retry succeeds -
     print("[d2] 429 + Retry-After=0 → single retry then success")

--- a/scripts/smoke/1468-usage-429-positive-signal-helper.py
+++ b/scripts/smoke/1468-usage-429-positive-signal-helper.py
@@ -372,19 +372,32 @@ def main() -> int:
         check(len(cand_b) >= 1, "monitor STILL rotates B at the equal reset_at after a real-reading latch (codex r4)")
 
     # ---- (6b) a clean reading clears the dedupe (later window can re-signal) --
+    # NOTE: an account-quota 429 now arms a Retry-After-bounded backoff window
+    # for the active token (parity with the edge-block path), so the clean probe
+    # can only fire once that window elapses — mirroring real daemon timing
+    # (the daemon would not re-probe a limited token inside its cooldown). The
+    # CONTRACT under test is unchanged: a clean reading clears the per-window
+    # dedupe so a LATER incident re-signals. We advance `now` past the cooldown
+    # span for the clean read + the subsequent re-signal instead of stacking
+    # them at the same instant the 429 fired.
     print("[6b] a clean reading clears the per-window dedupe")
     with tempfile.TemporaryDirectory() as d:
         tmp = Path(d)
         reg = _registry(tmp, MOCK_TOKEN_A)
         r1 = _run(tmp, http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3143.0), registry=reg, now=1000.0)
         check(r1["status"] == "rate-limited-signal", "tick1 signals")
-        # A clean reading on the active token (it is no longer limited).
+        # Inside the backoff window the probe serves stale (suppressed), by design.
+        r_cool = _run(tmp, http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3143.0), registry=reg, now=1100.0)
+        check(r_cool["status"] == "rate-limited-suppressed", "inside the backoff window the re-emit is suppressed (serve stale)")
+        # A clean reading on the active token (it is no longer limited), AFTER the
+        # cooldown window elapsed (tick1 armed ~3143s → until ~4143).
         ok_body = {"five_hour": {"utilization": 5.0, "resets_at": "2026-06-01T18:00:00+00:00"},
                    "seven_day": {"utilization": 2.0, "resets_at": "2026-06-07T00:00:00+00:00"}}
-        r2 = _run(tmp, http_get=_stub_ok(ok_body), registry=reg, now=1000.0)
-        check(r2["status"] == "written", "tick2 reads cleanly and writes the real cache")
-        # A subsequent 429 (new incident) re-signals because the dedupe was cleared.
-        r3 = _run(tmp, http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3143.0), registry=reg, now=1000.0)
+        r2 = _run(tmp, http_get=_stub_ok(ok_body), registry=reg, now=5000.0)
+        check(r2["status"] == "written", "tick2 reads cleanly and writes the real cache (post-cooldown)")
+        # A subsequent 429 (new incident) re-signals because the dedupe + the
+        # cooldown streak were cleared by the clean reading.
+        r3 = _run(tmp, http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3143.0), registry=reg, now=5100.0)
         check(r3["status"] == "rate-limited-signal", "after a clean reading a later 429 re-signals")
 
     # ---- (7) the daemon-helper classifies the outcome for the audit row ------

--- a/scripts/smoke/usage-probe-edge-classification-helper.py
+++ b/scripts/smoke/usage-probe-edge-classification-helper.py
@@ -226,6 +226,58 @@ def main() -> int:
         check(cache["data"]["fiveHour"] == 100.0, "synthetic at-limit cache persisted")
         check(cache["_token_digest"] == probe._token_signal_digest(MOCK_TOKEN_A), "signal cache attributed to the active token digest")
 
+    print("[A3b] origin 429 ALSO arms a Retry-After-based backoff window (not the fixed 60s knob)")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        dig_a = probe._token_signal_digest(MOCK_TOKEN_A)
+        # cooldown=60.0 is the operator's fixed knob. An account-quota 429 must
+        # NOT settle for it: the token is unusable for the reset window, so the
+        # backoff must follow the same span contract as an edge block
+        # (max(EDGE_BACKOFF_SCHEDULE[streak], min(Retry-After, cap))). With
+        # Retry-After=3600 the first strike → 3600s, NOT 60s.
+        res = _run(
+            tmp,
+            http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3600.0, headers=ANTHROPIC_HEADERS),
+            registry=reg, now=1000.0, cooldown=60.0,
+        )
+        check(res["status"] == "rate-limited-signal", "still emits the #1468 near-limit signal (contract unchanged)")
+        cooldowns = probe._token_cooldowns(tmp / "plugins" / "claude-hud" / ".usage-cache.json")
+        entry = cooldowns.get(dig_a) or {}
+        until = probe.token_cooldown_until(tmp / "plugins" / "claude-hud" / ".usage-cache.json", dig_a)
+        span = until - 1000.0
+        check(span >= min(3600.0, probe.EDGE_RETRY_AFTER_CAP_SECONDS), f"backoff honors Retry-After (got span={span:g}s)")
+        check(abs(span - 3600.0) < 1e-6, "first account-quota strike → 3600s (Retry-After), NOT the 60s knob")
+        check(span != 60.0, "explicitly NOT the fixed 60s cooldown")
+        check(int(entry.get("streak") or 0) == 1, "escalate=True bumped the consecutive-failure streak to 1")
+        check(entry.get("outcome") == "rate-limited", "cooldown outcome tagged rate-limited")
+        # A second strike on the SAME still-limited token escalates the streak.
+        res2 = _run(
+            tmp,
+            http_get=_stub_http_error(429, RATE_LIMIT_BODY, 300.0, headers=ANTHROPIC_HEADERS),
+            registry=reg, now=5000.0, cooldown=60.0,
+        )
+        check(res2["status"] in ("rate-limited-signal", "rate-limited-suppressed"), "second strike still on the signal lane")
+        entry2 = probe._token_cooldowns(tmp / "plugins" / "claude-hud" / ".usage-cache.json").get(dig_a) or {}
+        until2 = probe.token_cooldown_until(tmp / "plugins" / "claude-hud" / ".usage-cache.json", dig_a)
+        check(int(entry2.get("streak") or 0) == 2, "consecutive account-quota strike escalated streak to 2")
+        # streak 2 → EDGE_BACKOFF_SCHEDULE[1]=900s vs min(RA=300, cap)=300 → 900s wins.
+        check(abs((until2 - 5000.0) - 900.0) < 1e-6, "streak-2 backoff = max(900s schedule, 300s RA) = 900s")
+
+    print("[A3c] a clean reading clears the account-quota backoff streak (success contract preserved)")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        dig_a = probe._token_signal_digest(MOCK_TOKEN_A)
+        cache_path = tmp / "plugins" / "claude-hud" / ".usage-cache.json"
+        # Strike once (arms streak=1, 3600s window), then a clean reading after
+        # the window must clear the cooldown so a later genuine limit re-arms
+        # from streak 1 — not inherit the prior streak.
+        _run(tmp, http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3600.0, headers=ANTHROPIC_HEADERS), registry=reg, now=1000.0, cooldown=60.0)
+        ok_res = _run(tmp, http_get=_stub_ok(OK_BODY), registry=reg, now=5000.0, cooldown=60.0)
+        check(ok_res["status"] == "written", "clean reading after the window writes a real cache")
+        check(probe.token_cooldown_until(cache_path, dig_a) == 0.0, "success cleared the account-quota cooldown/streak entry")
+
     print("[A4] headerless legacy seam (headers=None) → pre-headers behavior preserved")
     with tempfile.TemporaryDirectory() as d:
         tmp = Path(d)

--- a/scripts/smoke/usage-probe-edge-classification-helper.py
+++ b/scripts/smoke/usage-probe-edge-classification-helper.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Mock-only harness — usage-probe edge classification + per-token backoff.
+
+Invoked by scripts/smoke/usage-probe-edge-classification.sh. NEVER makes a
+live network call: every scenario injects a stub ``http_get`` into
+``run_probe`` (the seam exists precisely so CI stays offline). Uses ONLY mock
+token strings — never a real credential.
+
+Background (field incident): every probe response was served by the CDN EDGE
+(``Server: cloudflare``, NO ``request-id`` / ``anthropic-*`` origin headers,
+Retry-After pinned at exactly 3600, the same token flapping 403<->429 minute
+to minute) while 20+ live sessions on the SAME account ran fine. The old
+``is_rate_limit_429`` looked ONLY at the body's ``rate_limit_error`` type, so
+the edge block was misread as account quota → a synthetic at-limit cache →
+usage-alert storms (18 rows/tick) + rotation ping-pong. The old fixed 60s
+cooldown also re-struck the edge every ~6 minutes, permanently renewing the
+edge ban window.
+
+Coverage:
+  (A) 429/403 3-way classification:
+      - CF edge 429/403 (Server: cloudflare / no origin headers) → status
+        ``edge-blocked``; NO synthetic cache is fabricated.
+      - anthropic-origin 429 rate_limit_error → the existing #1468
+        near-limit signal path is PRESERVED.
+      - headerless legacy seam (headers=None) → pre-headers body-only
+        behavior preserved (back-compat for older callers).
+      - anthropic-origin 403 → plain probe failure (degraded), not edge.
+  (B) per-token exponential backoff: 5min → 15min → 60min cap on consecutive
+      edge blocks, min(Retry-After, cap) honored, in-cooldown ticks make NO
+      network call, a rotated-in token probes immediately, success clears
+      the streak.
+  (C) synthetic-signal alert isolation: a 429-signal cache reaches the
+      rotation-candidate lane but NEVER the operator alert lane; real
+      readings still alert.
+  (D) cache token attribution: a cache attributed to a previously-active
+      token is stale for BOTH the probe freshness gate (re-probe now) and
+      the monitor (drop the synthetic, no ping-pong); real readings are
+      fail-open; the active-token-digest CLI prints the digest, never the
+      token.
+  (E) statusLine-tap priority: a FRESH stdin-tap cache satisfies the probe
+      freshness gate (real measured data is never overwritten); a STALE tap
+      cache does not suppress the probe.
+  (F) audit TSV sentinel: empty middle columns are emitted as `-` so the
+      bash consumer's IFS=$'\\t' read cannot collapse fields (http_status no
+      longer shifts into the reset_at slot).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(mod_name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(mod_name, str(REPO_ROOT / filename))
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+probe = _load("bridge_usage_probe", "bridge-usage-probe.py")
+usage = _load("bridge_usage", "bridge-usage.py")
+helpers = _load("bridge_daemon_helpers", "bridge-daemon-helpers.py")
+
+MOCK_TOKEN_A = "sk-ant-oat-MOCK-not-a-real-token-AAAA"
+MOCK_TOKEN_B = "sk-ant-oat-MOCK-not-a-real-token-BBBB"
+
+RATE_LIMIT_BODY = {"error": {"message": "Rate limited.", "type": "rate_limit_error"}}
+CF_BLOCK_BODY = {"error": {"message": "Rate limited.", "type": "rate_limit_error"}}
+CF_403_BODY = "<!DOCTYPE html><html><body>Access denied | api.anthropic.com used Cloudflare to restrict access</body></html>" + ("x" * 300)
+
+# Edge responses: Server: cloudflare, NO request-id / anthropic-* headers.
+CF_HEADERS = {"Server": "cloudflare", "CF-RAY": "8f2mock-NRT", "Content-Type": "application/json"}
+# Origin responses: request-id / anthropic-* present.
+ANTHROPIC_HEADERS = {
+    "request-id": "req_mock_0123456789",
+    "anthropic-organization-id": "org-mock",
+    "Content-Type": "application/json",
+    "Server": "cloudflare",  # the origin ALSO transits cloudflare; origin headers win
+}
+
+OK_BODY = {
+    "five_hour": {"utilization": 42.0, "resets_at": "2026-06-12T18:00:00+00:00"},
+    "seven_day": {"utilization": 13.0, "resets_at": "2026-06-18T00:00:00+00:00"},
+}
+AT_LIMIT_BODY = {
+    "five_hour": {"utilization": 100.0, "resets_at": "2026-06-12T18:00:00+00:00"},
+    "seven_day": {"utilization": 100.0, "resets_at": "2026-06-12T18:00:00+00:00"},
+}
+
+failures: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    if cond:
+        print(f"  PASS  {label}")
+    else:
+        print(f"  FAIL  {label}")
+        failures.append(label)
+
+
+def _stub_http_error(status, body_obj, retry_after, headers="__omit__", calls=None):
+    """Stub raising ProbeHTTPError. headers='__omit__' builds a LEGACY
+    (pre-headers) exception so back-compat callers are exercised too."""
+
+    def _get(url, headers_req, timeout):
+        if calls is not None:
+            calls["n"] = calls.get("n", 0) + 1
+        assert headers_req.get("User-Agent", "").startswith("claude-code/"), "missing/bad UA"
+        body = body_obj if isinstance(body_obj, str) else ("" if body_obj is None else json.dumps(body_obj))
+        if headers == "__omit__":
+            raise probe.ProbeHTTPError(status, body=body, retry_after=retry_after)
+        raise probe.ProbeHTTPError(status, body=body, retry_after=retry_after, headers=headers)
+
+    return _get
+
+
+def _stub_ok(body_obj, calls=None):
+    def _get(url, headers_req, timeout):
+        if calls is not None:
+            calls["n"] = calls.get("n", 0) + 1
+        return json.dumps(body_obj)
+
+    return _get
+
+
+def _registry(tmp: Path, active_token: str) -> Path:
+    p = tmp / "claude-oauth-tokens.json"
+    p.write_text(
+        json.dumps(
+            {
+                "active_token_id": "tok-active",
+                "tokens": [
+                    {"id": "tok-active", "token": active_token, "enabled": True},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+def _run(tmp: Path, *, http_get, registry=None, now=1000.0, max_age=0.0, cooldown=0.0):
+    cache_path = tmp / "plugins" / "claude-hud" / ".usage-cache.json"
+    return probe.run_probe(
+        cache_path=cache_path,
+        registry_path=registry,
+        credentials_path=None,
+        user_agent_version="2.1.0",
+        max_age_seconds=max_age,
+        cooldown_seconds=cooldown,
+        http_timeout=10.0,
+        retry_after_cap=5.0,
+        now=now,
+        http_get=http_get,
+        log=lambda m: None,
+    )
+
+
+def _monitor_run(cache_path: Path, state_path: Path, *, active_token_digest=None, rotation_threshold=99.0):
+    """Drive the REAL bridge-usage.py monitor on a single cache and return its
+    full result envelope (snapshots / alerts / rotation_candidates)."""
+
+    class _NS:
+        pass
+
+    ns = _NS()
+    ns.claude_usage_cache = str(cache_path)
+    ns.codex_sessions_dir = str(cache_path.parent / "no-codex")
+    ns.warn_threshold = 90.0
+    ns.elevated_threshold = 95.0
+    ns.critical_threshold = 100.0
+    ns.rotation_threshold = rotation_threshold
+    ns.per_agent_cache_json = None
+    ns.legacy_single_path = None
+    ns.native_usage_cache = None
+    ns.active_token_digest = active_token_digest
+    ns.state_file = str(state_path)
+    ns.json = True
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        usage.cmd_monitor(ns)
+    return json.loads(buf.getvalue() or "{}")
+
+
+def main() -> int:
+    # ================= (A) 429/403 3-way classification ====================
+    print("[A1] CF edge 429 (cloudflare, no origin headers) → edge-blocked, NO synthetic cache")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        res = _run(tmp, http_get=_stub_http_error(429, CF_BLOCK_BODY, 3600.0, headers=CF_HEADERS), registry=reg)
+        check(res["status"] == "edge-blocked", "status is edge-blocked (NOT rate-limited-signal)")
+        check(res["http_status"] == 429, "http_status carried")
+        cache_path = tmp / "plugins" / "claude-hud" / ".usage-cache.json"
+        check(not cache_path.is_file(), "no synthetic near-limit cache fabricated")
+        check(res["cooldown_seconds"] == 3600.0, "Retry-After=3600 honored in full (max(backoff, capped RA))")
+        check(bool(res.get("detail")), "body snippet carried as detail for the audit row")
+
+    print("[A2] CF edge 403 (cloudflare HTML block, no Retry-After) → edge-blocked")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        res = _run(tmp, http_get=_stub_http_error(403, CF_403_BODY, None, headers=CF_HEADERS), registry=reg)
+        check(res["status"] == "edge-blocked", "403 from the edge classifies edge-blocked too")
+        check(not (tmp / "plugins" / "claude-hud" / ".usage-cache.json").is_file(), "no cache fabricated on 403")
+        check(len(res.get("detail") or "") <= 200, "detail snippet capped at 200 chars")
+        check(res["cooldown_seconds"] == 300.0, "no Retry-After → first-failure backoff floor (5min)")
+
+    print("[A3] anthropic-origin 429 rate_limit_error → #1468 signal path PRESERVED")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        res = _run(tmp, http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3143.0, headers=ANTHROPIC_HEADERS), registry=reg)
+        check(res["status"] == "rate-limited-signal", "origin-proven 429 still emits the near-limit signal")
+        cache = json.loads((tmp / "plugins" / "claude-hud" / ".usage-cache.json").read_text())
+        check(cache["data"]["fiveHour"] == 100.0, "synthetic at-limit cache persisted")
+        check(cache["_token_digest"] == probe._token_signal_digest(MOCK_TOKEN_A), "signal cache attributed to the active token digest")
+
+    print("[A4] headerless legacy seam (headers=None) → pre-headers behavior preserved")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        res = _run(tmp, http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3143.0), registry=reg)
+        check(res["status"] == "rate-limited-signal", "legacy headerless 429 rate_limit_error still signals (back-compat)")
+
+    print("[A5] anthropic-origin 403 → plain failure (degraded), not edge, not signal")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        res = _run(tmp, http_get=_stub_http_error(403, {"error": {"type": "permission_error"}}, None, headers=ANTHROPIC_HEADERS), registry=reg)
+        check(res["status"] == "degraded", "origin 403 degrades (probe failure, no edge backoff escalation)")
+        check(not (tmp / "plugins" / "claude-hud" / ".usage-cache.json").is_file(), "no cache fabricated")
+
+    print("[A6] headers PRESENT but empty (no origin proof) → edge-blocked")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        res = _run(tmp, http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3600.0, headers={}), registry=reg)
+        check(res["status"] == "edge-blocked", "a 429 with NO anthropic origin headers is an edge block, not quota")
+
+    print("[A7] classifier units")
+    exc_edge = probe.ProbeHTTPError(429, body=json.dumps(RATE_LIMIT_BODY), retry_after=3600.0, headers=CF_HEADERS)
+    exc_origin = probe.ProbeHTTPError(429, body=json.dumps(RATE_LIMIT_BODY), retry_after=3143.0, headers=ANTHROPIC_HEADERS)
+    exc_legacy = probe.ProbeHTTPError(429, body=json.dumps(RATE_LIMIT_BODY), retry_after=3143.0)
+    exc_401 = probe.ProbeHTTPError(401, body="{}", headers=ANTHROPIC_HEADERS)
+    exc_origin_403 = probe.ProbeHTTPError(403, body="{}", headers=ANTHROPIC_HEADERS)
+    check(probe.classify_probe_http_error(exc_edge) == "edge-blocked", "classify: CF edge 429 → edge-blocked")
+    check(probe.classify_probe_http_error(exc_origin) == "account-rate-limit", "classify: origin 429 rate_limit_error → account")
+    check(
+        probe.classify_probe_http_error(exc_origin_403) == "failure",
+        "classify: origin 403 (request-id present, Server: cloudflare transit) → failure, NOT edge",
+    )
+    check(probe.classify_probe_http_error(exc_legacy) == "account-rate-limit", "classify: headerless legacy 429 → account (back-compat)")
+    check(probe.classify_probe_http_error(exc_401) == "failure", "classify: 401 → failure")
+    check(probe.is_rate_limit_429(exc_origin) is True, "is_rate_limit_429 wrapper: origin 429 → True")
+    check(probe.is_rate_limit_429(exc_edge) is False, "is_rate_limit_429 wrapper: edge 429 → False")
+
+    # ================= (B) per-token exponential backoff ====================
+    print("[B1] consecutive edge blocks escalate 5min → 15min → 60min cap; cooldown ticks make NO call")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        edge_403 = _stub_http_error(403, CF_403_BODY, None, headers=CF_HEADERS)
+        r1 = _run(tmp, http_get=edge_403, registry=reg, now=1000.0)
+        check(r1["cooldown_seconds"] == 300.0, "1st edge block → 300s")
+        calls = {"n": 0}
+        r_gate = _run(tmp, http_get=_stub_http_error(403, CF_403_BODY, None, headers=CF_HEADERS, calls=calls), registry=reg, now=1100.0)
+        check(r_gate["status"] == "cooldown", "tick inside the window → cooldown (serving stale)")
+        check(calls["n"] == 0, "in-cooldown tick made NO network call (edge ban not renewed)")
+        r2 = _run(tmp, http_get=edge_403, registry=reg, now=1400.0)
+        check(r2["cooldown_seconds"] == 900.0, "2nd consecutive edge block → 900s")
+        r3 = _run(tmp, http_get=edge_403, registry=reg, now=2400.0)
+        check(r3["cooldown_seconds"] == 3600.0, "3rd consecutive edge block → 3600s (cap)")
+        r4 = _run(tmp, http_get=edge_403, registry=reg, now=6100.0)
+        check(r4["cooldown_seconds"] == 3600.0, "4th+ stays at the 60min cap")
+
+    print("[B2] rotated-in token probes immediately (per-token map, not global)")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg_a = _registry(tmp, MOCK_TOKEN_A)
+        _run(tmp, http_get=_stub_http_error(429, CF_BLOCK_BODY, 3600.0, headers=CF_HEADERS), registry=reg_a, now=1000.0)
+        # Rotation lands token B 10s later — B has NO cooldown entry.
+        reg_b = _registry(tmp, MOCK_TOKEN_B)
+        calls = {"n": 0}
+        res_b = _run(tmp, http_get=_stub_ok(OK_BODY, calls=calls), registry=reg_b, now=1010.0)
+        check(calls["n"] == 1, "token B's first probe goes out immediately (no inherited cooldown)")
+        check(res_b["status"] == "written", "token B writes a real reading")
+
+    print("[B3] a clean reading clears the token's cooldown streak")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        edge_403 = _stub_http_error(403, CF_403_BODY, None, headers=CF_HEADERS)
+        _run(tmp, http_get=edge_403, registry=reg, now=1000.0)   # streak 1 → 300s
+        ok_res = _run(tmp, http_get=_stub_ok(OK_BODY), registry=reg, now=1400.0)
+        check(ok_res["status"] == "written", "clean reading after the window writes")
+        r_next = _run(tmp, http_get=edge_403, registry=reg, now=1500.0)
+        check(r_next["cooldown_seconds"] == 300.0, "streak restarted after success (back to 300s, not 900s)")
+
+    # ================= (C) synthetic-signal alert isolation =================
+    print("[C1] 429-signal cache → rotation candidate YES, operator alert NO")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        res = _run(tmp, http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3143.0, headers=ANTHROPIC_HEADERS), registry=reg)
+        check(res["status"] == "rate-limited-signal", "signal cache persisted")
+        cache_path = Path(res["cache_path"])
+        out = _monitor_run(cache_path, tmp / "monitor-state.json")
+        check(len(out.get("rotation_candidates") or []) >= 1, "monitor still surfaces the rotation candidate")
+        check(out.get("alerts") == [], "monitor emits ZERO operator alerts for the synthetic signal (no alert storm)")
+        snaps = [s for s in out.get("snapshots") or [] if s.get("provider") == "claude"]
+        check(all(s.get("signal") == "rate_limit_429" for s in snaps), "snapshots carry the signal marker")
+
+    print("[C2] positive control: a REAL at-limit reading still alerts")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        res = _run(tmp, http_get=_stub_ok(AT_LIMIT_BODY), registry=reg)
+        check(res["status"] == "written", "real at-limit reading written")
+        out = _monitor_run(Path(res["cache_path"]), tmp / "monitor-state.json")
+        check(len(out.get("alerts") or []) >= 1, "real readings still produce operator alerts")
+        check(len(out.get("rotation_candidates") or []) >= 1, "and still rotate")
+
+    # ================= (D) cache token attribution ==========================
+    print("[D1] probe freshness gate: a fresh cache from a PREVIOUS token is stale → re-probe")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg_a = _registry(tmp, MOCK_TOKEN_A)
+        res = _run(tmp, http_get=_stub_http_error(429, RATE_LIMIT_BODY, 3143.0, headers=ANTHROPIC_HEADERS), registry=reg_a, now=1000.0)
+        cache_path = Path(res["cache_path"])
+        os.utime(cache_path, (1000.0, 1000.0))
+        # Same token, within max_age → fresh (no call).
+        calls = {"n": 0}
+        r_same = _run(tmp, http_get=_stub_ok(OK_BODY, calls=calls), registry=reg_a, now=1100.0, max_age=300.0)
+        check(r_same["status"] == "fresh", "same active token → cache is fresh")
+        check(calls["n"] == 0, "no call while fresh")
+        # Rotated to B: digest mismatch → NOT fresh → re-probe NOW.
+        reg_b = _registry(tmp, MOCK_TOKEN_B)
+        calls = {"n": 0}
+        r_rot = _run(tmp, http_get=_stub_ok(OK_BODY, calls=calls), registry=reg_b, now=1100.0, max_age=300.0)
+        check(calls["n"] == 1, "rotated-in token re-probes immediately (stale attribution)")
+        check(r_rot["status"] == "written", "and replaces the inherited synthetic with a real reading")
+
+    print("[D2] monitor: a synthetic signal from a previously-active token is DROPPED; real readings fail open")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        dig_a = probe._token_signal_digest(MOCK_TOKEN_A)
+        dig_b = probe._token_signal_digest(MOCK_TOKEN_B)
+        cache_path = tmp / ".usage-cache.json"
+        signal_cache = probe.build_rate_limit_signal_cache("2026-06-12T18:00:00+00:00", dig_a)
+        cache_path.write_text(json.dumps(signal_cache), encoding="utf-8")
+        out_stale = _monitor_run(cache_path, tmp / "ms1.json", active_token_digest=dig_b)
+        claude_stale = [s for s in out_stale.get("snapshots") or [] if s.get("provider") == "claude"]
+        check(claude_stale == [], "mismatched digest → synthetic snapshots dropped (no ping-pong)")
+        check(out_stale.get("rotation_candidates") == [], "no rotation candidate from the stale synthetic")
+        out_match = _monitor_run(cache_path, tmp / "ms2.json", active_token_digest=dig_a)
+        check(len(out_match.get("rotation_candidates") or []) >= 1, "matching digest → the signal still rotates")
+        # Real reading (no _signal) attributed to A while B is active → kept.
+        real_cache = probe.map_payload_to_cache(AT_LIMIT_BODY, token_digest=dig_a)
+        cache_path.write_text(json.dumps(real_cache), encoding="utf-8")
+        out_real = _monitor_run(cache_path, tmp / "ms3.json", active_token_digest=dig_b)
+        claude_real = [s for s in out_real.get("snapshots") or [] if s.get("provider") == "claude"]
+        check(len(claude_real) >= 1, "real readings are NOT dropped on digest mismatch (fail-open)")
+
+    print("[D3] active-token-digest CLI prints the digest, never the token")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        import contextlib
+        import io
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            probe.main(["active-token-digest", "--registry-path", str(reg)])
+        out = buf.getvalue().strip()
+        check(out == probe._token_signal_digest(MOCK_TOKEN_A), "CLI digest matches _token_signal_digest")
+        check(MOCK_TOKEN_A not in out and MOCK_TOKEN_A[-4:] not in out, "no token material on stdout")
+        buf2 = io.StringIO()
+        with contextlib.redirect_stdout(buf2):
+            probe.main(["active-token-digest", "--registry-path", str(tmp / "missing.json")])
+        check(buf2.getvalue().strip() == "", "absent registry prints nothing (caller skips the guard)")
+
+    # ================= (E) statusLine-tap priority ==========================
+    print("[E] a FRESH stdin-tap cache satisfies the freshness gate; a STALE one does not")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        cache_path = tmp / "plugins" / "claude-hud" / ".usage-cache.json"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        tap_cache = {
+            "data": {"planName": "subscription", "fiveHour": 37.0, "sevenDay": 12.0,
+                     "fiveHourResetAt": "2026-06-12T18:00:00+00:00", "sevenDayResetAt": None},
+            "_source": "stdin-tap",
+        }
+        cache_path.write_text(json.dumps(tap_cache), encoding="utf-8")
+        os.utime(cache_path, (5000.0, 5000.0))
+        calls = {"n": 0}
+        r_fresh = _run(tmp, http_get=_stub_ok(OK_BODY, calls=calls), registry=reg, now=5100.0, max_age=300.0)
+        check(r_fresh["status"] == "fresh", "live tap data (age 100s < 300s) → probe stands down")
+        check(calls["n"] == 0, "probe did not overwrite the real measured tap reading")
+        check(json.loads(cache_path.read_text())["data"]["fiveHour"] == 37.0, "tap reading intact")
+        # Stale tap (statusLine gone / headless) → probe takes over.
+        calls = {"n": 0}
+        r_stale = _run(tmp, http_get=_stub_ok(OK_BODY, calls=calls), registry=reg, now=5500.0, max_age=300.0)
+        check(calls["n"] == 1, "stale tap cache (age 500s) no longer suppresses the probe")
+        check(r_stale["status"] == "written", "probe refreshed the cache on the headless path")
+
+    # ================= (F) audit TSV `-` sentinel ===========================
+    print("[F] usage-probe-result-parse emits `-` for empty columns (no field collapse)")
+
+    class _A:
+        pass
+
+    def _parse(obj):
+        ns = _A()
+        ns.probe_json = json.dumps(obj)
+        import contextlib
+        import io
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            helpers.cmd_usage_probe_result_parse(ns)
+        return buf.getvalue().rstrip("\n")
+
+    row = _parse({"status": "degraded", "http_status": 403})
+    check(row == "degraded\t-\t-\t403\t-", f"degraded row uses `-` sentinels (got {row!r})")
+    cols = row.split("\t")
+    check(len(cols) == 5 and cols[3] == "403", "http_status stays in column 4 (no shift into reset_at)")
+    edge_row = _parse({
+        "status": "edge-blocked", "http_status": 429, "retry_after": 3600.0,
+        "detail": json.dumps(RATE_LIMIT_BODY),
+    })
+    edge_cols = edge_row.split("\t")
+    check(edge_cols[0] == "edge-blocked", "edge-blocked is a noteworthy audit status")
+    check(len(edge_cols) == 5 and edge_cols[3] == "429", "edge row carries http_status in place")
+    check("rate_limit_error" in edge_cols[4], "edge row carries the body snippet detail")
+    sig_row = _parse({"status": "rate-limited-signal", "reset_at": "2026-06-12T18:00:00+00:00", "retry_after": 3143.0})
+    check(sig_row.split("\t")[0] == "rate-limited-signal" and len(sig_row.split("\t")) == 5, "signal row keeps 5 columns")
+    check(_parse({"status": "written"}) == "", "healthy ticks stay audit-silent")
+    tabby = _parse({"status": "edge-blocked", "http_status": 403, "detail": "a\tb\nc"})
+    check("\t".join(tabby.split("\t")[4:]) == "a b c", "tabs/newlines in detail are sanitized to spaces")
+
+    # ============ credential safety on the new paths ========================
+    print("[G] credential safety: token absent from edge results, cooldown state, digest output")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        reg = _registry(tmp, MOCK_TOKEN_A)
+        res = _run(tmp, http_get=_stub_http_error(429, CF_BLOCK_BODY, 3600.0, headers=CF_HEADERS), registry=reg)
+        state_text = (tmp / "plugins" / "claude-hud" / probe.PROBE_STATE_BASENAME).read_text()
+        for blob, name in ((json.dumps(res), "edge result"), (state_text, "probe-state (cooldown map)")):
+            check(MOCK_TOKEN_A not in blob, f"token absent from the {name}")
+            check(MOCK_TOKEN_A[-4:] not in blob, f"token tail absent from the {name}")
+
+    if failures:
+        print(f"[edge-classification-helper] {len(failures)} FAILED: {failures}")
+        return 1
+    print("[edge-classification-helper] all assertions PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke/usage-probe-edge-classification.sh
+++ b/scripts/smoke/usage-probe-edge-classification.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# scripts/smoke/usage-probe-edge-classification.sh — regression for the
+# CDN-edge-block misclassification of the native usage probe.
+#
+# Field incident: every `GET api/oauth/usage` response was served by the CDN
+# EDGE (`Server: cloudflare`, NO `request-id`/`anthropic-*` origin headers,
+# Retry-After pinned at 3600, the same token flapping 403<->429) while live
+# sessions on the SAME account ran fine. The probe's body-only 429 check
+# misread the edge block as ACCOUNT quota → synthetic at-limit cache →
+# usage-alert storms + rotation ping-pong; the fixed 60s cooldown re-struck
+# the edge every ~6 min, permanently renewing the edge ban window.
+#
+# Fix surface covered here:
+#   PY — scripts/smoke/usage-probe-edge-classification-helper.py drives every
+#        scenario against the REAL run_probe + REAL monitor with an injected
+#        HTTP seam (no live network, mock tokens only): 3-way 429/403
+#        classification, per-token exponential backoff (5m→15m→60m cap,
+#        Retry-After honored, no call while cooling down, rotated-in token
+#        probes immediately), synthetic-signal alert isolation (rotation lane
+#        only, zero operator alerts), cache token attribution (probe + monitor
+#        stale guard, fail-open for real readings), statusLine-tap freshness
+#        priority, audit TSV `-` sentinel, credential safety.
+#   S1 — in-source wiring greps: classifier + backoff in the probe, the
+#        --active-token-digest plumbing, the sentinel decode in the wrapper,
+#        edge-blocked in the audit parser's noteworthy set.
+#   F1 — bash-side TSV consumer: the `-` sentinel keeps http_status in its own
+#        column through a real `IFS=$'\t' read` (the original field-collapse
+#        bug shifted it into reset_at).
+#   E1 — ensure-hud-usage-tap installs the tap STANDALONE when the statusLine
+#        slot is empty ({} or absent), is idempotent, reports `present` via
+#        status-hud-usage-tap, and never clobbers a foreign statusLine.
+
+set -euo pipefail
+
+SMOKE_NAME="usage-probe-edge-classification"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+
+PROBE="$REPO_ROOT/bridge-usage-probe.py"
+USAGE_PY="$REPO_ROOT/bridge-usage.py"
+USAGE_SH="$REPO_ROOT/bridge-usage.sh"
+HELPERS_PY="$REPO_ROOT/bridge-daemon-helpers.py"
+HOOKS_PY="$REPO_ROOT/bridge-hooks.py"
+HELPER="$SCRIPT_DIR/usage-probe-edge-classification-helper.py"
+
+failed=0
+fail() {
+  echo "  FAIL  $1" >&2
+  failed=1
+}
+ok() { echo "  PASS  $1"; }
+
+# --- PY: the mock-only python harness (the bulk of behavioral coverage) ------
+echo "[PY] mock-only classification/backoff/isolation scenarios (no live network)"
+if python3 "$HELPER"; then
+  ok "python harness: all edge-classification scenarios pass"
+else
+  fail "python harness: one or more edge-classification scenarios failed"
+fi
+
+# --- S1: in-source wiring -----------------------------------------------------
+echo "[S1] in-source wiring"
+if grep -q 'def classify_probe_http_error' "$PROBE" && grep -q 'CLASSIFICATION_EDGE_BLOCKED' "$PROBE"; then
+  ok "probe ships the 3-way classifier (classify_probe_http_error / edge-blocked)"
+else
+  fail "probe missing the 3-way classifier"
+fi
+if grep -q 'def record_token_cooldown' "$PROBE" && grep -q 'EDGE_BACKOFF_SCHEDULE_SECONDS' "$PROBE"; then
+  ok "probe ships the per-token exponential backoff (record_token_cooldown)"
+else
+  fail "probe missing the per-token backoff"
+fi
+if grep -q 'active-token-digest' "$PROBE" && grep -q -- '--active-token-digest' "$USAGE_PY" \
+   && grep -q -- '--active-token-digest' "$USAGE_SH"; then
+  ok "active-token-digest plumbing present (probe CLI → wrapper → monitor)"
+else
+  fail "active-token-digest plumbing incomplete"
+fi
+if grep -q '"edge-blocked"' "$HELPERS_PY"; then
+  ok "edge-blocked is a noteworthy audit status in usage-probe-result-parse"
+else
+  fail "edge-blocked missing from the audit parser's noteworthy set"
+fi
+if grep -q '== "-" \]\] && p_reset=""' "$USAGE_SH"; then
+  ok "wrapper decodes the \`-\` sentinel back to empty fields"
+else
+  fail "wrapper missing the \`-\` sentinel decode"
+fi
+if grep -q '"signal"' "$USAGE_PY" && grep -q 'bucket = "signal"' "$USAGE_PY"; then
+  ok "monitor routes synthetic signal snapshots to the signal bucket (no operator alerts)"
+else
+  fail "monitor missing the signal bucket isolation"
+fi
+
+# --- F1: bash-side TSV consumer survives empty middle columns -----------------
+echo "[F1] bash TSV consumer: http_status stays in its own column via the \`-\` sentinel"
+f1_row="$(python3 "$HELPERS_PY" usage-probe-result-parse '{"status":"degraded","http_status":403}')"
+f1_tmp="$(mktemp "${TMPDIR:-/tmp}/agb-edge-f1.XXXXXX")"
+printf '%s\n' "$f1_row" >"$f1_tmp"
+f1_status="" f1_reset="" f1_retry="" f1_http="" f1_detail=""
+IFS=$'\t' read -r f1_status f1_reset f1_retry f1_http f1_detail <"$f1_tmp"
+rm -f -- "$f1_tmp"
+[[ "$f1_reset" == "-" ]] && f1_reset=""
+[[ "$f1_retry" == "-" ]] && f1_retry=""
+[[ "$f1_http" == "-" ]] && f1_http=""
+[[ "$f1_detail" == "-" ]] && f1_detail=""
+if [[ "$f1_status" == "degraded" && "$f1_http" == "403" && -z "$f1_reset" && -z "$f1_retry" ]]; then
+  ok "http_status=403 decoded in column 4 with empty reset/retry (no field collapse)"
+else
+  fail "TSV consumer field shift: status=$f1_status reset=$f1_reset retry=$f1_retry http=$f1_http"
+fi
+
+# --- E1: ensure-hud-usage-tap fresh-install on an empty statusLine slot -------
+echo "[E1] ensure-hud-usage-tap installs the tap standalone when statusLine is empty"
+E1_WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/agb-edge-hudtap.XXXXXX")"
+mkdir -p "$E1_WORKDIR/.claude"
+printf '%s' '{}' >"$E1_WORKDIR/.claude/settings.json"
+E1_OUT="$(python3 "$HOOKS_PY" ensure-hud-usage-tap --workdir "$E1_WORKDIR" --bridge-home "$REPO_ROOT" --python-bin "$(command -v python3)")"
+if printf '%s' "$E1_OUT" | grep -q "status: installed" \
+   && grep -q 'hud-usage-tap' "$E1_WORKDIR/.claude/settings.json"; then
+  ok "empty settings ({}) → tap installed standalone"
+else
+  fail "empty settings did not install the tap (out=$E1_OUT)"
+fi
+# Idempotent second run reports present and does not change the file.
+E1_HASH_BEFORE="$(cksum "$E1_WORKDIR/.claude/settings.json")"
+E1_OUT2="$(python3 "$HOOKS_PY" ensure-hud-usage-tap --workdir "$E1_WORKDIR" --bridge-home "$REPO_ROOT" --python-bin "$(command -v python3)")"
+E1_HASH_AFTER="$(cksum "$E1_WORKDIR/.claude/settings.json")"
+if printf '%s' "$E1_OUT2" | grep -q "status: present" && [[ "$E1_HASH_BEFORE" == "$E1_HASH_AFTER" ]]; then
+  ok "second run is an idempotent no-op (present)"
+else
+  fail "second run not idempotent (out=$E1_OUT2)"
+fi
+# status-hud-usage-tap recognizes the standalone tap as present.
+if python3 "$HOOKS_PY" status-hud-usage-tap --workdir "$E1_WORKDIR" --bridge-home "$REPO_ROOT" | grep -q "status: present"; then
+  ok "status-hud-usage-tap reports the standalone tap as present"
+else
+  fail "status-hud-usage-tap does not recognize the standalone tap"
+fi
+rm -rf "$E1_WORKDIR"
+
+# Absent statusLine KEY entirely → also installs.
+E2_WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/agb-edge-hudtap2.XXXXXX")"
+mkdir -p "$E2_WORKDIR/.claude"
+printf '%s' '{"model":"opus"}' >"$E2_WORKDIR/.claude/settings.json"
+E2_OUT="$(python3 "$HOOKS_PY" ensure-hud-usage-tap --workdir "$E2_WORKDIR" --bridge-home "$REPO_ROOT" --python-bin "$(command -v python3)")"
+if printf '%s' "$E2_OUT" | grep -q "status: installed" \
+   && grep -q '"model": "opus"' "$E2_WORKDIR/.claude/settings.json"; then
+  ok "absent statusLine key → installed; sibling settings preserved"
+else
+  fail "absent statusLine key not handled (out=$E2_OUT)"
+fi
+rm -rf "$E2_WORKDIR"
+
+# A foreign (non-HUD, non-empty) statusLine is NEVER clobbered.
+E3_WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/agb-edge-hudtap3.XXXXXX")"
+mkdir -p "$E3_WORKDIR/.claude"
+printf '%s' '{"statusLine":{"type":"command","command":"my-custom-statusline --fancy"}}' >"$E3_WORKDIR/.claude/settings.json"
+E3_HASH_BEFORE="$(cksum "$E3_WORKDIR/.claude/settings.json")"
+E3_OUT="$(python3 "$HOOKS_PY" ensure-hud-usage-tap --workdir "$E3_WORKDIR" --bridge-home "$REPO_ROOT" --python-bin "$(command -v python3)" || true)"
+E3_HASH_AFTER="$(cksum "$E3_WORKDIR/.claude/settings.json")"
+if printf '%s' "$E3_OUT" | grep -q "status: no-hud" && [[ "$E3_HASH_BEFORE" == "$E3_HASH_AFTER" ]]; then
+  ok "foreign statusLine left untouched (no-hud)"
+else
+  fail "foreign statusLine was modified or misreported (out=$E3_OUT)"
+fi
+rm -rf "$E3_WORKDIR"
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "[smoke:${SMOKE_NAME}] FAILED"
+  exit 1
+fi
+echo "[smoke:${SMOKE_NAME}] PASS"


### PR DESCRIPTION
# usage: classify CDN edge blocks, per-token probe backoff, alert isolation

**Closes #1824.** Measurement lane only — the rotation round-robin (#1818) is a separate follow-up and is intentionally out of scope here.

## Problem

On an install whose `GET api/oauth/usage` poll is blocked at the CDN edge, the native usage probe misread the block as account quota and destabilized the entire usage/rotation loop:

- Every probe response was edge-served: `Server: cloudflare` with **no** `request-id` / `anthropic-*` origin headers, `Retry-After` pinned at exactly 3600, and the same token flapping 403↔429 minute to minute — while 20+ live Claude sessions on the same account ran normally.
- `is_rate_limit_429()` inspected only the body's `error.type == rate_limit_error`, so the edge 429 was treated as a genuine near-limit signal (#1468 path): the probe fabricated a synthetic `fiveHour = sevenDay = 100.0` cache for an account that was **not** limited.
- That synthetic 100% (a) flooded the operator alert lane (`usage_alert`, ~18 rows per daemon tick) and (b) drove rotation ping-pong (8 rotations in a single day), because after each rotation the freshly-activated token inherited the previous token's synthetic cache and instantly re-tripped the monitor.
- The fixed 60s cooldown + 5min cache max-age made the probe re-strike the edge every ~6 minutes, permanently renewing the edge ban window — the probe could never recover on its own.
- Independently, the `usage_probe` audit row was corrupted: bash `IFS=$'\t' read` treats tab as IFS whitespace and collapses adjacent separators, so an empty `reset_at`/`retry_after` column shifted `http_status` into the `reset_at` slot.

## Fix

Six coordinated changes — defense in depth, each independently useful:

1. **3-way 429/403 classification** (`bridge-usage-probe.py`). `ProbeHTTPError` now carries the (token-free) response headers; `classify_probe_http_error()` distinguishes:
   - `account-rate-limit` — 429 + `rate_limit_error` body + anthropic **origin** headers (`request-id` / `anthropic-*`) → the existing #1468 synthetic-signal path, unchanged;
   - `edge-blocked` — 429/403 **without** any origin header → new status: no synthetic cache is ever fabricated, the outcome is audited as `edge-blocked` with a 200-char body snippet. `Server: cloudflare` alone is deliberately *not* the discriminator (genuine origin responses also transit Cloudflare); the decisive evidence is origin-header absence.
   - `failure` — everything else → the existing degrade path.
   A headers-less exception (legacy seam) falls back to the previous body-only rule, so out-of-tree callers keep their behavior.
2. **Per-token exponential backoff** (`bridge-usage-probe.py`, `.usage-probe-state.json`). The fixed last-attempt cooldown becomes a `token_cooldowns: {digest: {until, streak}}` map. Edge **and account-quota** 429s apply `max(backoff[streak], min(Retry-After, 60min))` with a 5min → 15min → 60min ladder; in-cooldown ticks make **no** network call; a clean reading clears the streak; a freshly rotated-in token has no entry and probes immediately. A genuine account-quota 429 now arms this same Retry-After-aware backoff (previously it fell through to the ordinary 60s knob and re-probed a quota-limited token after the 5min freshness window); the in-cooldown gate is signal-aware, returning a stable `reset_at` derived from the live #1468 signal window rather than recomputing a drifting cooldown each daemon pass — so the #1468 positive signal is still emitted, only the premature re-probe is suppressed.
3. **Synthetic-signal alert isolation** (`bridge-usage.py`). Snapshots parsed from a `_signal == rate_limit_429` cache carry a `signal` marker and route to a dedicated `signal` bucket in the monitor: they remain rotation candidates but can never fire (or latch) operator usage alerts. Real readings still alert. This is the second line of defense even if a synthetic cache is ever produced wrongly again.
4. **Cache token attribution** (probe + monitor + wrapper). Both real and synthetic caches now record the active token's one-way SHA-256 digest (`_token_digest`, no token bytes). The probe freshness gate re-probes immediately when the cache belongs to a previously-active token, and the monitor (new `--active-token-digest`, supplied by `bridge-usage.sh` via the new registry-only `active-token-digest` subcommand) drops a *synthetic* cache attributed to a non-active token. This breaks the post-rotation inheritance that powered the ping-pong. Real readings are fail-open (never dropped).
5. **statusLine tap priority** (`bridge-usage-probe.py`, `bridge-hooks.py`). A *fresh* `stdin-tap` cache (a live statusLine is rendering right now) satisfies the probe freshness gate, so measured tap data is never overwritten by the probe; the age gate still hands headless hosts to the probe once the tap goes stale. `ensure-hud-usage-tap` now installs the tap standalone (`<python> hud-usage-tap.py > /dev/null`) when the statusLine slot is empty (absent / `{}` / empty command) instead of bailing `no-hud` — sessions without a HUD still produce real usage readings. Foreign non-HUD statusLines are never clobbered; `status-hud-usage-tap` recognizes the standalone install as `present`.
6. **Audit TSV `-` sentinel** (`bridge-daemon-helpers.py`, `bridge-usage.sh`). `usage-probe-result-parse` emits `-` for empty columns (and adds a `detail` column for the edge/403 body snippet); the wrapper decodes `-` back to empty after the `read`. Same producer/consumer contract as the existing rotation-TSV and mcp-miss-queue sentinel rows.

## Validation

All on the branch worktree, offline (the smoke harness injects the HTTP seam; no live network, mock tokens only):

```
python3 -m py_compile bridge-usage-probe.py bridge-usage.py bridge-daemon-helpers.py bridge-hooks.py
bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh
shellcheck bridge-usage.sh scripts/smoke/usage-probe-edge-classification.sh   # clean
shellcheck <full repo per CLAUDE.md>   # output byte-identical to the pristine v0.16.9 baseline (pre-existing info notes only)

bash scripts/smoke/usage-probe-edge-classification.sh        # NEW — PASS (python asserts + shell-side wiring/TSV/
                                                              #   hud-tap-install checks: classifier, backoff ladder,
                                                              #   account-429 Retry-After backoff (A3b/A3c: first strike
                                                              #   ≥3600s NOT 60s, streak 1→2, signal-aware reset_at),
                                                              #   alert isolation, attribution guards, tap freshness,
                                                              #   sentinel decode incl. a real bash IFS read)
bash scripts/smoke/1437-native-usage-probe.sh                 # PASS (no regression, incl. credential-safety attack runs)
bash scripts/smoke/1468-usage-429-positive-signal.sh          # PASS (full #1468 contract preserved: signal, idempotence,
                                                              #   pool-walk bound, codex r1–r4 cases, E2E audit + monitor)
bash scripts/smoke/weekly-usage-quota-escalation.sh           # PASS
./scripts/smoke-test.sh                                       # see host caveats below
```

`./scripts/smoke-test.sh` host-environment caveats — each verified to reproduce **identically on the pristine v0.16.9 tag** on the validation host (macOS), i.e. pre-existing and not introduced by this branch:

1. The suite's lint gate fails on stock shellcheck 0.11.0 due to a pre-existing `SC2102` info in `bridge-run.sh:1133`; full-repo shellcheck output is byte-identical between the baseline and this branch.
2. The `#365 ephemeral-controller-env guard` block fails on this Darwin host (Linux-only guard).
3. The `starting isolated tmux role` step cannot boot the smoke engine session on this host.

With (1) severity-filtered and (2) locally skipped, the suite progresses to (3) and the branch's run log is **byte-identical** (after path/session-id normalization) to the pristine-baseline run log for every step the host can reach. The HUD-tap assertions that live beyond (3) in the suite (seeded HUD command → `status: missing` → ensure `updated` → `present` → idempotent re-run, and `{}` → `status-hud-usage-tap: no-hud`) were replayed manually against this branch and pass unchanged.

## Behavior after upgrade (converging from a live incident)

- A stale synthetic 100% cache left on disk by the old code is dropped by the monitor's attribution guard as soon as it belongs to a non-active token, and the probe re-probes immediately on the active token; edge blocks then back off to one attempt per hour (one `edge-blocked` audit row each), so the edge ban window can actually expire.
- Operator alert volume from synthetic signals goes to zero; real readings (tap or probe) alert exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
