### PR TITLE
[wave v0.16.10] ci: de-flake daemon + kappa state-audit smokes

### DIFF
--- a/scripts/smoke/beta5-2-kappa-state-audit-reconcile.sh
+++ b/scripts/smoke/beta5-2-kappa-state-audit-reconcile.sh
@@ -123,6 +123,78 @@ _kappa_snapshot_source() {
   cp "$REPO_ROOT/$rel" "$dest" || smoke_fail "could not snapshot $rel -> $dest"
 }
 
+# ---------------------------------------------------------------------
+# T1.c-class flake root cause (CI false-red, e.g. PR #1847 run
+# 27401135893): this smoke runs under `set -o pipefail`, and the
+# original assertions used the shape
+#
+#     awk '<function range>' file | grep -qF 'needle'
+#
+# `grep -q` exits 0 at the FIRST match and closes the read end of the
+# pipe. The snapshot-writer body is 4412 bytes with the needle at byte
+# 3508 — past one 4096-byte stdio buffer — so awk emits it in two
+# writes. When the runner deschedules awk between those writes (loaded
+# CI box), grep matches in write 1 and exits before write 2; awk's
+# second write then dies with SIGPIPE (rc 141), `pipefail` propagates
+# 141 as the pipeline status even though grep matched, and the leading
+# `!` turns a successful match into a false-red. Verified mechanically:
+# an identical producer (4096B chunk containing the needle + delayed
+# tail) yields pipeline rc=141 with PIPESTATUS producer=141/grep=0.
+# The failing CI runs had `lib/bridge-state.sh` byte-identical to a
+# passing main — content was never the problem; the pipe race was.
+#
+# Fix shape used below: extract the function body to a FILE (plain
+# redirect, no pipe), then `grep -q` the file. No pipeline → no
+# SIGPIPE → deterministic. T1.d (3403B) / T8.a (3857B) sit one
+# refactor away from the same >4096B cliff, so they get the same
+# treatment. Single-short-line `printf | grep -q` sites (T4 gate
+# line) are not raceable — the producer's only write necessarily
+# precedes grep's exit — and are left as-is.
+# ---------------------------------------------------------------------
+
+# Extract a shell function body by NAME from a (hermetic snapshot) source
+# file, anchored on structural brace depth rather than a textual line
+# window. Prints the function block (header line through its matching close
+# brace) to stdout — call sites MUST redirect to a file and grep the file
+# (see flake root-cause block above; piping this into `grep -q` under
+# pipefail re-opens the SIGPIPE false-red).
+#
+# Why not `awk '/^name\(\) \{/,/^\}/'`: that range stops at the FIRST line
+# whose first char is `}`. It happens to work today, but it is a fragile
+# textual window — a future refactor that places any `}`-leading line inside
+# the body (a nested close brace at col 0, a heredoc terminator, a brace
+# group) silently truncates the range and the call-site grep then false-reds.
+# Brace-depth tracking instead follows the real nesting: it opens on
+# `name() {`, accumulates the net `{`/`}` balance per line, and stops
+# exactly when depth returns to 0. Balanced `${param}` expansions net to
+# zero per line so they do not perturb the count. The result is
+# deterministic regardless of where the body's braces sit on the line.
+_kappa_extract_func_body() {
+  local fn="$1" src="$2"
+  awk -v fn="$fn" '
+    BEGIN { want = fn "() {"; infn = 0; depth = 0 }
+    {
+      if (!infn) {
+        if (index($0, want) == 1) { infn = 1; depth = 0 }
+        else next
+      }
+      print
+      depth += gsub(/\{/, "{") - gsub(/\}/, "}")
+      if (depth <= 0) exit
+    }
+  ' "$src"
+}
+
+# File-based wrapper: extract FUNC from SRC into DEST and fail loudly if
+# the extraction came back empty (function vanished / unparseable) —
+# an empty body must never let a `! grep -q` assertion pass vacuously.
+_kappa_extract_func_body_file() {
+  local fn="$1" src="$2" dest="$3"
+  _kappa_extract_func_body "$fn" "$src" >"$dest"
+  [[ -s "$dest" ]] \
+    || smoke_fail "could not extract ${fn}() body from $src (empty extraction)"
+}
+
 STATE_LIB="$SNAP_DIR/bridge-state.sh"
 AGENT_LIB="$SNAP_DIR/bridge-agent.sh"
 DAEMON_LIB="$SNAP_DIR/bridge-daemon.sh"
