### PR TITLE
[wave v0.16.10] docs: surface claude-token OAT rotation on agent-facing docs (#1850)

### DIFF
--- a/.claude/skills/agent-bridge-operating-manual/SKILL.md
+++ b/.claude/skills/agent-bridge-operating-manual/SKILL.md
@@ -27,6 +27,7 @@ description: >-
 | 메모리 | `MEMORY-SCHEMA.md`. 팀 공유=`agent-bridge knowledge`, 개인=`agent-bridge memory`, 사용자별=`users/<id>/` |
 | 외부 push (`[Agent Bridge] event=…`) | `external-push-handling` 스킬 |
 | cron 생성·수정 | `agent-bridge cron …` (직접 crontab 금지) |
+| 사용량/주간 한도 경고·429 쿼터·토큰 로테이션·fleet 크레덴셜 동기화 | Claude OAT 풀은 `agent-bridge auth claude-token list\|activate\|auto-rotate\|mark-quota\|recover-due`, codex fleet-sync는 `agent-bridge auth codex-cred …`. 운영 런북=`OPERATIONS.md` "Claude setup-token registry and rotation", 설계 SSOT=`docs/design/fleet-credential-design.md` |
 | 변경 분류(upstream/downstream) | `CHANGE-POLICY.md` |
 | upstream issue/PR | 운영자 승인 없이 생성·`propose --yes` 금지 |
 | 인프라 장애 | `agent-bridge urgent <admin>` |

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1784,6 +1784,56 @@ The daemon runs the probe automatically inside its usage-monitor tick
 > surface). This is the same containment posture as the rest of the
 > token-rotation path.
 
+#### Weekly-limit / quota-exhaustion runbook (operator quick reference)
+
+When a Claude account hits its weekly limit or starts returning `429`
+at-limit responses, this is the operator-side sequence (the verbs are
+detailed above; this is the short order of operations):
+
+1. **See the pool.** `agent-bridge auth claude-token list` shows the
+   registered token ids, fingerprints, and which one is active — no token
+   value is ever printed. `agent-bridge auth claude-token auto-rotate status`
+   reports whether auto-rotation is armed and the threshold.
+2. **Have a second account ready.** Rotation only crosses a *weekly* limit
+   when the next token belongs to a **different account** — quota is
+   account-level, so a pool of same-account tokens all hit the same wall.
+   Register per-account OATs (the `claude setup-token` step is interactive
+   and operator-run):
+
+   ```bash
+   claude setup-token   # interactive, operator at a terminal
+   agent-bridge auth claude-token add --id <account-b> --stdin --sync
+   ```
+
+3. **Arm auto-rotation** so the daemon's usage monitor rotates before the
+   next hard-limit instead of after a 429:
+
+   ```bash
+   agent-bridge auth claude-token auto-rotate enable --threshold 99
+   ```
+
+4. **Manual cutover** when you need it now:
+
+   ```bash
+   agent-bridge auth claude-token activate <account-b> --sync
+   # or, to pick the next eligible token by policy:
+   agent-bridge auth claude-token rotate --reason manual --sync
+   ```
+
+5. **Quota mark + recovery.** A token that hit a limit is held out of
+   rotation until its reset estimate passes. The daemon does this
+   automatically; to drive it by hand, mark the exhausted token and let the
+   recovery pass re-enable it once the reset time has elapsed:
+
+   ```bash
+   agent-bridge auth claude-token mark-quota <account-a> --reset-at <iso>
+   agent-bridge auth claude-token recover-due
+   ```
+
+The codex fleet-sync side (`agent-bridge auth codex-cred …`) and the full
+cross-engine rationale — including why true multi-engine rotation parity is
+not possible — live in [`docs/design/fleet-credential-design.md`](./docs/design/fleet-credential-design.md).
+
 ### v0.7 → v0.8 migration runbook
 
 For an isolated agent that drifted across the v0.7 → v0.8 cut:

--- a/bridge-docs.py
+++ b/bridge-docs.py
@@ -471,6 +471,22 @@ Discord/Telegram MCP가 `fetch_messages`·channel webhook으로 반환하는 tim
 - inventory/list/create/update/delete: `{home}/agent-bridge cron ...`
 - 옛 cron helper 예시는 더 이상 기준이 아니다.
 
