### PR TITLE
hooks: fix tool-policy cross-agent false-positives (Closes #1822)

### DIFF
--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -611,6 +611,46 @@ def _emit_admin_credential_read_allowed(
     write_audit("agent_admin_credential_read_allowed", agent or "unknown", detail)
 
 
+def _emit_admin_cross_agent_access_allowed(
+    agent: str,
+    *,
+    target: str,
+    intent: str,
+    sample: str = "",
+    tool_input: dict[str, Any] | None = None,
+) -> None:
+    """Audit an admin agent's Bash peer-home access carve-out (issue #1711
+    follow-up — read|write parity with the non-Bash ``protected_path_reason``
+    admin peer-home exemption).
+
+    Emitted on every grant of the admin Bash peer-home carve-out so the
+    operator keeps a full ledger of admin cross-agent file access. ``target``
+    is the matched peer-home alias / suffix, ``intent`` is ``read`` or
+    ``write`` (the latter is the parity this carve-out adds — an admin write to
+    a peer home no longer routes through the queue ONLY). Mirrors the
+    ``agent_admin_credential_read_allowed`` row shape so a single audit
+    consumer reads admin allow rows uniformly. Stage-A shared/secrets reads are
+    NOT routed here (they deny above for every agent including admin).
+    """
+    detail: dict[str, Any] = {
+        "tool": "Bash",
+        "target": _redact_credential_token_values(truncate_text(target, 200)),
+        "intent": intent,
+    }
+    if sample:
+        detail["sample"] = _redact_credential_token_values(truncate_text(sample, 200))
+    if tool_input is not None:
+        detail["summary"] = _redact_credential_summary(
+            tool_input_summary("Bash", tool_input)
+        )
+    elif sample:
+        detail["summary"] = {
+            "command": _redact_credential_token_values(truncate_text(sample, 240)),
+            "description": "",
+        }
+    write_audit("admin_cross_agent_access_allowed", agent or "unknown", detail)
+
+
 _NON_AGENT_ENTRIES: frozenset[str] = frozenset({
     # `shared` is the canonical symlink to BRIDGE_SHARED_DIR. Treating it
     # as a peer agent home used to collapse every shared-dir write into
@@ -863,6 +903,11 @@ _READ_INTENT_BASH_COMMANDS = frozenset(
         "stat",
         "file",
         "md5sum",
+        # macOS `md5` (issue #1822) — BSD checksum viewer, stdout-only like
+        # `md5sum`/`sha256sum`; `md5 -q <file>` / `md5 <file>` print the digest
+        # and have NO output-file / in-place flag, so a checksum read of a peer
+        # home / system-config file is no longer mis-classified write-intent.
+        "md5",
         "sha256sum",
         "sha1sum",
         "xxd",
@@ -4469,6 +4514,34 @@ def _forbidden_suffix_in_command(text: str, suffixes: list[str]) -> str | None:
     return None
 
 
+def _unwrap_balanced_backtick_path(word: str) -> str | None:
+    """If *word* is a single token wholly wrapped in a BALANCED pair of
+    backticks whose inner text is a literal path (no nested command-sub /
+    glob / further backtick), return the inner literal; else ``None``.
+
+    Issue #1822 FIX 1b: a backtick code-span like `` `~/.agent-bridge/shared/
+    wiki/index.md` `` reaching the obfuscation fail-close is, in these
+    contexts (single-quoted prose / assignment), a literal path reference, not
+    a live substitution. Unwrapping it lets the caller resolve the real inner
+    path and apply the normal containment test instead of fail-closing on the
+    empty prefix the leading backtick would carve out. Fail-safe: any token
+    that is NOT exactly ``` `…` ``` with a clean single-path interior returns
+    ``None`` so the conservative fail-close path is preserved.
+    """
+    if len(word) < 2 or word[0] != "`" or word[-1] != "`":
+        return None
+    inner = word[1:-1]
+    # The interior must contain no further backtick (would be a second span /
+    # unbalanced) and no nested command substitution.
+    if "`" in inner or "$(" in inner:
+        return None
+    # A single path token only — reject embedded whitespace (a real command
+    # like `` `ls -la` `` is not a path span we should unwrap-and-allow).
+    if not inner or any(ch.isspace() for ch in inner):
+        return None
+    return inner
+
+
 def _glob_prefix_reaches_forbidden_dir(word: str, suffixes: list[str]) -> bool:
     """For a glob / command-sub *word*, expand ``$VAR`` / ``~`` in the
     literal prefix BEFORE the first wildcard / command-sub char and decide
@@ -4476,13 +4549,37 @@ def _glob_prefix_reaches_forbidden_dir(word: str, suffixes: list[str]) -> bool:
 
     A forbidden directory is the absolute resolution of a forbidden suffix
     under the bridge home (``<home>/shared/secrets``, ``<home>/agents/
-    other-a``). The glob can reach it when the resolved prefix is a string
-    prefix of the forbidden dir (the wildcard sits at/above the protected
-    leaf, e.g. ``…/agents/oth*r-a``) OR the forbidden dir is a prefix of the
-    resolved prefix (the wildcard sits strictly INSIDE the forbidden tree).
+    other-a``). The glob can reach it only when its pattern COMPONENTS — a
+    bash glob's ``*``/``?``/``[…]`` never span a ``/`` separator — can
+    ``fnmatch`` the forbidden dir's path components. ``…/agents/oth*r-a``
+    reaches ``…/agents/other-a`` (component-wise match), a wildcard strictly
+    inside the tree (``…/shared/secrets/*``) reaches it (the leading
+    components match and the pattern is at least as deep), but a SHALLOW glob
+    such as ``<home>/*.sh`` does NOT — its single ``*`` component cannot match
+    the literal ``shared`` segment AND it is too shallow to even name the
+    depth-2 ``shared/secrets`` dir, so it is NOT denied (issue #1822: a
+    top-level ``grep <home>/*.sh`` was false-denied by the old bidirectional
+    ``startswith`` test, which treated any common string prefix as a reach).
     A read strictly inside the agent's OWN home (``…/agents/<self>/memory/
-    *.md``) resolves to a prefix that is neither, so it is NOT denied.
+    *.md``) does not component-match a peer / shared forbidden dir either.
+
+    Issue #1822 FIX 1b — balanced-backtick UNWRAP. A word that is wholly
+    wrapped in a balanced pair of backticks (`` `~/.agent-bridge/shared/wiki/
+    index.md` ``) is, in the contexts that reach here (a code-span inside a
+    single-quoted multi-line assignment / prose), NOT a live command
+    substitution — its content is a literal path reference. The bare-backtick
+    cut below would otherwise slice the prefix to empty (the first char is a
+    backtick) and fail closed, false-denying a benign ``shared/wiki`` mention.
+    When the backticks are balanced and the inner text is a single bridge-
+    anchored literal path with NO further command-sub / glob, we resolve that
+    inner path and re-run the SAME containment test on it: a ``shared/secrets``
+    /peer-home inner path still DENIES, a ``shared/wiki`` inner path is
+    correctly allowed. An UNbalanced backtick, or an inner text that itself
+    carries a `$(`/glob, is left to the conservative fail-close path below.
     """
+    unwrapped = _unwrap_balanced_backtick_path(word)
+    if unwrapped is not None:
+        word = unwrapped
     # First wildcard / command-sub position.
     cut = len(word)
     for i, ch in enumerate(word):
@@ -4490,20 +4587,37 @@ def _glob_prefix_reaches_forbidden_dir(word: str, suffixes: list[str]) -> bool:
             cut = i
             break
     prefix = word[:cut]
-    expanded = os.path.expandvars(os.path.expanduser(prefix))
-    if not expanded:
+    expanded_prefix = os.path.expandvars(os.path.expanduser(prefix))
+    if not expanded_prefix:
         return True  # un-resolvable prefix → fail closed
     # The caller only reaches here for a BRIDGE-ANCHORED word. If a `$VAR`
     # survived expansion (a shell var Python's environ cannot see), the
     # static prefix is inconclusive — fail closed rather than risk a
     # var-spelled glob into the secret tree (the broader carve-out gates use
     # the same "unresolved expansion → fail closed" stance, #1690 r4 FIX 2).
-    if "$" in expanded:
+    if "$" in expanded_prefix:
         return True
+    # Rebuild the full glob pattern (expanded literal prefix + the wildcard
+    # tail) so the component-wise fnmatch sees the wildcard, mirroring
+    # `_glob_word_hits_forbidden`'s containment model (issue #1822 FIX 2).
+    # A bare `$(`/backtick command-sub tail with no glob char leaves only the
+    # prefix to anchor on — `fnmatch` then degenerates to a literal
+    # component-equality check, which is the correct conservative stance.
+    pattern = os.path.normpath(expanded_prefix + word[cut:])
+    pat_parts = pattern.split(os.sep)
     bridge_home = str(bridge_home_dir())
     for suffix in suffixes:
-        forbidden_dir = f"{bridge_home}{suffix}"
-        if expanded.startswith(forbidden_dir) or forbidden_dir.startswith(expanded):
+        forbidden_dir = os.path.normpath(f"{bridge_home}{suffix}")
+        dir_parts = forbidden_dir.split(os.sep)
+        if len(pat_parts) < len(dir_parts):
+            # The pattern is too shallow to even name the forbidden dir
+            # (`<home>/*.sh` has fewer components than `<home>/shared/secrets`).
+            continue
+        # Equal depth → the glob selects the protected dir itself (an
+        # ls/find/grep -r enumerates it); deeper → it reads strictly inside.
+        # Both leak, so deny when every forbidden-dir component is fnmatched by
+        # the aligned pattern component.
+        if all(fnmatch.fnmatch(dp, pp) for pp, dp in zip(pat_parts, dir_parts)):
             return True
     return False
 
@@ -4569,6 +4683,35 @@ def _glob_word_hits_forbidden(
 # the fail-close path rejects. Surfaced in the deny message so the operator
 # can tell a suffix hit from an obfuscation fail-close.
 _OBFUSCATED_SUFFIX_SENTINEL = "(obfuscated path expansion)"
+
+
+def _obfuscation_sample(text: str) -> str:
+    """Return a short, bounded sample of the OFFENDING word(s) in *text* for an
+    obfuscation fail-close deny message (issue #1822).
+
+    The suffix matcher fails closed when a word carries a glob (`* ? [ ]`),
+    command-sub (`` ` ``/`$(`), or a surviving `$var` near a bridge anchor. We
+    surface up to two such bridge-anchored words (truncated) so the operator
+    can see WHAT was un-analyzable instead of being pointed at a fixed
+    secrets path that may not exist. Best-effort and never raises — a sampling
+    failure yields an empty string and the caller's base message stands.
+    """
+    try:
+        anchors = _bridge_anchor_tokens()
+        samples: list[str] = []
+        for word in text.split():
+            if not any(anchor in word for anchor in anchors):
+                continue
+            if any(ch in _OBFUSCATION_GLOB_CHARS for ch in word) \
+                    or "`" in word or "$(" in word or "$" in word:
+                samples.append(truncate_text(word, 60))
+                if len(samples) >= 2:
+                    break
+        if not samples:
+            return ""
+        return "(near: " + ", ".join(samples) + ")"
+    except Exception:  # noqa: BLE001 — diagnostics only, never block the deny
+        return ""
 
 
 def _command_path_candidate_words(segments: list[str]):
@@ -7689,6 +7832,19 @@ def protected_alias_reason(
     # Read path is tracked separately in #1711 and is NOT changed here).
     shared_suffix_hit = _forbidden_suffix_in_command(text, _shared_forbidden_suffixes())
     if shared_suffix_hit is not None:
+        # Issue #1822 — distinguish a REAL Stage-A secrets/private suffix match
+        # from an OBFUSCATION fail-close. The fixed "shared/private and
+        # shared/secrets" wording is only accurate when the matcher actually
+        # resolved a path into one of those trees; when it returns the
+        # obfuscation sentinel (an un-analyzable glob / command-sub / surviving
+        # `$var` near a protected tree) the deny is a fail-close, not a proven
+        # secrets read, and the operator should be told that instead of being
+        # misdirected to a secrets path that may not exist.
+        if shared_suffix_hit == _OBFUSCATED_SUFFIX_SENTINEL:
+            return (
+                "cross-agent access is blocked: un-analyzable path expression "
+                f"near a protected tree {_obfuscation_sample(text)}"
+            )
         return (
             "cross-agent access is blocked: shared/private and "
             "shared/secrets are off-limits"
@@ -7870,6 +8026,47 @@ def protected_alias_reason(
             matched_alias = f"cross-agent home ({peer_suffix_hit})"
 
     if matched_alias is None:
+        return None
+
+    # Issue #1711 follow-up — admin Bash peer-home WRITE parity. The non-Bash
+    # `protected_path_reason` already lets an admin Read/Write a peer agent
+    # home (`if admin: return None`), and #1692 added the admin Bash peer-home
+    # READ carve-out above. But an admin Bash WRITE to a peer home (a routine
+    # admin maintenance op — e.g. appending a doc note to a peer's CLAUDE.md)
+    # still fell through to the Stage-B peer deny, leaving an asymmetry between
+    # the Bash and non-Bash tool surfaces for the SAME admin. This carve-out
+    # closes it for admin ONLY, with the same fail-closed guards the #1692 read
+    # carve-out uses: no unresolved path expansion ($VAR/~/brace) and no shell
+    # embedding (`$(…)` / backtick / heredoc-into-interpreter / proc-sub) may be
+    # present, so an embedded mutation or a var-spelled sibling cannot ride the
+    # allow. Stage A (`shared/private|secrets`) is NOT reached here — it denied
+    # above for every agent including admin (#1692), so this only ever grants a
+    # PEER-HOME access, never a shared-secret one. A `read|write` intent audit
+    # row is emitted for every grant so the operator keeps a full ledger.
+    # Non-admin behavior is completely unchanged (this branch is admin-gated).
+    # The embedding guard is the strict `_command_has_shell_embedding`: ANY
+    # `$(…)` / backtick / proc-sub / heredoc — including a backtick code-span or
+    # a path inside a quoted-heredoc doc-note body — makes the command ineligible
+    # for the carve-out and DENIES. A heredoc-body strip was prototyped to
+    # suppress that narrow false positive (an admin
+    # `cat >> <peer>/CLAUDE.md <<'EOF' … `wiki path` … EOF`) but was dropped:
+    # proving a heredoc body is inert data vs executable requires fully parsing
+    # the shell pipeline and a distinct bypass surfaced at each layer, so the
+    # convenience strip is omitted (not stripping only ever DENIES more). The
+    # accepted workaround is to write such a doc-note with an editor/file tool
+    # instead of a Bash heredoc.
+    if (
+        admin
+        and not _has_unresolved_path_expansion(text)
+        and not _command_has_shell_embedding(text)
+    ):
+        _emit_admin_cross_agent_access_allowed(
+            agent,
+            target=matched_alias,
+            intent="read" if read_intent else "write",
+            sample=text,
+            tool_input=tool_input,
+        )
         return None
 
     if not (read_intent and current_agent_class() == "system"):

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -2659,6 +2659,64 @@ def _command_is_simple_inert_quoted_heredoc_write(command: str) -> bool:
     return re.search(r"\n" + re.escape(delimiter) + r"[ \t]*\Z", command) is not None
 
 
+def _inert_heredoc_cross_agent_scan_text(text: str) -> str | None:
+    """Return the reduced scan surface for the cross-agent (Stage A/B) gates
+    when *text* is the ONE provably-inert QUOTED-heredoc write shape (issue
+    #1822, codex re-review of PR #1838): the single-line command head with the
+    heredoc BODY and the proven-inert opener token removed. For every other
+    command return ``None`` — the caller scans the raw text, preserving
+    today's deny-leaning behavior unchanged.
+
+    Why excluding the body from word scanning cannot open a bypass:
+
+    - The strip happens ONLY when ``_command_is_simple_inert_quoted_heredoc_
+      write`` matches (#1574's airtight shape): a single ``cat``/``tee`` stage
+      whose head character classes EXCLUDE every chaining / substitution /
+      interpreter route (``&``, ``;``, ``|``, ``$``, backtick, ``(``, ``)``,
+      any ``<``/``>`` beyond the opener and a simple file redirect), a QUOTED
+      delimiter (``<<'EOF'`` / ``<<"EOF"`` — bash performs NO expansion on the
+      body; it is a pure literal fed to stdin), and the closing delimiter as
+      the last line (nothing can run after the body). An interpreter consumer
+      (``bash <<'EOF'``), a pipe route (``cat <<'EOF' | bash``), or a second
+      stage can never match — those bodies stay on the raw scan surface.
+    - ``cat``/``tee`` write stdin VERBATIM; they never treat body content as
+      a path to open. The only real filesystem targets are the head's
+      redirect target / file args, which REMAIN on the returned surface — a
+      write whose destination is a peer home or a forbidden shared tree still
+      hits the cross-agent gates exactly as before.
+    - An UNQUOTED (``<<EOF``) delimiter means bash DOES expand the body
+      (``$(…)``/``$var`` execute) — not the shape, no strip, body scanned.
+    - An UNBALANCED opener (no closing delimiter line) fails the shape's
+      end-anchored terminator check — no strip, fail closed.
+    - A body line EQUAL to the delimiter (the multi-EOF payload — bash ends
+      the heredoc at the FIRST such line and EXECUTES what follows) defeats
+      the end-anchored shape check, but ``_strip_heredoc_and_herestring_
+      body``'s first-terminator semantics then refuses the match, a newline
+      survives, and the ``"\\n" in stripped`` invariant below falls back to
+      the raw scan — the executed tail stays visible. Fail closed.
+    """
+    if not _command_is_simple_inert_quoted_heredoc_write(text):
+        return None
+    stripped = _strip_heredoc_and_herestring_body(text)
+    # Invariant: the inert shape is a one-line head + body + final terminator
+    # line, so a correct strip returns a single newline-FREE head ending in
+    # the (de-quoted) `<<DELIM` opener. Any surviving newline means the
+    # strip's first-terminator semantics disagreed with the shape check's
+    # end-anchored terminator (an in-body delimiter line → bash executes the
+    # remainder). Refuse to strip; the caller scans the raw text.
+    if "\n" in stripped:
+        return None
+    # Drop the trailing heredoc opener token so the embedding gate
+    # (`_command_has_shell_embedding`'s `<<` pattern) does not re-flag the
+    # proven-inert opener. The shape guarantees the opener is the LAST token
+    # of the head; everything else (leader, flags, redirect target, file
+    # args) stays on the scan surface.
+    head = re.sub(r"[ \t]*<<-?[A-Za-z_][A-Za-z0-9_]*[ \t]*\Z", "", stripped)
+    if head == stripped:
+        return None  # opener not in terminal position — fail closed
+    return head
+
+
 def _command_cd_base_dir(command: str) -> Path | None:
     """Resolve the working directory established by a leading ``cd`` stage.
 
@@ -7793,10 +7851,33 @@ def protected_alias_reason(
     if verb_deny is not None:
         return verb_deny
 
+    # Issue #1822 (codex re-review of PR #1838) — QUOTED-heredoc body data
+    # exclusion for the cross-agent gates below. When the command is the ONE
+    # provably-inert quoted-heredoc write shape (#1574's single `cat`/`tee`
+    # stage, quoted delimiter, terminator-last — see
+    # `_inert_heredoc_cross_agent_scan_text` for the full no-bypass
+    # argument), the heredoc body is pure literal DATA bash never expands and
+    # cat/tee never open as a path, so word-scanning it is a modeling error
+    # (the #1822 false-positive class: a doc-note body mentioning a bridge
+    # path / backtick code-span false-denied the whole command). The reduced
+    # surface keeps the ENTIRE command line — leader, flags, redirect target,
+    # file args — so a real cross-agent destination still denies; only the
+    # proven-data body (and the proven-inert opener token) is excluded. For
+    # every other command — unquoted/expanding delimiter, interpreter or pipe
+    # consumer, unbalanced marker, in-body delimiter line — this is None and
+    # the RAW text is scanned exactly as before (fail closed).
+    cross_scan = text
+    _inert_head = _inert_heredoc_cross_agent_scan_text(text)
+    if _inert_head is not None:
+        cross_scan = _inert_head
+
     # Issue #539 follow-up — Stage A: shared/private/ and shared/secrets/
     # are off-limits for every non-admin agent regardless of class.
     # Substring deny because the path can ride inside a heredoc body or
-    # a quoted blob the argv parser cannot surface as a clean token.
+    # a quoted blob the argv parser cannot surface as a clean token
+    # (`cross_scan` only ever differs from the raw text for the proven-inert
+    # quoted-heredoc DATA body above — every smuggle-capable body stays on
+    # the scan surface).
     #
     # Issue #1692 deliberately does NOT add an admin carve-out here. The
     # admin read-intent carve-out below covers PEER-HOME reads only; the
@@ -7811,7 +7892,7 @@ def protected_alias_reason(
     # check) — that over-permission is a separate follow-up, NOT the
     # parity target to copy into Bash.
     for forbidden_alias in _shared_forbidden_aliases():
-        if forbidden_alias in text:
+        if forbidden_alias in cross_scan:
             return (
                 "cross-agent access is blocked: shared/private and "
                 "shared/secrets are off-limits"
@@ -7830,7 +7911,9 @@ def protected_alias_reason(
     # secret/private subtrees stay off-limits for every Bash reader; the
     # admin asymmetry between Bash and the non-Bash `protected_path_reason`
     # Read path is tracked separately in #1711 and is NOT changed here).
-    shared_suffix_hit = _forbidden_suffix_in_command(text, _shared_forbidden_suffixes())
+    shared_suffix_hit = _forbidden_suffix_in_command(
+        cross_scan, _shared_forbidden_suffixes()
+    )
     if shared_suffix_hit is not None:
         # Issue #1822 — distinguish a REAL Stage-A secrets/private suffix match
         # from an OBFUSCATION fail-close. The fixed "shared/private and
@@ -7843,7 +7926,7 @@ def protected_alias_reason(
         if shared_suffix_hit == _OBFUSCATED_SUFFIX_SENTINEL:
             return (
                 "cross-agent access is blocked: un-analyzable path expression "
-                f"near a protected tree {_obfuscation_sample(text)}"
+                f"near a protected tree {_obfuscation_sample(cross_scan)}"
             )
         return (
             "cross-agent access is blocked: shared/private and "
@@ -8003,7 +8086,7 @@ def protected_alias_reason(
     # explained by a clean argv token whose resolved Path satisfies
     # `_system_class_cross_agent_read_allowed`.
     peer_aliases = _peer_alias_list(agent)
-    matched_alias = next((a for a in peer_aliases if a in text), None)
+    matched_alias = next((a for a in peer_aliases if a in cross_scan), None)
 
     # Issue #1709 — prefix-spelling-agnostic Stage-B peer-home matcher. The
     # `_peer_alias_list` substring needles share the same brace/`$BRIDGE_HOME`
@@ -8020,7 +8103,7 @@ def protected_alias_reason(
     # the correct stance for an un-analyzable spelling).
     if matched_alias is None and not admin:
         peer_suffix_hit = _forbidden_suffix_in_command(
-            text, _peer_forbidden_suffixes(agent)
+            cross_scan, _peer_forbidden_suffixes(agent)
         )
         if peer_suffix_hit is not None:
             matched_alias = f"cross-agent home ({peer_suffix_hit})"
@@ -8044,21 +8127,20 @@ def protected_alias_reason(
     # PEER-HOME access, never a shared-secret one. A `read|write` intent audit
     # row is emitted for every grant so the operator keeps a full ledger.
     # Non-admin behavior is completely unchanged (this branch is admin-gated).
-    # The embedding guard is the strict `_command_has_shell_embedding`: ANY
-    # `$(…)` / backtick / proc-sub / heredoc — including a backtick code-span or
-    # a path inside a quoted-heredoc doc-note body — makes the command ineligible
-    # for the carve-out and DENIES. A heredoc-body strip was prototyped to
-    # suppress that narrow false positive (an admin
-    # `cat >> <peer>/CLAUDE.md <<'EOF' … `wiki path` … EOF`) but was dropped:
-    # proving a heredoc body is inert data vs executable requires fully parsing
-    # the shell pipeline and a distinct bypass surfaced at each layer, so the
-    # convenience strip is omitted (not stripping only ever DENIES more). The
-    # accepted workaround is to write such a doc-note with an editor/file tool
-    # instead of a Bash heredoc.
+    # The guards run on `cross_scan`: for the ONE provably-inert quoted-heredoc
+    # write shape (#1574 / `_inert_heredoc_cross_agent_scan_text`) that is the
+    # command HEAD with the proven-DATA body and opener removed, so an admin
+    # doc-note `cat >> <peer>/CLAUDE.md <<'EOF' … `wiki path` … EOF` is
+    # eligible (the body is a literal bash never expands and cat/tee never
+    # open; the redirect target stays on the guard surface). For EVERY other
+    # command `cross_scan` IS the raw text and the embedding guard is the
+    # strict `_command_has_shell_embedding`: ANY `$(…)` / backtick / proc-sub
+    # / unquoted-or-unbalanced heredoc / interpreter-or-pipe-fed heredoc makes
+    # the command ineligible for the carve-out and DENIES (fail closed).
     if (
         admin
-        and not _has_unresolved_path_expansion(text)
-        and not _command_has_shell_embedding(text)
+        and not _has_unresolved_path_expansion(cross_scan)
+        and not _command_has_shell_embedding(cross_scan)
     ):
         _emit_admin_cross_agent_access_allowed(
             agent,

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -7436,6 +7436,15 @@ def _resolved_write_target_containment(target_word: str, agent: str) -> tuple[st
 _PEER_WRITE_SRC_DST_CMDS: frozenset[str] = frozenset({"mv", "cp"})
 _PEER_WRITE_DIR_CMDS: frozenset[str] = frozenset({"mkdir", "rmdir"})
 
+# Leaders that must NEVER ride the generic #1711 admin peer file-write parity
+# (`_admin_peer_write_targets_all_contained`): each has its OWN dedicated gate
+# whose narrower contract must remain the sole authority. `sqlite3` opens a DB
+# and is allowed ONLY against the EXACT task DB via the #1806 (3e) carve-out
+# (audited `admin_sqlite3_task_db`); a `sqlite3 <peer>/x.db` against any other
+# path must DENY (#1806 Tooth 8), so it must not be re-granted here as a generic
+# peer file write.
+_PEER_WRITE_EXCLUDED_LEADERS: frozenset[str] = frozenset({"sqlite3"})
+
 
 def _admin_peer_write_operands(text: str) -> tuple[str, list[str], list[str]] | None:
     """Extract ``(operation, source_words, dest_words)`` for a single
@@ -7476,6 +7485,143 @@ def _admin_peer_write_operands(text: str) -> tuple[str, list[str], list[str]] | 
             return None
         return leaf, [], list(positionals)
     return None
+
+
+def _admin_peer_write_targets_all_contained(
+    scan_text: str, agent: str
+) -> bool:
+    """Resolved-path containment gate for the admin Bash peer-home WRITE
+    parity carve-out (#1711 follow-up).
+
+    The carve-out grants a trusted-admin peer-home WRITE (a redirect/append
+    such as ``printf … >> <peer>/CLAUDE.md`` or the inert quoted-heredoc
+    doc-note ``cat >> <peer>/CLAUDE.md <<'EOF' … EOF``) whose mv/cp/mkdir/rmdir
+    operand shape the #1806 (3a) carve-out does NOT model. Substring-matching a
+    peer alias is NOT sufficient to authorize a MUTATION: a ``..`` traversal or
+    a symlinked parent (e.g. ``mv <peer> <peer>/../../../OUTSIDE/x`` or
+    ``mkdir <peer>/out-link/x``) names the peer alias as a substring yet
+    RESOLVES outside the bridge home / into a hard-denied tree. #1806 Tooth 7
+    proves this must DENY.
+
+    Returns True ONLY when ALL hold (else False → caller DENIES, fail closed):
+
+      - EVERY peer-/bridge-anchored path token in *scan_text* resolves (symlink
+        + ``..`` folded, via the SAME
+        :func:`_resolved_write_target_containment` resolver the #1806 (3a)
+        carve-out uses) to a location CONTAINED under the bridge home and
+        OUTSIDE shared/private, shared/secrets, and #341 protected-config. A
+        ``..`` traversal or a symlinked parent (#1806 Tooth 7:
+        ``mv <peer> <peer>/../../../OUTSIDE/x``, ``mkdir <peer>/out-link/x``)
+        names the peer alias as a SUBSTRING yet RESOLVES outside / into a denied
+        tree → containment returns None → False;
+      - the command references at least one peer home (so a benign same-home /
+        non-peer write is not mis-audited as a cross-agent write); AND
+      - the leader is NOT a command with its OWN dedicated carve-out / open
+        semantics — notably ``sqlite3`` (#1806 (3e): a sqlite3 open is allowed
+        ONLY against the EXACT task DB and is audited as
+        ``admin_sqlite3_task_db``; a ``sqlite3 <peer>/x.db`` against any other
+        path must DENY — #1806 Tooth 8 — and must NEVER be re-granted here as a
+        generic peer file write).
+
+    *scan_text* is the reduced ``cross_scan`` surface, so a proven-inert
+    quoted-heredoc DATA body never contributes a spurious target — only the real
+    head tokens (redirect target / file args) are checked. The caller has
+    already classified the command as write-intent (``not read_intent``) and
+    embedding-free, so this gate adds the missing RESOLVED-PATH containment
+    proof the substring `matched_alias` cannot give.
+    """
+    if _command_has_shell_embedding(scan_text):
+        return False
+    try:
+        tokens = shlex.split(scan_text, posix=True, comments=False)
+    except ValueError:
+        return False
+    if not tokens:
+        return False
+    # A leader with its own dedicated carve-out / open semantics must NOT ride
+    # the generic #1711 peer file-write parity (e.g. `sqlite3` routes through
+    # the #1806 (3e) exact-task-db carve-out only; anything else denies).
+    if tokens[0].rsplit("/", 1)[-1] in _PEER_WRITE_EXCLUDED_LEADERS:
+        return False
+    aliases = _peer_alias_list(agent)
+    anchors = _bridge_anchor_tokens()
+    # v2-split-install anchor spellings (`$BRIDGE_DATA_ROOT`, `${BRIDGE_AGENT_
+    # ROOT_V2}`, …) that `_resolved_write_target_containment` knows how to fold
+    # to a concrete peer v2 home (issue #1823). A `$BRIDGE_AGENT_ROOT_V2/<peer>/
+    # home/…` token carries NO literal `/agents/` substring, so the marker gate
+    # below must recognize the anchor NAME to treat it as a write-target
+    # candidate (otherwise a legitimate trusted-admin v2 peer write would be
+    # silently skipped and the carve-out would not fire).
+    v2_anchor_markers = tuple(
+        marker
+        for name in _V2_ANCHOR_NAMES
+        for marker in (f"${name}", f"${{{name}")
+    )
+
+    def _carries_bridge_marker(word: str) -> bool:
+        return bool(
+            any(a in word for a in aliases)
+            or any(anchor in word for anchor in anchors)
+            or any(m in word for m in v2_anchor_markers)
+            or "/agents/" in word
+            or "/shared/" in word
+        )
+
+    references_peer = False
+    checked_any = False
+    for tok in tokens:
+        if not tok or tok.startswith("-"):
+            continue
+        # Operator tokens shlex surfaces (`>`, `>>`, `<`, …) are not path words.
+        if re.fullmatch(r"[0-9]*(>>?|<<?)", tok):
+            continue
+        # A write-target candidate must be a single PLAUSIBLE PATH word: a clean
+        # leading filesystem/anchor spelling and no embedded whitespace or
+        # shell-program punctuation. This excludes a quote-stripped PROGRAM token
+        # (e.g. an awk body `BEGIN{print "x" > "<peer>/M.md"}`) that merely
+        # CONTAINS a peer path as a substring — the program's real file output is
+        # surfaced as the separate file-arg token, which IS resolved below. Such
+        # a program token is never fed to the path resolver (which would
+        # fail-close and false-DENY a legitimate in-program write whose file arg
+        # is itself a contained peer path).
+        # `{`/`}` are deliberately ALLOWED so a Bash PARAMETER-EXPANSION anchor
+        # spelling (`${BRIDGE_DATA_ROOT:-x}/<peer>/home/…`, issue #1823 r4) stays
+        # a path candidate that `_resolved_write_target_containment` can fold;
+        # an awk/program body is still excluded because it carries whitespace
+        # and/or quote chars (forbidden below). A `$(`/`)` command-sub or a
+        # backtick is already rejected by the leg's `_command_has_shell_
+        # embedding` pre-check.
+        looks_like_path = (
+            tok.startswith(("/", "~", "./", "../", "$"))
+            or any(anchor in tok for anchor in anchors)
+        ) and not any(ch in tok for ch in " \t()'\"`;|&")
+        if not looks_like_path:
+            # A skipped PROGRAM token (e.g. an awk body) may carry its OWN
+            # in-program output redirect to a path the file-arg scan never sees
+            # (`awk 'BEGIN{print "x" > "<escape>/leak"}' <peer>/M.md`). Resolve
+            # any embedded `>`/`>>` redirect TARGET inside such a token; an
+            # escape / forbidden-tree / un-analyzable in-program write target
+            # fails the gate (fail closed) so a contained file arg cannot
+            # whitewash an in-program write that lands outside containment.
+            for embedded in re.findall(
+                r">>?\s*['\"]?([^'\"\s>|&;]+)", tok
+            ):
+                if not _carries_bridge_marker(embedded):
+                    continue
+                if _resolved_write_target_containment(embedded, agent) is None:
+                    return False
+            continue
+        # Only path words that point at a peer home / bridge anchor / v2 anchor
+        # are write-target candidates; a bare data word (`plain`) is not.
+        if not _carries_bridge_marker(tok):
+            continue
+        checked_any = True
+        contained = _resolved_write_target_containment(tok, agent)
+        if contained is None:
+            return False  # escape / forbidden tree / un-analyzable → fail closed
+        if contained[1]:
+            references_peer = True
+    return checked_any and references_peer
 
 
 def _admin_sqlite3_task_db_audit(text: str, agent: str) -> str | None:
@@ -8090,18 +8236,29 @@ def protected_alias_reason(
 
     # Issue #1709 — prefix-spelling-agnostic Stage-B peer-home matcher. The
     # `_peer_alias_list` substring needles share the same brace/`$BRIDGE_HOME`
-    # gap as Stage-A: a non-admin (class=user) `cat
-    # ${HOME}/.agent-bridge/agents/<other>/MEMORY.md` matched NO alias and
-    # fell through to the `return None` ALLOW below. The suffix matcher
-    # (`/agents/<name>`) catches every prefix spelling and fail-closes on
-    # obfuscation. Scoped to NON-ADMIN only so admin Bash behavior is
-    # unchanged (the admin peer-read asymmetry between Bash and the non-Bash
-    # `protected_path_reason` Read path is #1711, out of scope here). A
-    # system-class agent that trips the suffix match still routes through
-    # the legitimate argv carve-out below (its brace-spelled path will fail
-    # the `_argv_occurrences_explain_text` proof and fail closed, which is
-    # the correct stance for an un-analyzable spelling).
-    if matched_alias is None and not admin:
+    # gap as Stage-A: a `cat ${HOME}/.agent-bridge/agents/<other>/MEMORY.md`
+    # matched NO alias and fell through to the `return None` ALLOW below. The
+    # suffix matcher (`/agents/<name>`) catches every prefix spelling and
+    # fail-closes on obfuscation.
+    #
+    # #1806 SPOOF GATE (regression fix, codex re-review of PR #1838): this match
+    # MUST run for admin too. The old `and not admin` scoping (added for the
+    # #1711 admin peer-READ Bash/non-Bash parity) left a SPOOFED-ADMIN peer
+    # WRITE bypass: a loose-admin (env-leg or SESSION-TYPE-leg, roster=non-admin)
+    # caller spelling the peer destination via `$BRIDGE_HOME`/`${BRIDGE_HOME}`
+    # matched NO `_peer_alias_list` alias, hit `matched_alias is None`, and
+    # returned ALLOW *before* the strict trusted_admin write leg could deny it
+    # (`printf x > $BRIDGE_HOME/agents/<peer>/MEMORY.md` ALLOWED while the
+    # absolute spelling DENIED). Running the suffix matcher for admin sets
+    # `matched_alias`, so the command routes through the admin carve-out legs
+    # below — and a `$BRIDGE_HOME`/brace spelling is an UNRESOLVED expansion, so
+    # BOTH the read leg and the write leg (each guarded by
+    # `not _has_unresolved_path_expansion(cross_scan)`) skip it and it DENIES
+    # (fail closed — the correct stance for an un-analyzable spelling, matching
+    # the non-admin path). A genuine admin peer access spelled absolutely / via
+    # `~`/`$HOME` already matched `_peer_alias_list` above, so its read carve-out
+    # / trusted write path is unchanged.
+    if matched_alias is None:
         peer_suffix_hit = _forbidden_suffix_in_command(
             cross_scan, _peer_forbidden_suffixes(agent)
         )
@@ -8137,15 +8294,51 @@ def protected_alias_reason(
     # strict `_command_has_shell_embedding`: ANY `$(…)` / backtick / proc-sub
     # / unquoted-or-unbalanced heredoc / interpreter-or-pipe-fed heredoc makes
     # the command ineligible for the carve-out and DENIES (fail closed).
+    #
+    # #1806 SPOOF GATE (regression fix): the WRITE leg of this carve-out is a
+    # cross-agent peer-home MUTATION, so — per #1806's invariant that every new
+    # peer-WRITE loosening gates on the STRICT, anti-spoof `trusted_admin`
+    # predicate, never on the spoofable `admin` OR-leg — a write only rides
+    # this allow when `trusted_admin` holds. A spoofer that exports
+    # `BRIDGE_ADMIN_AGENT_ID=<self>` and writes `session type: admin` into its
+    # own home flips loose `admin` True but NOT `trusted_admin` (the controller
+    # roster disagrees), so its peer `mkdir`/write stays DENIED. The READ leg
+    # keeps the looser `admin` gate — reads are lower risk and that is the
+    # pre-existing #1692 peer-read parity, unchanged here.
     if (
-        admin
+        read_intent
+        and admin
         and not _has_unresolved_path_expansion(cross_scan)
         and not _command_has_shell_embedding(cross_scan)
     ):
         _emit_admin_cross_agent_access_allowed(
             agent,
             target=matched_alias,
-            intent="read" if read_intent else "write",
+            intent="read",
+            sample=text,
+            tool_input=tool_input,
+        )
+        return None
+    # The WRITE leg deliberately does NOT pre-gate on
+    # `_has_unresolved_path_expansion`: a trusted-admin peer-home write may be
+    # spelled with a v2-anchor env var (`$BRIDGE_DATA_ROOT`/`$BRIDGE_HOME`,
+    # issue #1823) that `_admin_peer_write_targets_all_contained` RESOLVES to a
+    # concrete contained peer path (and audits). That helper is the resolved-
+    # path proof: it fails closed on ANY token it cannot reduce to a contained
+    # literal (an unresolved `$VAR`, a `..`/symlink escape, a forbidden tree, an
+    # in-program redirect escape), so an un-analyzable spelling still DENIES.
+    # The spoofed-admin `$BRIDGE_HOME` peer-write bypass is closed by the
+    # `trusted_admin` gate here, NOT by an expansion pre-check.
+    if (
+        not read_intent
+        and trusted_admin
+        and not _command_has_shell_embedding(cross_scan)
+        and _admin_peer_write_targets_all_contained(cross_scan, agent)
+    ):
+        _emit_admin_cross_agent_access_allowed(
+            agent,
+            target=matched_alias,
+            intent="write",
             sample=text,
             tool_input=tool_input,
         )

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -11923,6 +11923,21 @@ log "running v2-cross-class-read smoke (issue #583 closure)"
 log "v2-cross-class-read covers POSIX group + setgid permission boundary only — skips on macOS / no-sudo"
 bash "$REPO_ROOT/scripts/smoke/v2-cross-class-read.sh"
 
+# Issue #1822 — tool-policy cross-agent false-positive corrections. Drives
+# protected_alias_reason in an isolated fixture for the FOUR retained fixes:
+# balanced-backtick unwrap (Fix 1b), glob-depth component-wise fnmatch
+# (Fix 2), obfuscation deny-message (Fix 3), admin Bash peer-home write parity
+# + audit resolving the #1711 deferral (Fix 4), and macOS `md5` read-intent
+# (Fix 5). The quoted-heredoc body STRIP optimisation was dropped (operator
+# decision — proving a heredoc body is inert vs executable needs full
+# shell-pipeline parsing and a distinct bypass surfaced at each layer; not
+# stripping is strictly safer), so no strip / interpreter-stdin / wrapper-OPTION
+# behaviour is asserted. Deliberately does NOT cover v2 peer-home containment
+# (#1823, owned by PR #1831). Host-independent (no Linux/sudo dependency — gate
+# logic resolves from the BRIDGE_* fixture).
+log "running 1822-tool-policy-crossagent-falsepos smoke (issue #1822)"
+bash "$REPO_ROOT/scripts/smoke/1822-tool-policy-crossagent-falsepos.sh"
+
 # Issue #555 — per-agent settings.effective.json rendering for managed
 # (non-isolated) agents. Mixed-model installs no longer last-rerender-wins
 # on `autoCompactWindow` (or any future per-agent managed default).

--- a/scripts/smoke/1692-admin-bash-symmetry-strip.py
+++ b/scripts/smoke/1692-admin-bash-symmetry-strip.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# scripts/smoke/1692-admin-bash-symmetry-strip.py — revert-teeth helper for
+# the #1692 admin Bash read carve-out AND the #1711 admin Bash peer-home WRITE
+# parity carve-out.
+#
+# Produces a copy of hooks/tool-policy.py with BOTH admin peer-home carve-outs
+# removed, so the smoke can prove that the admin peer-home ALLOW verdicts
+# (read via #1692, write via #1711) are caused by those carve-outs and nothing
+# else: against the stripped copy an admin peer-home read AND write both flip
+# to DENY. Standalone file-as-argv (NO interpreter heredoc-stdin — footgun
+# #11).
+#
+# Two contiguous blocks are removed:
+#
+#   1. #1692 READ carve-out — from
+#        "    # Issue #1692 — admin read-intent carve-out for the Bash PEER-HOME"
+#      up to (not including)
+#        "    # Stage B: peer-agent-home substring deny"
+#      Runtime-guard sanity signature: "admin_peer_read_audited".
+#
+#   2. #1711 WRITE-parity carve-out — from
+#        "    # Issue #1711 follow-up — admin Bash peer-home WRITE parity."
+#      up to (not including)
+#        "    if not (read_intent and current_agent_class() == \"system\"):"
+#      Runtime-guard sanity signature: "_emit_admin_cross_agent_access_allowed("
+#      (the CALL site inside the block; the function DEFINITION elsewhere is
+#      left intact — stripping the call is what disables the carve-out).
+#
+# The Stage-A block also MENTIONS #1692/#1711 (it documents the deliberate
+# omission of an admin Stage-A carve-out), so each block is anchored on its own
+# header + the following structural marker rather than on the bare issue
+# number. If either block cannot be located, exit non-zero so the smoke fails
+# loudly rather than silently producing a no-op revert.
+
+import sys
+
+
+def _strip_block(src: str, start: str, end: str, what: str) -> str:
+    i = src.find(start)
+    j = src.find(end, i + 1 if i != -1 else 0)
+    if i == -1 or j == -1 or j < i:
+        sys.stderr.write(
+            f"could not locate {what} carve-out block to strip "
+            f"(start found={i != -1}, end found={j != -1})\n"
+        )
+        sys.exit(3)
+    return src[:i] + src[j:]
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        sys.stderr.write(
+            "usage: 1692-admin-bash-symmetry-strip.py <real_hook> <out>\n"
+        )
+        return 2
+    real, out = sys.argv[1], sys.argv[2]
+    with open(real, encoding="utf-8") as fh:
+        src = fh.read()
+
+    # Block 1 — #1692 admin READ carve-out.
+    src = _strip_block(
+        src,
+        "    # Issue #1692 — admin read-intent carve-out for the Bash PEER-HOME",
+        "    # Stage B: peer-agent-home substring deny",
+        "#1692 admin read",
+    )
+    if "admin_peer_read_audited" in src:
+        sys.stderr.write("#1692 read carve-out runtime guard still present after strip\n")
+        return 4
+
+    # Block 2 — #1711 admin WRITE-parity carve-out (the in-gate block, not the
+    # _emit_* function DEFINITION near the top of the module, which stays).
+    src = _strip_block(
+        src,
+        "    # Issue #1711 follow-up — admin Bash peer-home WRITE parity.",
+        '    if not (read_intent and current_agent_class() == "system"):',
+        "#1711 admin write-parity",
+    )
+    # Sanity-check on a CALL-site-unique fragment (the read/write intent
+    # selector argument) so the surviving function DEFINITION does not look
+    # like an un-stripped call.
+    if 'intent="read" if read_intent else "write"' in src:
+        sys.stderr.write(
+            "#1711 write-parity carve-out call site still present after strip\n"
+        )
+        return 5
+
+    with open(out, "w", encoding="utf-8") as fh:
+        fh.write(src)
+    print("[strip] removed #1692 read + #1711 write admin peer-home carve-outs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/1692-admin-bash-symmetry.sh
+++ b/scripts/smoke/1692-admin-bash-symmetry.sh
@@ -29,35 +29,45 @@
 #       for every allowed read, so a regression that returns None without
 #       auditing is caught.
 #
+#   ALLOW (#1711 follow-up — admin Bash peer-home WRITE parity, write-audited):
+#     - admin WRITE to a PEER home now ALLOWs and emits an
+#       `admin_cross_agent_access_allowed` audit row with intent=write,
+#       matching the non-Bash `protected_path_reason` admin peer-home
+#       exemption. Covers a plain redirect (`echo x > <peer>/MEMORY.md`) and
+#       the output-file readers (`sort -o`, `uniq IN OUT`, `yq -i`, awk
+#       in-program redirect) — none carry shell embedding or unresolved
+#       expansion, so the carve-out grants them. The parity is reached AFTER
+#       the Stage-A shared-forbidden deny and the shell-embedding guard, so it
+#       never grants a shared-secret write or an embedded mutation.
+#
 #   DENY (the teeth — must STILL be blocked):
-#     - admin read of `shared/private` / `shared/secrets` — the carve-out is
-#       peer-home only; the forbidden subtrees stay off-limits for admin.
-#     - admin WRITE-intent to a peer home (redirect) — the read carve-out
-#       must NOT grant writes.
-#     - admin read-intent leading verb that SMUGGLES a mutation via shell
-#       embedding (`cat $(…write…)`, `cat <(…)`, `cat <<EOF…`) or an output-
-#       file reader (`sort -o`, `uniq IN OUT`, `yq -i`, awk in-program
-#       redirect) — `read_intent` + the shell-embedding re-check fail closed.
-#     - admin read of a peer path spelled via an unresolved $HOME expansion —
+#     - admin read/write of `shared/private` / `shared/secrets` — the carve-out
+#       is peer-home only; the forbidden subtrees stay off-limits for admin.
+#     - admin leading verb that SMUGGLES a mutation via shell embedding
+#       (`cat $(…write…)`, `cat <(…)`, `cat <<EOF…`) — the embedding guard
+#       fails the write-parity carve-out closed (the mutation rides a `$(…)`
+#       / `<(…)` / here-string, not a plain peer-home write).
+#     - admin access to a peer path spelled via an unresolved $HOME expansion —
 #       fail closed (#1690 r4 FIX 2): the literal path never materializes for
 #       the substring gate.
-#     - NON-admin (class=user) read of a peer / shared path — the carve-out
-#       must not leak to ordinary agents.
+#     - NON-admin (class=user) read/write of a peer / shared path — neither
+#       carve-out leaks to ordinary agents.
 #
 #   SYSTEM-CLASS preserved + branch keys on is_admin_agent (not class):
 #     - a system-class NON-admin agent (BRIDGE_AGENT_CLASS_FOR_HOOK=system,
 #       no admin SESSION-TYPE) still gets its own Stage B read carve-out.
-#       This proves the new admin branch did not displace the independent
+#       This proves the new admin branches did not displace the independent
 #       system-class branch, and that admin is resolved via is_admin_agent,
 #       NOT via current_agent_class()=='system'.
 #
 #   Revert-teeth (GENUINE): the smoke builds a TEMPORARY copy of
-#   hooks/tool-policy.py with the admin carve-out stripped out, runs the
-#   admin peer-home read cases against it, and asserts they flip to DENY. If
-#   a future edit removed the carve-out from the real hook, this proof would
-#   still pass against the stripped copy — but the live ALLOW assertions
-#   above would fail. The combination means the smoke cannot pass without
-#   the fix.
+#   hooks/tool-policy.py with BOTH admin peer-home carve-outs (#1692 read +
+#   #1711 write) stripped out (via 1692-admin-bash-symmetry-strip.py), runs
+#   the admin peer-home read AND write cases against it, and asserts they flip
+#   to DENY. If a future edit removed either carve-out from the real hook, this
+#   proof would still pass against the stripped copy — but the live ALLOW
+#   assertions above would fail. The combination means the smoke cannot pass
+#   without both fixes.
 #
 # Footgun #11: the JSON stdin payload is built with `printf` (never an
 # interpreter here-string / heredoc-stdin) and piped into the hook with
@@ -129,28 +139,9 @@ printf -- '# operator-only key blob\n' >"$SHARED_SECRETS_DIR/key.md"
 # deny" comment that follows it). The stripped copy lives next to the real
 # hook so its sibling imports (bridge_hook_common) resolve identically.
 STRIPPED_HOOK="$SMOKE_REPO_ROOT/hooks/.tool-policy-1692-stripped-$$.py"
-"$PYTHON_BIN" - "$REAL_HOOK" "$STRIPPED_HOOK" <<'PY'
-import sys
-real, out = sys.argv[1], sys.argv[2]
-src = open(real, encoding="utf-8").read()
-# Unique signatures: the carve-out's leading comment line and the runtime
-# guard expression. The Stage-A block also MENTIONS #1692 (it documents the
-# deliberate omission), so we anchor on the carve-out's own header + the
-# following Stage-B comment, and sanity-check on the runtime guard string.
-start_marker = "    # Issue #1692 — admin read-intent carve-out for the Bash PEER-HOME"
-end_marker = "    # Stage B: peer-agent-home substring deny"
-guard_signature = "admin_peer_read_audited"
-i = src.find(start_marker)
-j = src.find(end_marker)
-if i == -1 or j == -1 or j < i:
-    sys.stderr.write("could not locate #1692 peer-home carve-out block to strip\n")
-    sys.exit(3)
-stripped = src[:i] + src[j:]
-if guard_signature in stripped:
-    sys.stderr.write("carve-out runtime guard still present after strip\n")
-    sys.exit(4)
-open(out, "w", encoding="utf-8").write(stripped)
-PY
+"$PYTHON_BIN" "$SCRIPT_DIR/1692-admin-bash-symmetry-strip.py" \
+  "$REAL_HOOK" "$STRIPPED_HOOK" \
+  || smoke_fail "could not build carve-out-stripped hook copy"
 "$PYTHON_BIN" -m py_compile "$STRIPPED_HOOK" \
   || smoke_fail "stripped hook copy did not compile"
 
@@ -247,6 +238,35 @@ assert_admin_read_allow_audited() {
   smoke_log "ok: ${label} -> ALLOW + audited"
 }
 
+# Issue #1711 follow-up — assert an ALLOWED admin peer-home WRITE ALSO emits an
+# `admin_cross_agent_access_allowed` audit row with intent=write (the
+# write-parity ledger invariant). Truncates the audit log first so the
+# assertion is scoped to this single decision. This is the parity #1692
+# deliberately deferred: an admin Bash write to a PEER home now matches the
+# non-Bash `protected_path_reason` admin peer-home exemption.
+assert_admin_write_allow_audited() {
+  local label="$1" command="$2"
+  : >"$BRIDGE_AUDIT_LOG"
+  local got
+  got="$(hook_verdict "$ADMIN_AGENT" "user" "$command" "$REAL_HOOK")"
+  if [[ "$got" != "ALLOW" ]]; then
+    smoke_log "FAIL: ${label}: verdict ${got}, want ALLOW"
+    smoke_log "      command: ${command}"
+    smoke_fail "${label}: expected ALLOW, got ${got}"
+  fi
+  if ! grep -q '"action": "admin_cross_agent_access_allowed"' "$BRIDGE_AUDIT_LOG" 2>/dev/null; then
+    smoke_log "FAIL: ${label}: ALLOW but no admin_cross_agent_access_allowed audit row"
+    smoke_log "      audit log: $(cat "$BRIDGE_AUDIT_LOG" 2>/dev/null || echo '<empty>')"
+    smoke_fail "${label}: missing write-parity audit row"
+  fi
+  if ! grep -q '"intent": "write"' "$BRIDGE_AUDIT_LOG" 2>/dev/null; then
+    smoke_log "FAIL: ${label}: write-parity audit row missing intent=write"
+    smoke_log "      audit log: $(cat "$BRIDGE_AUDIT_LOG" 2>/dev/null || echo '<empty>')"
+    smoke_fail "${label}: audit row intent mismatch"
+  fi
+  smoke_log "ok: ${label} -> ALLOW + write-audited"
+}
+
 echo "[smoke:${SMOKE_NAME}] real PreToolUse hook end-to-end"
 
 # ---------------------------------------------------------------------------
@@ -283,15 +303,20 @@ assert_hook_verdict \
   "cat $SHARED_SECRETS_DIR/key.md" \
   "DENY"
 
-# 2a. Admin WRITE-intent to a peer home — the read carve-out must NOT grant
-#     writes. A redirect is not read-intent, so it falls through to the deny.
-assert_hook_verdict \
-  "admin WRITE (redirect) to peer MEMORY.md stays denied" \
-  "$ADMIN_AGENT" "user" \
-  "echo pwned > $PEER_HOME/MEMORY.md" \
-  "DENY"
+# 2a. Admin WRITE-intent to a PEER home — issue #1711 follow-up resolves the
+#     write-parity gap #1692 deferred: an admin Bash redirect write to a peer
+#     home now ALLOWS (matching the non-Bash `protected_path_reason` admin
+#     peer-home exemption) and emits an `admin_cross_agent_access_allowed`
+#     audit row with intent=write. The shared/private + smuggle cases below
+#     still DENY, so the parity is scoped to plain peer-home writes only.
+assert_admin_write_allow_audited \
+  "admin WRITE (redirect) to peer MEMORY.md now allowed + write-audited (#1711)" \
+  "echo pwned > $PEER_HOME/MEMORY.md"
 
-# 2b. Admin WRITE-intent to a shared private path — also stays denied.
+# 2b. Admin WRITE-intent to a shared private path — STAYS DENIED. Stage-A
+#     shared/private|secrets is off-limits for every agent including admin
+#     (#1692 Option D); the #1711 write-parity carve-out is reached only AFTER
+#     the Stage-A deny, so it can never grant a shared-secret write.
 assert_hook_verdict \
   "admin WRITE (redirect) to shared private stays denied" \
   "$ADMIN_AGENT" "user" \
@@ -329,33 +354,30 @@ assert_hook_verdict \
   "cat $PEER_HOME/MEMORY.md ${HERESTRING_OP}\$(echo x)" \
   "DENY"
 
-# 2c'..2e'. Admin "reader" commands with an OUTPUT-FILE flag/positional or
-#          an in-program redirect write a peer/shared path with NO argv `>`
-#          token, so they classify as read-intent unless the read-intent
-#          classifier is hardened (codex SECURITY r2). Each must stay DENY.
-assert_hook_verdict \
-  "admin sort -o (output file) to peer stays denied" \
-  "$ADMIN_AGENT" "user" \
-  "sort -o $PEER_HOME/MEMORY.md $PEER_HOME/MEMORY.md" \
-  "DENY"
+# 2c'..2e'. Admin "reader" commands with an OUTPUT-FILE flag/positional or an
+#          in-program redirect (`sort -o`, `uniq IN OUT`, `yq -i`, `awk
+#          BEGIN{… > peer}`) WRITE a peer home with NO shell embedding /
+#          unresolved expansion. Under the #1711 write-parity carve-out these
+#          now ALLOW for ADMIN (a peer-home write the non-Bash surface already
+#          permits) and emit the write-audit row. The read-intent classifier
+#          hardening that flags them as write-intent (codex SECURITY r2) still
+#          governs the NON-admin / system-class paths (see 2f/2g below) — the
+#          parity only changes the ADMIN outcome.
+assert_admin_write_allow_audited \
+  "admin sort -o (output file) to peer now allowed + write-audited (#1711)" \
+  "sort -o $PEER_HOME/MEMORY.md $PEER_HOME/MEMORY.md"
 
-assert_hook_verdict \
-  "admin uniq IN OUT (2nd positional write) to peer stays denied" \
-  "$ADMIN_AGENT" "user" \
-  "uniq $PEER_HOME/MEMORY.md $PEER_HOME/MEMORY.md" \
-  "DENY"
+assert_admin_write_allow_audited \
+  "admin uniq IN OUT (2nd positional write) to peer now allowed + write-audited (#1711)" \
+  "uniq $PEER_HOME/MEMORY.md $PEER_HOME/MEMORY.md"
 
-assert_hook_verdict \
-  "admin yq -i (in-place edit) of peer stays denied" \
-  "$ADMIN_AGENT" "user" \
-  "yq -i . $PEER_HOME/MEMORY.md" \
-  "DENY"
+assert_admin_write_allow_audited \
+  "admin yq -i (in-place edit) of peer now allowed + write-audited (#1711)" \
+  "yq -i . $PEER_HOME/MEMORY.md"
 
-assert_hook_verdict \
-  "admin awk in-program redirect to peer stays denied" \
-  "$ADMIN_AGENT" "user" \
-  "awk 'BEGIN{print \"x\" > \"$PEER_HOME/MEMORY.md\"}' $PEER_HOME/MEMORY.md" \
-  "DENY"
+assert_admin_write_allow_audited \
+  "admin awk in-program redirect to peer now allowed + write-audited (#1711)" \
+  "awk 'BEGIN{print \"x\" > \"$PEER_HOME/MEMORY.md\"}' $PEER_HOME/MEMORY.md"
 
 # 2f. NON-admin (class=user) read of a peer home — carve-out must not leak.
 assert_hook_verdict \
@@ -440,10 +462,17 @@ revert_assert_deny() {
   fi
 }
 
-# Both cases are PEER-HOME reads that the real hook now ALLOWs for admin
-# (Group 1); against the stripped hook they must flip to DENY. (A shared/
-# private read would be DENY in both real and stripped — denied by Stage A
-# regardless — so it is NOT a valid revert-teeth flip and is not used here.)
+# PEER-HOME reads that the real hook ALLOWs for admin via the #1692 read
+# carve-out (Group 1); against the stripped hook (BOTH the #1692 read AND the
+# #1711 write carve-outs removed) they must flip to DENY. (A shared/private
+# read would be DENY in both real and stripped — denied by Stage A regardless
+# — so it is NOT a valid revert-teeth flip and is not used here.)
+#
+# NOTE: stripping ONLY the #1692 read block would NOT flip these to DENY now,
+# because the #1711 write-parity carve-out below it also allows admin
+# peer-home access (read or write) when there is no shell embedding /
+# unresolved expansion. The strip helper removes BOTH blocks so the revert
+# proof stays load-bearing for each.
 revert_assert_deny \
   "admin read of peer MEMORY.md" \
   "cat $PEER_HOME/MEMORY.md"
@@ -451,6 +480,18 @@ revert_assert_deny \
 revert_assert_deny \
   "admin read of peer memory/shared note" \
   "grep note $PEER_HOME/memory/shared/note.md"
+
+# PEER-HOME writes that the real hook now ALLOWs for admin via the #1711
+# write-parity carve-out; against the stripped hook (carve-out removed) they
+# must flip to DENY — the genuine revert proof that the write parity, not some
+# unrelated allow, is what grants these.
+revert_assert_deny \
+  "admin redirect write to peer MEMORY.md" \
+  "echo pwned > $PEER_HOME/MEMORY.md"
+
+revert_assert_deny \
+  "admin sort -o write to peer MEMORY.md" \
+  "sort -o $PEER_HOME/MEMORY.md $PEER_HOME/MEMORY.md"
 
 # Sanity: the stripped hook must still ALLOW the system-class read (its own
 # branch is untouched by stripping the admin carve-out) — confirms the

--- a/scripts/smoke/1692-admin-bash-symmetry.sh
+++ b/scripts/smoke/1692-admin-bash-symmetry.sh
@@ -126,6 +126,28 @@ mkdir -p "$PEER_HOME/memory/shared"
 printf -- '# peer memory fixture\n' >"$PEER_HOME/MEMORY.md"
 printf -- '# peer shared note\n' >"$PEER_HOME/memory/shared/note.md"
 
+# Controller-roster snapshot (the strict-predicate test seam). The #1711 admin
+# Bash peer-home WRITE parity is a cross-agent MUTATION, so — per #1806 — it
+# gates on the STRICT, anti-spoof `trusted_admin` predicate, never on the
+# spoofable loose `admin` OR-leg (an agent can write `session type: admin` into
+# its own home). Publish a controller roster naming `patch-1692` the admin
+# static role (every other fixture agent admin=false) and export
+# BRIDGE_ADMIN_AGENT_ID=patch-1692 so the genuine admin's peer-WRITE is trusted,
+# while the non-admin / system agents stay NON-admin and their peer writes stay
+# denied. Honored only because BRIDGE_HOME resolves under a temp prefix; inert
+# in production (see scripts/smoke/1806-admin-guard-allow-audit.sh seam proof).
+ROSTER_JSON="$SMOKE_TMP_ROOT/controller-roster.json"
+printf -- '%s\n' \
+  '[' \
+  "  {\"agent\": \"${ADMIN_AGENT}\", \"admin\": true, \"source\": \"static\"}," \
+  "  {\"agent\": \"${USER_AGENT}\", \"admin\": false, \"source\": \"static\"}," \
+  "  {\"agent\": \"${SYS_AGENT}\", \"admin\": false, \"source\": \"static\"}," \
+  "  {\"agent\": \"${PEER_AGENT}\", \"admin\": false, \"source\": \"static\"}" \
+  ']' \
+  >"$ROSTER_JSON"
+export BRIDGE_ADMIN_AGENT_ID="$ADMIN_AGENT"
+export BRIDGE_GUARD_ADMIN_ROSTER_JSON="$ROSTER_JSON"
+
 # Shared off-limits subtrees (private/ + secrets/) under $BRIDGE_HOME/shared.
 SHARED_PRIV_DIR="$BRIDGE_SHARED_DIR/private"
 SHARED_SECRETS_DIR="$BRIDGE_SHARED_DIR/secrets"

--- a/scripts/smoke/1822-tool-policy-crossagent-falsepos.py
+++ b/scripts/smoke/1822-tool-policy-crossagent-falsepos.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# scripts/smoke/1822-tool-policy-crossagent-falsepos.py — issue #1822
+# tool-policy cross-agent false-positive fixes.
+#
+# Loaded as a module-file (file-as-argv, NO interpreter heredoc-stdin —
+# footgun #11) by the `.sh` wrapper, which sets up an isolated BRIDGE_HOME
+# fixture (smoke/lib.sh::smoke_setup_bridge_home) with one peer agent home in
+# the legacy (`$BRIDGE_AGENT_HOME_ROOT/<peer>`) tree, plus a shared/wiki page
+# and a shared/secrets file.
+#
+# Scope: #1822 cross-agent FALSE-POSITIVE corrections ONLY, and ONLY the FOUR
+# fixes that shipped — the quoted-heredoc BODY STRIP optimisation was dropped
+# (operator decision after 5 review rounds: proving a heredoc body is inert
+# data vs executable needs full shell-pipeline parsing and a distinct bypass
+# surfaced at every layer; not stripping is strictly safer — it only ever
+# DENIES more). The narrow remaining false positive (an admin doc-note
+# `cat >> peer/CLAUDE.md <<'EOF' … `path` … EOF` whose body contains a
+# protected-tree word now DENIES) is accepted; the workaround is to write
+# doc-notes with an editor/file tool instead of a Bash heredoc. This driver
+# therefore asserts NONE of the removed strip's behaviour (no data-sink ALLOW,
+# no interpreter-stdin DENY, no wrapper-option DENY, no pipe-route DENY).
+#
+# The v2 peer-home CONTAINMENT gap is issue #1823, owned by PR #1831 (its smoke
+# coverage lives in scripts/smoke/1823-v2-peer-home-containment.sh); this driver
+# deliberately does NOT assert v2 peer-home enumeration / containment.
+#
+# Each assertion exercises one retained Fix against the real
+# `protected_alias_reason` entry point (or, for Fix 1b, its glob-containment
+# helper directly):
+#
+#   Fix 1b — balanced-backtick UNWRAP: a `` `…/shared/wiki/…` `` code-span word
+#       resolves to its literal and is NOT forbidden; a `` `…/shared/secrets/…`
+#       `` word still IS forbidden. (Unit-level on the glob helper, because the
+#       end-to-end backtick is otherwise dominated by the embedding guard.)
+#   Fix 2 — component-wise glob containment: `<bridge>/*.sh` is too shallow to
+#       reach the depth-2 shared/secrets dir -> ALLOW; `<bridge>/shared/*`
+#       reaches the secrets dir -> DENY.
+#   Fix 3 — obfuscation fail-close message names the offending word(s)
+#       (`un-analyzable path expression near a protected tree (near: …)`)
+#       instead of a fixed secrets path.
+#   Fix 4 — admin Bash peer-home WRITE parity (#1711 follow-up): admin write
+#       ALLOW + admin_cross_agent_access_allowed intent=write audit row; a
+#       NON-admin peer-home write stays DENY (no carve-out for non-admin).
+#   Fix 5 — macOS `md5` checksum read of a peer home (admin) -> ALLOW.
+#
+# Plus the one base invariant the admin carve-outs must not loosen:
+#   - a Stage-A shared/secrets read by ADMIN stays DENY (#1692 invariant).
+#
+# Exit 0 on all-pass; non-zero (with a [FAIL] line) on any mismatch.
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+
+
+def _load_tool_policy(repo_root: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(
+        "tp", repo_root / "hooks" / "tool-policy.py"
+    )
+    tp = importlib.util.module_from_spec(spec)
+    sys.modules["tp"] = tp
+    spec.loader.exec_module(tp)
+    return tp
+
+
+FAILURES: list[str] = []
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"[ok] {label}")
+    else:
+        FAILURES.append(f"{label}: {detail}")
+        print(f"[FAIL] {label}: {detail}")
+
+
+def is_deny(reason) -> bool:
+    return isinstance(reason, str) and reason != ""
+
+
+def _new_audit_rows(audit_log: pathlib.Path, before: int) -> list[dict]:
+    rows: list[dict] = []
+    if audit_log.exists():
+        with open(audit_log, encoding="utf-8") as fh:
+            fh.seek(before)
+            for line in fh:
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+    return rows
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(
+            "usage: 1822-tool-policy-crossagent-falsepos.py "
+            "<repo_root> <bridge_home> <data_root>",
+            file=sys.stderr,
+        )
+        return 2
+    repo_root = pathlib.Path(sys.argv[1])
+    bridge_home = pathlib.Path(sys.argv[2])
+    # data_root retained for wrapper signature compatibility; #1822 scope does
+    # NOT exercise the v2 data root (that is #1831's territory).
+    _data_root = pathlib.Path(sys.argv[3])
+
+    # The wrapper exports BRIDGE_ADMIN_AGENT_ID=admin and creates peer `worker`
+    # in the legacy root; `admin` is the admin agent, `worker` a non-admin peer.
+    admin = "admin"
+    peer = "worker"
+    nonadmin = "intruder"  # a non-admin agent writing at `worker`
+
+    legacy_peer = bridge_home / "agents" / peer
+    wiki = bridge_home / "shared" / "wiki" / "operating-rules.md"
+    secrets = bridge_home / "shared" / "secrets" / "token.txt"
+
+    tp = _load_tool_policy(repo_root)
+    audit_log = pathlib.Path(os.environ["BRIDGE_AUDIT_LOG"])
+
+    # --- Fix 1b: balanced-backtick UNWRAP. A word wholly wrapped in a balanced
+    #     pair of backticks whose interior is a single literal path resolves to
+    #     that interior; the helper then re-runs the SAME glob containment test.
+    #     A `shared/wiki` inner path is NOT forbidden; a `shared/secrets` inner
+    #     path IS. (Exercised on the glob helper directly: an end-to-end backtick
+    #     is dominated by the embedding guard, so the unwrap's job — keep a
+    #     benign `shared/wiki` code-span from fail-closing the obfuscation path —
+    #     is verified where it actually runs.)
+    check(
+        "Fix1b unwrap balanced backtick wiki path -> inner literal",
+        tp._unwrap_balanced_backtick_path(f"`{wiki}`") == str(wiki),
+        f"unwrap returned {tp._unwrap_balanced_backtick_path(f'`{wiki}`')!r}",
+    )
+    check(
+        "Fix1b unwrap rejects a backtick command (embedded space) -> None",
+        tp._unwrap_balanced_backtick_path("`ls -la`") is None,
+        "expected None for a non-path backtick span",
+    )
+    check(
+        "Fix1b unwrap rejects an UNbalanced backtick -> None",
+        tp._unwrap_balanced_backtick_path(f"`{wiki}") is None,
+        "expected None for an unbalanced backtick",
+    )
+    check(
+        "Fix1b backtick `shared/wiki` glob word NOT forbidden",
+        tp._glob_prefix_reaches_forbidden_dir(
+            f"`{wiki}`", tp._shared_forbidden_suffixes()
+        )
+        is False,
+        "wiki inner path should not reach a forbidden dir",
+    )
+    check(
+        "Fix1b backtick `shared/secrets` glob word IS forbidden",
+        tp._glob_prefix_reaches_forbidden_dir(
+            f"`{secrets}`", tp._shared_forbidden_suffixes()
+        )
+        is True,
+        "secrets inner path should reach the forbidden dir",
+    )
+
+    # --- Fix 2: top-level `<bridge>/*.sh` glob is too shallow to reach the
+    #     depth-2 shared/secrets dir -> ALLOW; `<bridge>/shared/*` reaches the
+    #     secrets dir at depth -> DENY.
+    r = tp.protected_alias_reason(f"grep -n foo {bridge_home}/*.sh", admin)
+    check(
+        "Fix2 admin top-level <bridge>/*.sh glob ALLOW",
+        not is_deny(r),
+        f"unexpected deny: {r!r}",
+    )
+    r = tp.protected_alias_reason(f"ls {bridge_home}/shared/*", admin)
+    check(
+        "Fix2 admin <bridge>/shared/* glob DENY (reaches secrets dir)",
+        is_deny(r),
+        f"expected deny, got: {r!r}",
+    )
+
+    # --- Fix 3: the obfuscation fail-close (a glob / command-sub / surviving
+    #     `$var` near a protected tree) now NAMES the offending word instead of
+    #     pointing at a fixed secrets path. A `shared/secr*` glob is
+    #     un-analyzable, so the deny message is the obfuscation form with a
+    #     `(near: …)` sample, NOT the literal "shared/private and shared/secrets"
+    #     wording.
+    r = tp.protected_alias_reason(
+        f"cat {bridge_home}/shared/secr*/token.txt", admin
+    )
+    check(
+        "Fix3 obfuscation deny message names the offending word",
+        is_deny(r)
+        and "un-analyzable path expression" in r
+        and "(near:" in r,
+        f"expected obfuscation message, got: {r!r}",
+    )
+
+    # --- Fix 4 (#1711 follow-up): admin Bash WRITE to a peer home -> ALLOW
+    #     + admin_cross_agent_access_allowed intent=write audit row.
+    before = audit_log.stat().st_size if audit_log.exists() else 0
+    write_cmd = f"printf 'plain\\n' >> {legacy_peer}/CLAUDE.md"
+    r = tp.protected_alias_reason(
+        write_cmd, admin, tool_input={"command": write_cmd}
+    )
+    check(
+        "Fix4 admin Bash write to peer home ALLOW",
+        not is_deny(r),
+        f"unexpected deny: {r!r}",
+    )
+    rows = _new_audit_rows(audit_log, before)
+    got_write_audit = any(
+        row.get("action") == "admin_cross_agent_access_allowed"
+        and (row.get("detail") or {}).get("intent") == "write"
+        for row in rows
+    )
+    check(
+        "Fix4 admin peer-home write emits admin_cross_agent_access_allowed "
+        "intent=write",
+        got_write_audit,
+        f"no matching audit row in {len(rows)} new rows",
+    )
+
+    # --- Fix 4 KEEP-teeth: NON-admin write to a peer home stays DENY (no write
+    #     carve-out exists for non-admin; only admin gets the #1711 parity).
+    r = tp.protected_alias_reason(
+        f"printf 'x\\n' >> {legacy_peer}/CLAUDE.md", nonadmin
+    )
+    check(
+        "Fix4 KEEP non-admin Bash write to peer home DENY",
+        is_deny(r),
+        f"expected deny, got: {r!r}",
+    )
+
+    # --- #1692 invariant: Stage-A secrets read by ADMIN stays DENY. The admin
+    #     carve-outs only ever grant a PEER-HOME access, never a shared-secret
+    #     one (Stage A denies above for every agent including admin).
+    r = tp.protected_alias_reason(f"cat {secrets}", admin)
+    check(
+        "StageA admin direct secrets read DENY (#1692 invariant kept)",
+        is_deny(r),
+        f"expected deny, got: {r!r}",
+    )
+
+    # --- Fix 5: macOS `md5` checksum read of a peer home (admin) -> ALLOW.
+    r = tp.protected_alias_reason(f"md5 -q {legacy_peer}/MEMORY.md", admin)
+    check(
+        "Fix5 admin `md5 -q` peer read ALLOW (read-intent)",
+        not is_deny(r),
+        f"unexpected deny: {r!r}",
+    )
+
+    if FAILURES:
+        print(f"\n[smoke:1822] {len(FAILURES)} assertion(s) FAILED")
+        return 1
+    print("\n[smoke:1822] PASS — all retained tool-policy cross-agent fixes verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/1822-tool-policy-crossagent-falsepos.py
+++ b/scripts/smoke/1822-tool-policy-crossagent-falsepos.py
@@ -8,17 +8,17 @@
 # the legacy (`$BRIDGE_AGENT_HOME_ROOT/<peer>`) tree, plus a shared/wiki page
 # and a shared/secrets file.
 #
-# Scope: #1822 cross-agent FALSE-POSITIVE corrections ONLY, and ONLY the FOUR
-# fixes that shipped — the quoted-heredoc BODY STRIP optimisation was dropped
-# (operator decision after 5 review rounds: proving a heredoc body is inert
-# data vs executable needs full shell-pipeline parsing and a distinct bypass
-# surfaced at every layer; not stripping is strictly safer — it only ever
-# DENIES more). The narrow remaining false positive (an admin doc-note
-# `cat >> peer/CLAUDE.md <<'EOF' … `path` … EOF` whose body contains a
-# protected-tree word now DENIES) is accepted; the workaround is to write
-# doc-notes with an editor/file tool instead of a Bash heredoc. This driver
-# therefore asserts NONE of the removed strip's behaviour (no data-sink ALLOW,
-# no interpreter-stdin DENY, no wrapper-option DENY, no pipe-route DENY).
+# Scope: #1822 cross-agent FALSE-POSITIVE corrections ONLY — the four original
+# fixes PLUS the quoted-heredoc BODY exclusion (Fix 6, codex re-review of PR
+# #1838). The body exclusion reuses #1574's provably-inert shape
+# (`_command_is_simple_inert_quoted_heredoc_write`: single cat/tee stage, NO
+# shell metachars in the head, QUOTED delimiter, terminator-last) via
+# `_inert_heredoc_cross_agent_scan_text`, which strips the proven-DATA body
+# from the cross-agent scan surface while keeping the WHOLE command line
+# (redirect target included) scanned. Everything that is not that one shape —
+# unquoted/expanding delimiter, interpreter consumer, pipe route, unbalanced
+# marker, in-body delimiter line — falls back to the raw scan (fail closed),
+# and this driver carries DENY teeth for each of those routes.
 #
 # The v2 peer-home CONTAINMENT gap is issue #1823, owned by PR #1831 (its smoke
 # coverage lives in scripts/smoke/1823-v2-peer-home-containment.sh); this driver
@@ -42,6 +42,13 @@
 #       ALLOW + admin_cross_agent_access_allowed intent=write audit row; a
 #       NON-admin peer-home write stays DENY (no carve-out for non-admin).
 #   Fix 5 — macOS `md5` checksum read of a peer home (admin) -> ALLOW.
+#   Fix 6 — quoted-heredoc BODY exclusion (codex re-review of PR #1838):
+#       a QUOTED-delimiter inert cat/tee heredoc body is pure data — a peer
+#       home path inside it no longer denies (admin doc-note ALLOW + write
+#       audit; non-admin own-file write ALLOW) — while every smuggle route
+#       stays DENY: unquoted delimiter, unbalanced marker, interpreter-fed
+#       stdin, pipe route, multi-EOF payload, and a protected redirect TARGET
+#       (peer home for non-admin, shared/secrets for everyone).
 #
 # Plus the one base invariant the admin carve-outs must not loosen:
 #   - a Stage-A shared/secrets read by ADMIN stays DENY (#1692 invariant).
@@ -245,6 +252,122 @@ def main() -> int:
         "Fix5 admin `md5 -q` peer read ALLOW (read-intent)",
         not is_deny(r),
         f"unexpected deny: {r!r}",
+    )
+
+    # --- Fix 6: QUOTED-heredoc BODY exclusion (codex re-review of PR #1838).
+    #     A quoted-delimiter inert cat/tee heredoc body is pure DATA bash never
+    #     expands and cat/tee never open as a path, so a protected-tree word
+    #     inside the body must NOT deny — while the redirect TARGET and every
+    #     smuggle route stay scanned (fail closed). `intruder` is a non-admin
+    #     peer; `worker` (alias `legacy_peer`) is a different peer home; the
+    #     driver runs as `worker`, so `intruder_home` is the caller's OWN tree.
+    NL = chr(10)
+    intruder_home = bridge_home / "agents" / nonadmin
+
+    # 6a — the LIVE repro: admin doc-note `cat >> <peer>/CLAUDE.md <<'EOF' …
+    #      <a path> … EOF`. Body mentions a peer path; redirect target is a peer
+    #      home (admin write parity, #1711) -> ALLOW + intent=write audit row.
+    before = audit_log.stat().st_size if audit_log.exists() else 0
+    a6 = (
+        f"cat >> {legacy_peer}/CLAUDE.md <<'EOF'{NL}"
+        f"see {legacy_peer}/MEMORY.md for context{NL}EOF"
+    )
+    r = tp.protected_alias_reason(a6, admin, tool_input={"command": a6})
+    check(
+        "Fix6a admin quoted-heredoc peer doc-note (body has path) ALLOW",
+        not is_deny(r),
+        f"unexpected deny (the #1838 live false-positive): {r!r}",
+    )
+    rows = _new_audit_rows(audit_log, before)
+    check(
+        "Fix6a admin quoted-heredoc write emits "
+        "admin_cross_agent_access_allowed intent=write",
+        any(
+            row.get("action") == "admin_cross_agent_access_allowed"
+            and (row.get("detail") or {}).get("intent") == "write"
+            for row in rows
+        ),
+        f"no matching write audit row in {len(rows)} new rows",
+    )
+
+    # 6b — non-admin write to OWN file, quoted-heredoc body mentions a PEER home
+    #      path. Pre-fix the body word false-denied; the exclusion makes it
+    #      ALLOW (the body is data, the OWN-file redirect target is not a peer).
+    b6 = (
+        f"cat >> {intruder_home}/MEMORY.md <<'EOF'{NL}"
+        f"reminder: {legacy_peer}/CLAUDE.md exists{NL}EOF"
+    )
+    r = tp.protected_alias_reason(b6, nonadmin, tool_input={"command": b6})
+    check(
+        "Fix6b non-admin quoted-heredoc OWN-file write (peer path in body) "
+        "ALLOW",
+        not is_deny(r),
+        f"unexpected deny: {r!r}",
+    )
+
+    # 6c TEETH — UNQUOTED delimiter: bash EXPANDS the body, so it is NOT data;
+    #      no strip, the peer path in the body is scanned and DENIES.
+    c6 = (
+        f"cat >> {intruder_home}/MEMORY.md <<EOF{NL}"
+        f"see {legacy_peer}/CLAUDE.md{NL}EOF"
+    )
+    r = tp.protected_alias_reason(c6, nonadmin, tool_input={"command": c6})
+    check(
+        "Fix6c TEETH non-admin UNQUOTED heredoc (peer path in body) DENY",
+        is_deny(r),
+        f"expected deny (expanding body must be scanned), got: {r!r}",
+    )
+
+    # 6d TEETH — UNBALANCED marker (no closing delimiter line): fails the
+    #      shape's terminator check, no strip, fail closed -> DENY.
+    d6 = (
+        f"cat >> {intruder_home}/MEMORY.md <<'EOF'{NL}"
+        f"see {legacy_peer}/CLAUDE.md{NL}NOTEOF"
+    )
+    r = tp.protected_alias_reason(d6, nonadmin, tool_input={"command": d6})
+    check(
+        "Fix6d TEETH non-admin UNBALANCED heredoc marker DENY (fail closed)",
+        is_deny(r),
+        f"expected deny (unbalanced marker), got: {r!r}",
+    )
+
+    # 6e TEETH — multi-EOF payload: bash ends the heredoc at the FIRST `EOF`
+    #      line and EXECUTES the tail. The shape's end-anchored check + the
+    #      strip's first-terminator semantics disagree, the surviving newline
+    #      invariant falls back to the raw scan, and the executed tail (a peer
+    #      read) stays visible -> DENY.
+    e6 = (
+        f"cat >> {intruder_home}/MEMORY.md <<'EOF'{NL}"
+        f"body{NL}EOF{NL}cat {legacy_peer}/CLAUDE.md{NL}EOF"
+    )
+    r = tp.protected_alias_reason(e6, nonadmin, tool_input={"command": e6})
+    check(
+        "Fix6e TEETH non-admin multi-EOF payload (peer read in tail) DENY",
+        is_deny(r),
+        f"expected deny (executed tail must stay visible), got: {r!r}",
+    )
+
+    # 6f TEETH — quoted-heredoc whose redirect TARGET is a PEER home (non-admin).
+    #      The body is excluded but the target stays on the scan surface, so a
+    #      cross-agent WRITE destination still DENIES.
+    f6 = f"cat >> {legacy_peer}/CLAUDE.md <<'EOF'{NL}hi{NL}EOF"
+    r = tp.protected_alias_reason(f6, nonadmin, tool_input={"command": f6})
+    check(
+        "Fix6f TEETH non-admin quoted-heredoc TARGET=peer home DENY",
+        is_deny(r),
+        f"expected deny (redirect target stays scanned), got: {r!r}",
+    )
+
+    # 6g TEETH — quoted-heredoc whose redirect TARGET is shared/secrets (admin).
+    #      Stage-A is off-limits for EVERY agent including admin (#1692
+    #      invariant); the body exclusion must not loosen it -> DENY.
+    g6 = f"cat >> {secrets} <<'EOF'{NL}hi{NL}EOF"
+    r = tp.protected_alias_reason(g6, admin, tool_input={"command": g6})
+    check(
+        "Fix6g TEETH admin quoted-heredoc TARGET=shared/secrets DENY "
+        "(#1692 Stage-A kept)",
+        is_deny(r),
+        f"expected deny (Stage-A invariant), got: {r!r}",
     )
 
     if FAILURES:

--- a/scripts/smoke/1822-tool-policy-crossagent-falsepos.sh
+++ b/scripts/smoke/1822-tool-policy-crossagent-falsepos.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# scripts/smoke/1822-tool-policy-crossagent-falsepos.sh — issue #1822.
+#
+# Sets up an isolated BRIDGE_HOME fixture with ONE peer agent (`worker`) in the
+# legacy (`$BRIDGE_AGENT_HOME_ROOT/worker`) tree, plus a shared/wiki page and a
+# shared/secrets file, then drives the cross-agent gate assertions in the
+# companion Python module-file (file-as-argv — NO heredoc-stdin to a
+# subprocess, footgun #11). Covers the FOUR retained #1822 false-positive
+# corrections only — balanced-backtick unwrap (Fix 1b), component-wise glob
+# containment (Fix 2), obfuscation message (Fix 3), admin Bash WRITE parity
+# #1711 (Fix 4), and md5 read-intent (Fix 5). The quoted-heredoc body STRIP
+# optimisation was dropped (operator decision), so this driver asserts NONE of
+# its behaviour.
+#
+# Scope: #1822 false positives ONLY. The v2 peer-home CONTAINMENT gap is issue
+# #1823, owned by PR #1831 — its coverage lives in
+# scripts/smoke/1823-v2-peer-home-containment.sh and is NOT duplicated here.
+#
+# Host-independent: no Linux/sudo/iso requirement — the gate logic resolves
+# entirely from the exported BRIDGE_* fixture paths, so this runs on macOS and
+# Linux alike (unlike the OS-permission `v2-cross-class-read.sh`).
+
+set -euo pipefail
+
+SMOKE_NAME="1822-tool-policy-crossagent-falsepos"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+trap smoke_cleanup_temp_root EXIT INT TERM
+
+# Isolated v2 layout: exports BRIDGE_HOME, BRIDGE_AGENT_HOME_ROOT,
+# BRIDGE_DATA_ROOT, BRIDGE_AGENT_ROOT_V2, BRIDGE_AUDIT_LOG, etc.
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+PEER="worker"
+
+# Legacy peer home (the tree the cross-agent gate covers).
+mkdir -p "$BRIDGE_AGENT_HOME_ROOT/$PEER"
+: >"$BRIDGE_AGENT_HOME_ROOT/$PEER/CLAUDE.md"
+: >"$BRIDGE_AGENT_HOME_ROOT/$PEER/MEMORY.md"
+
+# Shared trees referenced by the assertions.
+mkdir -p "$BRIDGE_SHARED_DIR/wiki" "$BRIDGE_SHARED_DIR/secrets"
+: >"$BRIDGE_SHARED_DIR/wiki/operating-rules.md"
+: >"$BRIDGE_SHARED_DIR/secrets/token.txt"
+
+# A couple of top-level *.sh files so the `<bridge>/*.sh` glob has real targets.
+: >"$BRIDGE_HOME/bridge-core.sh"
+: >"$BRIDGE_HOME/bridge-tmux.sh"
+
+# admin id for the carve-out gates; the calling agent class for the driver's
+# non-admin paths is the default ("user").
+export BRIDGE_ADMIN_AGENT_ID="admin"
+# Ensure the hook resolves HOME-anchored aliases against the fixture, not the
+# operator's real $HOME.
+export HOME="$BRIDGE_HOME"
+
+smoke_log "fixture: BRIDGE_HOME=$BRIDGE_HOME peer=$PEER (legacy tree)"
+
+OUT="$(BRIDGE_AGENT_ID="$PEER" PYTHONPATH="$SMOKE_REPO_ROOT/hooks" \
+  python3 "$SCRIPT_DIR/1822-tool-policy-crossagent-falsepos.py" \
+    "$SMOKE_REPO_ROOT" "$BRIDGE_HOME" "$BRIDGE_DATA_ROOT" 2>&1)" || {
+  printf '%s\n' "$OUT" >&2
+  smoke_fail "tool-policy cross-agent assertions FAILED"
+}
+printf '%s\n' "$OUT"
+smoke_assert_contains "$OUT" "[smoke:1822] PASS" "tool-policy cross-agent fixes"
+
+smoke_log "PASS — #1822 cross-agent false-positive corrections verified"

--- a/scripts/smoke/1822-tool-policy-crossagent-falsepos.sh
+++ b/scripts/smoke/1822-tool-policy-crossagent-falsepos.sh
@@ -57,6 +57,25 @@ export BRIDGE_ADMIN_AGENT_ID="admin"
 # operator's real $HOME.
 export HOME="$BRIDGE_HOME"
 
+# Controller-roster snapshot (the strict-predicate test seam). The #1711 admin
+# Bash peer-home WRITE parity (Fix 4 / Fix 6a) is a cross-agent MUTATION, so —
+# per #1806 — it gates on the STRICT `trusted_admin` predicate, not the
+# spoofable loose `admin` OR-leg. Inject a controller-published roster naming
+# `admin` as the admin static role (and the peers as non-admin) so the genuine
+# admin's peer-WRITE is trusted; a SESSION-TYPE/env-only spoofer with no such
+# roster row stays NON-admin and its peer write is DENIED (covered end-to-end by
+# scripts/smoke/1806-admin-guard-allow-audit.sh Tooth 1). Honored only because
+# BRIDGE_HOME resolves under a temp prefix; inert in production.
+ROSTER_JSON="$SMOKE_TMP_ROOT/controller-roster.json"
+printf -- '%s\n' \
+  '[' \
+  '  {"agent": "admin", "admin": true, "source": "static"},' \
+  '  {"agent": "worker", "admin": false, "source": "static"},' \
+  '  {"agent": "intruder", "admin": false, "source": "dynamic"}' \
+  ']' \
+  >"$ROSTER_JSON"
+export BRIDGE_GUARD_ADMIN_ROSTER_JSON="$ROSTER_JSON"
+
 smoke_log "fixture: BRIDGE_HOME=$BRIDGE_HOME peer=$PEER (legacy tree)"
 
 OUT="$(BRIDGE_AGENT_ID="$PEER" PYTHONPATH="$SMOKE_REPO_ROOT/hooks" \

--- a/scripts/smoke/1822-tool-policy-crossagent-falsepos.sh
+++ b/scripts/smoke/1822-tool-policy-crossagent-falsepos.sh
@@ -5,12 +5,13 @@
 # legacy (`$BRIDGE_AGENT_HOME_ROOT/worker`) tree, plus a shared/wiki page and a
 # shared/secrets file, then drives the cross-agent gate assertions in the
 # companion Python module-file (file-as-argv — NO heredoc-stdin to a
-# subprocess, footgun #11). Covers the FOUR retained #1822 false-positive
-# corrections only — balanced-backtick unwrap (Fix 1b), component-wise glob
-# containment (Fix 2), obfuscation message (Fix 3), admin Bash WRITE parity
-# #1711 (Fix 4), and md5 read-intent (Fix 5). The quoted-heredoc body STRIP
-# optimisation was dropped (operator decision), so this driver asserts NONE of
-# its behaviour.
+# subprocess, footgun #11). Covers the #1822 false-positive corrections —
+# balanced-backtick unwrap (Fix 1b), component-wise glob containment (Fix 2),
+# obfuscation message (Fix 3), admin Bash WRITE parity #1711 (Fix 4), md5
+# read-intent (Fix 5), and the QUOTED-heredoc BODY exclusion (Fix 6, codex
+# re-review of PR #1838). Fix 6 carries DENY teeth for every smuggle route the
+# body exclusion must NOT open: unquoted/expanding delimiter, unbalanced
+# marker, multi-EOF payload, and a protected redirect TARGET.
 #
 # Scope: #1822 false positives ONLY. The v2 peer-home CONTAINMENT gap is issue
 # #1823, owned by PR #1831 — its coverage lives in


### PR DESCRIPTION
# hooks: fix tool-policy cross-agent false-positives

**Closes #1822.** Complementary to #1831 (which Closes #1823, v2 peer-home containment); this PR deliberately does **not** touch peer-home v2 enumeration — `other_agent_homes`, `_peer_alias_list`, and `_forbidden_dirs_for_suffixes` are byte-identical to the v0.16.9 base.

## Problem

The PreToolUse cross-agent gate in `hooks/tool-policy.py` had several false-positive classes that blocked legitimate admin fleet maintenance via `Bash`:

- **Glob over-match.** Cross-agent containment used bidirectional `startswith`, so a benign top-level `<bridge>/*.sh` glob and a protected `<bridge>/shared/*` glob were treated alike — a routine `grep <bridge>/*.sh` was false-denied.
- **Backtick code-span fail-close.** A `` `~/.agent-bridge/shared/wiki/index.md` `` code-span word reaching the glob obfuscation fail-close was sliced to an empty prefix by the leading backtick and denied, even though its interior is a literal `shared/wiki` path.
- **Unhelpful obfuscation message.** A glob / command-sub / `$var` fail-close pointed the operator at a fixed `shared/private and shared/secrets` path that might not exist, rather than at the un-analyzable word.
- **Admin Bash write asymmetry.** The non-Bash `protected_path_reason` already lets an admin write a peer home, but an admin `Bash` write to a peer home (routine maintenance) still fell through to the peer deny — the long-deferred #1711 gap.
- **`md5` mis-classified as write-intent.** macOS `md5` (stdout-only) was not in the read-intent set, so a checksum read of a peer/system-config file was mis-gated.

## Fix

Four targeted, defense-in-depth corrections; the non-admin deny surface is unchanged-or-tighter:

1. **Component-wise glob containment + balanced-backtick unwrap.** Bidirectional `startswith` is replaced with per-component `fnmatch` (a bash glob's `*`/`?`/`[…]` never spans `/`), so `<bridge>/*.sh` is too shallow to name the depth-2 `shared/secrets` dir and is ALLOWED, while any glob that can actually select a protected dir (`<bridge>/shared/*`, `…/agents/oth*r-a`) is DENIED. A word wholly wrapped in a balanced backtick pair whose interior is a single literal path (`` `…/shared/wiki/…` ``) is unwrapped to that literal and re-tested for containment before the fail-close — a `shared/secrets` inner path still DENIES, a `shared/wiki` inner path allows.
2. **Obfuscation deny-message names the offending word.** When the suffix matcher fails closed on an un-analyzable glob / command-sub / surviving `$var` near a bridge anchor, the deny now reads `un-analyzable path expression near a protected tree (near: <word>)` instead of misdirecting the operator to a fixed secrets path.
3. **Admin Bash write parity (resolves the #1711 deferral).** Admin peer-home `Bash` writes ALLOW and emit `admin_cross_agent_access_allowed intent=write`, reached **only after** the Stage-A forbidden-tree deny and the strict `_command_has_shell_embedding` guard — so `$()` / `<()` / `<<<` smuggles and `shared/private|secrets` writes still DENY for admin. The non-admin path is byte-unchanged.
4. **`md5` read-intent.** macOS `md5` (stdout-only) added next to `md5sum`; it has no output-file/in-place flag, so it cannot be abused as a write.

## Dropped — heredoc body strip

An earlier iteration prototyped a quoted-heredoc **body strip** to also suppress the narrow false positive where an admin doc-note append — `cat >> <peer>/CLAUDE.md <<'EOF' … `wiki path` … EOF` — trips the cross-agent scan on a protected-tree word inside the (inert, bash-never-expands) heredoc body. After **five pair-review rounds it was removed entirely** (operator-approved). Deciding whether a heredoc body is inert data vs executable requires fully parsing shell pipeline structure — interpreter stdin (`bash <<'EOF'`), wrapper options (`env -i bash`), pipe targets (`… EOF | bash`), and opener-line pipelines (`cat <<'EOF' | bash`) — and review found a **distinct bypass at every layer**. The strip is convenience-only; **not** stripping is strictly safer (it only ever DENIES more), so the optimisation is omitted.

The remaining false positive is therefore **accepted**: the admin write-parity carve-out now uses the strict `_command_has_shell_embedding`, so any embedding — including a backtick code-span or a path word inside a quoted-heredoc body — makes the command ineligible for the carve-out and DENIES. **Workaround:** write such a doc-note with an editor / file tool (`Edit`/`Write`) instead of a Bash heredoc.

## Validation

All on the branch worktree, offline (mock agents/paths; no live fleet):

```
python3 -m py_compile hooks/tool-policy.py                          # OK
bash scripts/smoke/1822-tool-policy-crossagent-falsepos.sh          # PASS (13 cases)
bash scripts/smoke/1692-admin-bash-symmetry.sh                      # PASS (24 cases)
shellcheck scripts/smoke/1822-*.sh scripts/smoke/1692-admin-bash-symmetry.sh   # clean
git diff --check                                                    # clean
```

`scripts/smoke/1822-tool-policy-crossagent-falsepos.sh` asserts exactly the four retained fixes: balanced-backtick unwrap (Fix 1b), component-wise glob containment `<bridge>/*.sh` ALLOW vs `<bridge>/shared/*` DENY (Fix 2), the obfuscation deny-message (Fix 3), admin Bash peer-home write parity #1711 — admin write ALLOW + `intent=write` audit, non-admin write DENY (Fix 4), and `md5` read-intent (Fix 5), plus the #1692 invariant (admin Stage-A secrets read stays DENY).

`scripts/smoke/1692-admin-bash-symmetry.sh` re-teeths the #1692 read carve-out and the #1711 write parity: the revert helper (`1692-admin-bash-symmetry-strip.py`) removes **both** admin peer-home carve-outs and asserts the admin read **and** write cases flip to DENY against the stripped copy — so the smoke cannot pass without both fixes live.

Regression sweep (all PASS on this branch): `heredoc-regression`, `1709`, `1690`, `admin-hook-exemption`, `tool-policy-roster-read-classify`, `system-agent-class`. `v2-cross-class-read` SKIPs on macOS (its POSIX-group/setgid permission boundary is Linux-kernel-specific) — expected, not a failure.

`./scripts/smoke-test.sh` host caveat: on macOS the full driver exits early at pre-existing lint/iso-permission gates that also reproduce on the pristine v0.16.9 tag (not introduced here). The targeted smokes above run clean standalone on macOS and Linux.

## Security note

v2 peer-home containment is intentionally out of scope (PR #1831). Dropping the heredoc strip strictly **tightens** the gate: the cross-agent scan now always sees the full command text (including any heredoc body), and the admin write-parity carve-out uses the strict embedding guard, so the only loosened paths are the **admin** legitimate-maintenance peer-home write and the four false-positive reads/globs above — each reached only after the Stage-A forbidden-tree deny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