@@ -163,23 +235,34 @@ fi
 # T1.c — snapshot writer in lib/bridge-state.sh calls the predicate
 # inside the "no prompt" branch (the only place activity_state can
 # transition into picker_blocked from working/starting).
-if ! grep -nF 'bridge_agent_picker_blocked' "$STATE_LIB" \
-      | grep -F 'bridge_write_roster_status_snapshot' >/dev/null \
-      && ! awk '/^bridge_write_roster_status_snapshot\(\) \{/,/^\}/' "$STATE_LIB" \
-      | grep -qF 'bridge_agent_picker_blocked'; then
+#
+# Extract the EXACT function body via brace-depth into a file and grep
+# the FILE (no pipeline — see the flake root-cause block above; the
+# original `awk range | grep -q` shape false-redded under pipefail when
+# grep's early exit SIGPIPE'd awk). This also retires (1) a
+# `grep picker_blocked | grep snapshot` pipeline that only ever matched
+# a line mentioning BOTH names — dead logic that asserted nothing — and
+# (2) the `awk '/start/,/^\}/'` textual range whose first-`}` stop is a
+# truncation hazard. Empty extraction fails LOUDLY inside the wrapper.
+_kappa_extract_func_body_file 'bridge_write_roster_status_snapshot' "$STATE_LIB" \
+  "$SMOKE_TMP_ROOT/t1c-snapshot-writer.body"
+if ! grep -qF 'bridge_agent_picker_blocked' "$SMOKE_TMP_ROOT/t1c-snapshot-writer.body"; then
   smoke_fail "T1.c: bridge_write_roster_status_snapshot does not call bridge_agent_picker_blocked"
 fi
 
 # T1.d — bridge_agent_activity_state in bridge-agent.sh calls the
-# predicate.
-if ! awk '/^bridge_agent_activity_state\(\) \{/,/^\}/' "$AGENT_LIB" \
-      | grep -qF 'bridge_agent_picker_blocked'; then
+# predicate. Same file-based shape as T1.c (body is 3403 bytes — one
+# refactor away from the >4096B two-write pipe race).
+_kappa_extract_func_body_file 'bridge_agent_activity_state' "$AGENT_LIB" \
+  "$SMOKE_TMP_ROOT/t1d-activity-state.body"
+if ! grep -qF 'bridge_agent_picker_blocked' "$SMOKE_TMP_ROOT/t1d-activity-state.body"; then
   smoke_fail "T1.d: bridge_agent_activity_state does not call bridge_agent_picker_blocked"
 fi
 
 # T1.e — heartbeat path in bridge-daemon.sh calls the predicate.
-if ! awk '/^bridge_agent_heartbeat_activity_state\(\) \{/,/^\}/' "$DAEMON_LIB" \
-      | grep -qF 'bridge_agent_picker_blocked'; then
+_kappa_extract_func_body_file 'bridge_agent_heartbeat_activity_state' "$DAEMON_LIB" \
+  "$SMOKE_TMP_ROOT/t1e-heartbeat.body"
+if ! grep -qF 'bridge_agent_picker_blocked' "$SMOKE_TMP_ROOT/t1e-heartbeat.body"; then
   smoke_fail "T1.e: bridge_agent_heartbeat_activity_state does not call bridge_agent_picker_blocked"
 fi
 
@@ -393,11 +476,16 @@ awk '
   { print }
 ' "$T5_LIB" >"$SMOKE_TMP_ROOT/state-lib.t5.reverted.sh"
 