+## Credential & Token Rotation
+Claude OAT 풀(여러 setup-token을 등록하고 하나만 active로 두는 다중 토큰 레지스트리)과 codex fleet-sync는 `{home}/agent-bridge auth` (= `bridge-auth.sh`)로 다룬다. 주간 한도/429 쿼터/토큰 로테이션 신호가 보이면 이 verb들을 먼저 본다.
+
+- pool 상태 확인: `{home}/agent-bridge auth claude-token list` (토큰 id·fingerprint만 노출, 토큰값은 안 나옴)
+- active 전환: `{home}/agent-bridge auth claude-token activate <id> --sync`
+- 자동 로테이션: `{home}/agent-bridge auth claude-token auto-rotate enable|disable|status [--threshold 99]` (기본 threshold 99%)
+- 수동 로테이션: `{home}/agent-bridge auth claude-token rotate --reason <text> --sync`
+- 쿼터 처리: 한도 친 토큰은 `{home}/agent-bridge auth claude-token mark-quota <id> [--reset-at <iso>]`로 빼두고, reset 이후 `recover-due`가 재검증해 복구한다
+- 헬스 체크: `{home}/agent-bridge auth claude-token check <id> --disable-on-quota --enable-on-ok`
+- codex fleet-sync: `{home}/agent-bridge auth codex-cred register|source|sync|verify`
+
+caveats:
+- **계정 경계.** 로테이션이 *주간* 한도를 실제로 넘기려면 토큰이 **서로 다른 계정** 소속이어야 한다(쿼터는 account-level). 같은 계정의 토큰만 풀에 있으면 로테이션해도 같은 한도에 막힌다.
+- **토큰=시크릿.** 등록은 `--stdin` / `--token-file` (또는 운영자 터미널 전용 echo-off `receive`)로만 넣는다. 절대 argv·env·채팅·큐 본문에 토큰값을 인라인하지 않는다.
+- 운영 런북(주간 한도/쿼터 소진 시 대응)은 `OPERATIONS.md`의 "Claude setup-token registry and rotation", 전체 설계는 `docs/design/fleet-credential-design.md`를 본다.
+
 ## Ops Recipes (intent → command)
 에이전트가 운영 점검 명령을 반복적으로 잘못 추측해서 blocked 된 사례가 있다(issue #163). 이름을 처음부터 찾는 대신 아래 의도→명령 매핑을 먼저 본다.
 
@@ -486,6 +502,7 @@ Discord/Telegram MCP가 `fetch_messages`·channel webhook으로 반환하는 tim
 | 메모리 위키 정합성 점검 | `{home}/agent-bridge memory lint --agent <agent>` |
 | 다른 에이전트로 작업 넘기기 | `{home}/agent-bridge task create --to <agent> ...` |
 | 긴급 인터럽트 | `{home}/agent-bridge urgent <agent> "..."` |
+| 토큰 풀/로테이션 확인 | `{home}/agent-bridge auth claude-token list` / `auto-rotate status` |
 
 CLI가 모르는 이름을 추측하면 `혹시 이 명령이었나요?` 힌트가 함께 뜬다. 자주 빗맞는 케이스(`health`, `diag`, `cron stats`, `cron list --failed`, `ps`, `agents`, `task stats`)는 `lib/bridge-core.sh`의 `bridge_suggest_subcommand` curated alias 테이블에 이미 들어 있다.
 


### PR DESCRIPTION
## Summary

The Claude OAT pool rotation feature (`bridge-auth.sh claude-token …` registry + `codex-cred …` fleet-sync) is fully implemented but was **invisible on every agent-facing doc surface**, so agents (including the admin) answered "the bridge has no token rotation" when the operator asked. This surfaces it on the three surfaces agents actually read, with no behavior change.

Refs #1850.

## Surfaces updated

1. **operating-manual skill** `.claude/skills/agent-bridge-operating-manual/SKILL.md` — one routing-table row mapping `사용량/주간 한도 경고·429 쿼터·토큰 로테이션·fleet 크레덴셜 동기화` to the `auth claude-token` / `auth codex-cred` verbs + the OPERATIONS runbook + the design SSOT.
2. **TOOLS.md template** `bridge-docs.py` `render_shared_tools_md` (re-rendered to every agent) — a new `## Credential & Token Rotation` section listing the real claude-token + codex-cred verbs (one line each), the **account-level-quota** caveat (rotation only crosses a *weekly* limit across different accounts), and the **secret-handling** caveat (`--stdin`/`--token-file` only, never argv/env/chat/queue), plus one Ops Recipes row.
3. **OPERATIONS.md** — a `#### Weekly-limit / quota-exhaustion runbook` quick reference under the existing `### Claude setup-token registry and rotation` section (list → different-account OAT → `auto-rotate enable` → `activate`/`rotate` → `mark-quota`/`recover-due`).

## Constraints honored

- Documents only verbs that exist in `bridge-auth.sh` (verified against its usage string — no invented verbs).
- Tracked source stays machine-agnostic — the `{home}` placeholder in `bridge-docs.py` is interpolated at render time; no real paths/tokens/channel IDs/emails.
- Links `docs/design/fleet-credential-design.md` as the deep reference rather than duplicating it.
- **No VERSION/CHANGELOG bump** (per the lane brief).

## Verification

- `grep -n 'claude-token|bridge-auth|rotat'` now returns hits on all three surfaces (was zero on SKILL.md and the TOOLS.md template body).
- `python3 -m py_compile bridge-docs.py` passes; `render_shared_tools_md` renders with every `{home}` interpolated and no stray braces.
- Markdown table structure validated (new SKILL.md row = same 2-column / escaped-pipe convention as the existing rows).
- Internal `codex` review on the diff: **`implement-ok`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