-# Now re-run the T1.c assertion against the reverted file. It MUST
-# fail (i.e., grep returns non-zero). If the assertion still passes,
-# the teeth check is broken.
-if awk '/^bridge_write_roster_status_snapshot\(\) \{/,/^\}/' "$SMOKE_TMP_ROOT/state-lib.t5.reverted.sh" \
-      | grep -qF 'bridge_agent_picker_blocked'; then
+# Now re-run the T1.c assertion against the reverted file using the SAME
+# robust extractor + file-based grep T1.c uses, so the teeth test proves
+# the real check (not a divergent textual range) catches the regression.
+# The wrapper's non-empty check also keeps the teeth honest: if the revert
+# mangled the function so badly the extraction came back empty, that is a
+# broken-teeth failure, not a vacuous pass. The extracted body MUST NOT
+# contain the predicate call anymore.
+_kappa_extract_func_body_file 'bridge_write_roster_status_snapshot' \
+  "$SMOKE_TMP_ROOT/state-lib.t5.reverted.sh" "$SMOKE_TMP_ROOT/t5-reverted.body"
+if grep -qF 'bridge_agent_picker_blocked' "$SMOKE_TMP_ROOT/t5-reverted.body"; then
   smoke_fail "T5: teeth revert failed — picker_blocked branch still present in reverted snapshot writer"
 fi
 
@@ -460,12 +548,14 @@ smoke_log "T7 PASS — teeth proves T4.a would catch the reconcile parity regres
 smoke_log "T8 (PR #1345 r2 BLOCKING): snapshot activity_state + queue.py picker_blocked exclude"
 
 # T8.a — static asserts on the snapshot writer + queue.py reader.
-if ! awk '/^bridge_write_agent_snapshot\(\) \{/,/^\}/' "$STATE_LIB" \
-      | grep -qE '\\tactivity_state"'; then
+# File-based extraction (body is 3857 bytes — see flake root-cause
+# block; `awk range | grep -q` under pipefail is the T1.c false-red).
+_kappa_extract_func_body_file 'bridge_write_agent_snapshot' "$STATE_LIB" \
+  "$SMOKE_TMP_ROOT/t8a-agent-snapshot.body"
+if ! grep -qE '\\tactivity_state"' "$SMOKE_TMP_ROOT/t8a-agent-snapshot.body"; then
   smoke_fail "T8.a: bridge_write_agent_snapshot header missing activity_state column (#1345 r2)"
 fi
-if ! awk '/^bridge_write_agent_snapshot\(\) \{/,/^\}/' "$STATE_LIB" \
-      | grep -qF 'bridge_agent_picker_blocked'; then
+if ! grep -qF 'bridge_agent_picker_blocked' "$SMOKE_TMP_ROOT/t8a-agent-snapshot.body"; then
   smoke_fail "T8.a: bridge_write_agent_snapshot does not call bridge_agent_picker_blocked (#1345 r2)"
 fi
 # $QUEUE_PY is the immutable snapshot frozen at smoke start (#1509).

--- a/scripts/smoke/daemon.sh
+++ b/scripts/smoke/daemon.sh
@@ -634,7 +634,7 @@ daemon_acl_default_inheritance() {
 }
 
 daemon_socket_listener_contract() {
-  local bridge_id socket_path daemon_log create_out task_id show_out i
+  local bridge_id socket_path pid_file daemon_log create_out task_id show_out
 
   export BRIDGE_GATEWAY_TRANSPORT=file
   export BRIDGE_GATEWAY_LISTENER=auto
@@ -649,6 +649,7 @@ daemon_socket_listener_contract() {
 
   bridge_id="$(python3 "$SMOKE_REPO_ROOT/bridge-queue-gateway.py" print-runtime-id --bridge-home "$BRIDGE_HOME")"
   socket_path="$BRIDGE_QUEUE_GATEWAY_RUNTIME_ROOT/$bridge_id/queue-gateway.sock"
+  pid_file="$BRIDGE_STATE_DIR/queue-gateway-socket.pid"
   daemon_log="$SMOKE_TMP_ROOT/daemon-run.log"
   cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
 bridge_add_agent_id_if_missing "worker-a"
@@ -663,13 +664,11 @@ EOF
   bash "$SMOKE_REPO_ROOT/bridge-daemon.sh" run >"$daemon_log" 2>&1 &
   DAEMON_SOCKET_PID="$!"
 
-  for ((i = 0; i < 50; i++)); do
-    if [[ -S "$socket_path" ]] && kill -0 "$DAEMON_SOCKET_PID" 2>/dev/null; then
-      break
-    fi
-    sleep 0.1
-  done
-  [[ -S "$socket_path" ]] || smoke_fail "daemon did not start queue socket listener; log=$(cat "$daemon_log" 2>/dev/null || true)"
+  # Same bounded poll as the loop-restart test (the old fixed 50*0.1=5s
+  # window was the same cold-boot cliff — a passing CI run was observed
+  # taking 4.0s of it). The socket assertion below is unchanged.
+  _daemon_wait_for_socket_listener_pid "$socket_path" "$pid_file" "$DAEMON_SOCKET_PID" >/dev/null || true
+  [[ -S "$socket_path" ]] || smoke_fail "daemon did not start queue socket listener; $(_daemon_socket_listener_diag "$DAEMON_SOCKET_PID" "$daemon_log")"
 
   create_out="$(
     BRIDGE_GATEWAY_PROXY=1 BRIDGE_AGENT_ID=worker-a BRIDGE_GATEWAY_TRANSPORT=socket python3 "$SMOKE_REPO_ROOT/bridge-queue.py" create \
@@ -689,8 +688,61 @@ EOF
   [[ ! -S "$socket_path" ]] || smoke_fail "daemon exit should remove queue socket"
 }
 
+# Poll, with a bounded budget, for the queue-gateway socket listener to be
+# live AND for its pid file to hold a numeric pid distinct from an optional
+# excluded pid (the restart case passes the killed listener's pid so it waits
+# for the *replacement*). Re-reads the pid file every iteration so a daemon
+# that writes the pid late is tolerated. The `kill -0 $daemon_pid` conjunct
+# gates ACCEPTANCE on the daemon still being alive — it does not fail fast
+# (a crashed-but-unreaped daemon is a zombie and zombies still pass kill -0);
+# the bounded budget is what terminates the wait. Echoes the discovered pid
+# on success (nothing on timeout) and returns non-zero on timeout, so the
+# caller's strict numeric assertion still fires when the listener never
+# comes up.
+#
+# Budget rationale (v0.16.10 wave CI flake, PR #1848 run 27401016284): the
+# daemon writes NOTHING to its own stdout/stderr on a healthy boot, so the
+# old failure message's empty `log=` was normal, not evidence of a hang.
+# What actually burns the budget on a congested runner is gateway-listener
+# cold start: each attempt is a python3 spawn with a 2s in-daemon wait
+# (BRIDGE_QUEUE_GATEWAY_SOCKET_START_WAIT_SECONDS), retried once per daemon
+# tick — so a couple of slow spawns already eat most of a fixed 10s window.
+# A healthy daemon breaks this poll the instant the socket binds, so a high
+# ceiling costs nothing on a green run; 300*0.1=30s absorbs that cold-boot
+# latency without masking a real never-start.
+_daemon_wait_for_socket_listener_pid() {
+  local socket_path="$1" pid_file="$2" daemon_pid="$3" exclude_pid="${4:-}"
+  local attempts="${DAEMON_SOCKET_LISTENER_WAIT_ATTEMPTS:-300}"
+  local found="" i
+  for ((i = 0; i < attempts; i++)); do
+    if [[ -S "$socket_path" && -f "$pid_file" ]] && kill -0 "$daemon_pid" 2>/dev/null; then
+      found="$(sed -n '1p' "$pid_file" 2>/dev/null || true)"
+      if [[ "$found" =~ ^[0-9]+$ && "$found" != "$exclude_pid" ]]; then
+        printf '%s\n' "$found"
+        return 0
+      fi
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+# Failure diagnostics for the socket-listener tests. The daemon's own log is
+# empty on a healthy boot, so on timeout we also need: is the daemon process
+# still alive, and what did the gateway listener spawn actually say (its
+# errors land in state/queue-gateway-socket.log, not the daemon log).
+_daemon_socket_listener_diag() {
+  local daemon_pid="$1" daemon_log="$2"
+  local alive="no"
+  kill -0 "$daemon_pid" 2>/dev/null && alive="yes"
+  printf 'daemon_alive=%s daemon_log=[%s] gateway_socket_log=[%s]' \
+    "$alive" \
+    "$(cat "$daemon_log" 2>/dev/null || true)" \
+    "$(tail -n 20 "$BRIDGE_STATE_DIR/queue-gateway-socket.log" 2>/dev/null || true)"
+}
+
 daemon_socket_listener_loop_restart() {
-  local bridge_id socket_path pid_file daemon_log first_pid second_pid create_out task_id show_out i
+  local bridge_id socket_path pid_file daemon_log first_pid second_pid create_out task_id show_out
 
   export BRIDGE_GATEWAY_TRANSPORT=file
   export BRIDGE_GATEWAY_LISTENER=auto
@@ -717,40 +769,30 @@ BRIDGE_AGENT_ISOLATION_MODE["worker-a"]="linux-user"
 BRIDGE_AGENT_OS_USER["worker-a"]="agent-bridge-worker-a"
 EOF
   mkdir -p "$SMOKE_TMP_ROOT/worker-a"
+  # Isolation from the preceding lifecycle test: it shares BRIDGE_STATE_DIR,
+  # so a pid file left by a partially-run daemon exit trap would hand this
+  # test the OLD listener's pid as first_pid (and kill the wrong process).
+  # The daemon's stop path normally removes it; this makes it deterministic.
+  rm -f "$pid_file"
   bash "$SMOKE_REPO_ROOT/bridge-daemon.sh" run >"$daemon_log" 2>&1 &
   DAEMON_SOCKET_PID="$!"
 
-  # Issue #1644 CI flake: first_pid is `local`-declared (above) but left UNSET, so if
-  # the initial listener does not bind within the wait budget the loop exits without
-  # ever assigning it and `set -u` aborts at the check below with a cryptic
-  # "first_pid: unbound variable" instead of the intended smoke_fail. Initialize it
-  # (mirroring second_pid="" below) AND give cold daemon boot more headroom on a loaded
-  # CI runner: 50*0.1=5s was too tight; 100*0.1=10s matches the restart loop's
-  # generosity. Common case is unaffected — the loop breaks as soon as the socket binds.
-  first_pid=""
-  for ((i = 0; i < 100; i++)); do
-    if [[ -S "$socket_path" && -f "$pid_file" ]] && kill -0 "$DAEMON_SOCKET_PID" 2>/dev/null; then
-      first_pid="$(sed -n '1p' "$pid_file" 2>/dev/null || true)"
-      [[ "$first_pid" =~ ^[0-9]+$ ]] && break
-    fi
-    sleep 0.1
-  done
-  [[ "$first_pid" =~ ^[0-9]+$ ]] || smoke_fail "loop-restart: daemon did not start initial listener; log=$(cat "$daemon_log" 2>/dev/null || true)"
+  # Wait for the initial listener to come up. first_pid is "" on timeout so
+  # the strict smoke_fail below fires (not a `set -u` "unbound variable"
+  # abort — issue #1644's original CI symptom). See
+  # _daemon_wait_for_socket_listener_pid for the bounded-poll + budget
+  # rationale (the prior fixed 10s window was still too tight under the
+  # v0.16.10 wave job: PR #1848 run 27401016284).
+  first_pid="$(_daemon_wait_for_socket_listener_pid "$socket_path" "$pid_file" "$DAEMON_SOCKET_PID" || true)"
+  [[ "$first_pid" =~ ^[0-9]+$ ]] || smoke_fail "loop-restart: daemon did not start initial listener; $(_daemon_socket_listener_diag "$DAEMON_SOCKET_PID" "$daemon_log")"
 
   kill "$first_pid" >/dev/null 2>&1 || true
 
-  second_pid=""
-  for ((i = 0; i < 80; i++)); do
-    if [[ -S "$socket_path" && -f "$pid_file" ]] && kill -0 "$DAEMON_SOCKET_PID" 2>/dev/null; then
-      second_pid="$(sed -n '1p' "$pid_file" 2>/dev/null || true)"
-      if [[ "$second_pid" =~ ^[0-9]+$ && "$second_pid" != "$first_pid" ]]; then
-        break
-      fi
-    fi
-    sleep 0.1
-  done
+  # Wait for the daemon to restart the killed listener: same bounded poll, but
+  # exclude first_pid so we only accept a genuinely new listener process.
+  second_pid="$(_daemon_wait_for_socket_listener_pid "$socket_path" "$pid_file" "$DAEMON_SOCKET_PID" "$first_pid" || true)"
   [[ "$second_pid" =~ ^[0-9]+$ && "$second_pid" != "$first_pid" ]] \
-    || smoke_fail "loop-restart: daemon did not restart dead queue socket listener (first=$first_pid second=${second_pid:-}); log=$(cat "$daemon_log" 2>/dev/null || true)"
+    || smoke_fail "loop-restart: daemon did not restart dead queue socket listener (first=$first_pid second=${second_pid:-}); $(_daemon_socket_listener_diag "$DAEMON_SOCKET_PID" "$daemon_log")"
 
   create_out="$(
     BRIDGE_GATEWAY_PROXY=1 BRIDGE_AGENT_ID=worker-a BRIDGE_GATEWAY_TRANSPORT=socket python3 "$SMOKE_REPO_ROOT/bridge-queue.py" create \


### PR DESCRIPTION
## Summary

De-flakes the two CI smokes that were intermittently false-redding the v0.16.10 wave PR cascade. **Unblocks CI for PRs #1845 / #1846 / #1847 / #1848** (all based on `release/v0.16.10-integration`; CI runs these smokes from the PR merge ref). No VERSION/CHANGELOG bump — pure CI de-flake, no assertions weakened.

## Root cause 1 — kappa (`scripts/smoke/beta5-2-kappa-state-audit-reconcile.sh`): pipefail + `grep -q` SIGPIPE race

The smoke runs under `set -o pipefail` and asserted function wiring with `awk '<range>' file | grep -qF needle`. `grep -q` exits at the **first** match and closes the pipe. The snapshot-writer body is 4412 bytes with the needle at byte 3508 — past one 4096-byte stdio buffer — so awk emits two writes. On a congested runner, when awk is descheduled between the writes, grep exits after write 1 and awk's second write dies with SIGPIPE (rc 141); pipefail propagates 141 and the leading `!` turns a successful match into a false-red.

Evidence: PR #1847 run 27401135893 failed T1.c while T1.a/T1.b passed on the same snapshot, with `lib/bridge-state.sh` byte-identical to a passing main. Mechanism reproduced with a controlled producer: pipeline rc=141, `PIPESTATUS` producer=141 / grep=0.

**Fix**: a brace-depth awk extractor writes the exact function body to a *file*, and assertions `grep -q` the file — no pipeline, no SIGPIPE, deterministic. Empty extraction fails loudly so `! grep -q` can never pass vacuously. T1.d (3403B) and T8.a (3857B) sit one refactor from the same >4096B cliff and get the same shape; the T5 teeth test re-proves regression detection through the same extractor. Remaining `printf | grep -q` sites are single-write producers (not raceable).

## Root cause 2 — daemon (`scripts/smoke/daemon.sh`): gateway-listener cold start vs fixed 5s/10s windows

The empty `log=` in PR #1848 run 27401016284's failure was a red herring — a healthy daemon writes nothing to its own stdout/stderr at boot. The real mechanism: each gateway-listener spawn is a python3 cold start with a 2s in-daemon wait (`BRIDGE_QUEUE_GATEWAY_SOCKET_START_WAIT_SECONDS`), retried once per daemon tick, so a couple of slow spawns on a loaded runner exhaust the fixed 10s (loop-restart) / 5s (lifecycle) windows.

**Fix**: shared `_daemon_wait_for_socket_listener_pid` bounded early-exit poll (`DAEMON_SOCKET_LISTENER_WAIT_ATTEMPTS`, default 300×0.1s = 30s) for both socket tests — a healthy daemon still breaks out the instant the socket binds, so the higher ceiling costs nothing on green runs; `first_pid` no longer trips a `set -u` abort on timeout (#1644's original symptom); the restart wait excludes the killed pid so only a genuine replacement passes; the loop-restart test removes a possible stale pid file from the preceding lifecycle test (shared `BRIDGE_STATE_DIR`); timeout diagnostics now report daemon-alive + `state/queue-gateway-socket.log` (the listener's real error surface). All assertions unchanged.

## Verification

- `scripts/smoke/daemon.sh` (patched): **20/20 consecutive green** on macOS (`/opt/homebrew/bin/bash`, fresh isolated `TMPDIR`/`BRIDGE_HOME` per run); 20x baseline + patched runs green on ubuntu 24.04 (container) under CPU load.
- `scripts/smoke/beta5-2-kappa-state-audit-reconcile.sh` (patched): **20/20 consecutive green** on macOS (BSD awk); green on ubuntu 24.04 (mawk, non-git cp-fallback snapshot path).
- SIGPIPE mechanism repro harness confirmed the race shape (pipeline rc=141, producer=141/grep=0).
- `bash -n` + `shellcheck` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
