### PR TITLE
reconcile/watchdog: common iso-boundary graceful-skip across controller scanners (#1820 rc4)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -2110,6 +2110,11 @@ AGENT_LIST_HELP
 #   is_alive        bridge_agent_is_active (tmux session exists)
 #   source          provenance: static-roster | dynamic-active-env |
 #                   dynamic-history-live-session | dynamic-tmux-recovered
+#   isolation_mode  bridge_agent_isolation_mode (#1820 rc4): linux-user |
+#                   "" — lets a controller scanner registry-classify the iso
+#                   boundary without a filesystem read of the agent home
+#   os_user         bridge_agent_os_user (#1820 rc4): the iso UID account
+#                   (e.g. agent-bridge-<a>) | "" on shared-mode agents
 run_registry() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -2147,6 +2152,8 @@ AGENT_REGISTRY_HELP
   local session
   local provenance
   local is_alive
+  local isolation_mode
+  local os_user
   local rows=""
 
   if declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1 && (( ${#BRIDGE_AGENT_IDS[@]} > 0 )); then
@@ -2174,7 +2181,15 @@ AGENT_REGISTRY_HELP
       else
         is_alive="0"
       fi
-      rows+=$(printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      # #1820 rc4: surface the registry isolation classification so
+      # controller-run scanners (the watchdog) can registry-classify "this is
+      # an iso-v2 boundary" WITHOUT a filesystem read of the agent home (the
+      # read that throws Errno13). isolation_mode==linux-user + a resolved
+      # os_user is the same triple bridge_agent_linux_user_isolation_effective
+      # checks. Empty on shared-mode agents.
+      isolation_mode="$(bridge_agent_isolation_mode "$agent" 2>/dev/null || printf '')"
+      os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || printf '')"
+      rows+=$(printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
         "$agent" \
         "$cleanup_class" \
         "$agent_source" \
@@ -2184,7 +2199,9 @@ AGENT_REGISTRY_HELP
         "$engine" \
         "$session" \
         "$is_alive" \
-        "$provenance")
+        "$provenance" \
+        "$isolation_mode" \
+        "$os_user")
       rows+=$'\n'
     done
   fi

--- a/bridge-watchdog.py
+++ b/bridge-watchdog.py
@@ -32,6 +32,18 @@ except ImportError:
     _isolated_workdir_owner_canonical = None
     _sudo_run_as_canonical = None
     _sudo_run_as_capture_canonical = None
+# Common iso-v2 controller-boundary classifier (#1820 rc4) — shared with
+# layout-v2-reconcile.py so both scanners agree on "this is the iso boundary".
+# Used to downgrade ONLY the pure expected-iso-boundary scan_error rows
+# (permission_denied on an effectively-iso agent) out of the problem count into
+# an auditable iso_skipped bucket. If the import is unavailable the downgrade is
+# a no-op and every row stays a problem (legacy behavior).
+try:
+    from bridge_iso_boundary import (
+        is_expected_iso_permission_boundary as _iso_is_expected_boundary,
+    )
+except ImportError:
+    _iso_is_expected_boundary = None
 
 MANAGED_START = "<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->"
 MANAGED_END = "<!-- END AGENT BRIDGE DOC MIGRATION -->"
@@ -379,11 +391,20 @@ def _registry_ids_from_payload(
         # ONLY as a fall-back location for the engine entrypoint when it is
         # absent from the scanned dir — a genuinely missing AGENTS.md
         # (absent from BOTH) still surfaces as drift.
+        # `isolation_mode` + `os_user` (#1820 rc4): the registry classification
+        # the watchdog uses to decide "this row's permission_denied is the
+        # EXPECTED iso controller boundary" purely from loaded metadata — no
+        # filesystem read of the (2770, Errno13-throwing) agent home. Missing =>
+        # "" => shared-mode => the iso-boundary downgrade never fires (legacy
+        # behavior preserved). The same triple the reconcile iso-map builder and
+        # `bridge_agent_linux_user_isolation_effective` use.
         meta[agent_id] = {
             "engine": str(row.get("engine") or "").strip(),
             "agent_source": str(row.get("agent_source") or "").strip(),
             "workdir": str(row.get("workdir") or "").strip(),
             "home": str(row.get("home") or "").strip(),
+            "isolation_mode": str(row.get("isolation_mode") or "").strip(),
+            "os_user": str(row.get("os_user") or "").strip(),
         }
     return ids, meta
 
@@ -1667,6 +1688,55 @@ def required_profile_files(engine: str, agent_source: str = "") -> tuple[str, ..
     return ()
 
 
+def _host_platform() -> str:
+    """Resolve the host platform for the iso-boundary classifier (#1820 rc4).
+
+    Honors ``BRIDGE_HOST_PLATFORM_OVERRIDE`` (the same env var the shell
+    ``bridge_host_platform`` predicate reads) so a smoke can stub ``Linux`` on a
+    macOS dev host without a real cross-UID boundary; otherwise falls back to
+    ``platform.system()`` (``Linux`` / ``Darwin`` / …)."""
+    override = os.environ.get("BRIDGE_HOST_PLATFORM_OVERRIDE", "").strip()
+    if override:
+        return override
+    try:
+        import platform as _platform
+
+        return _platform.system()
+    except Exception:  # pragma: no cover — defensive
+        return ""
+
+
+def is_expected_iso_boundary_row(
+    item: "AgentWatch",
+    registry_meta: RegistryMeta,
+    platform: str,
+) -> bool:
+    """True iff ``item`` is the PURE expected iso controller-boundary
+    (#1820 rc4) — a ``scan_error`` row whose ``error_kind`` is
+    ``permission_denied`` on an EFFECTIVELY-iso agent (registry-classified
+    linux-user + resolved os_user + Linux host), and whose ``error_category`` is
+    an iso-boundary category (not a ``publish-gap`` / not a ``not_found`` /
+    ``os_error``).
+
+    Only such rows are downgraded out of the problem count into the auditable
+    ``iso_skipped`` bucket. ``not_found`` / ``os_error`` rows — even on an iso
+    agent — stay genuine problems (they are real drift, not the boundary). The
+    classification is delegated to the common helper so the watchdog and the
+    reconcile agree on "this is the iso boundary"."""
+    if _iso_is_expected_boundary is None:
+        return False
+    if item.status != "scan_error":
+        return False
+    meta = registry_meta.get(item.agent, {})
+    return _iso_is_expected_boundary(
+        platform=platform,
+        isolation_mode=meta.get("isolation_mode", ""),
+        os_user=meta.get("os_user", ""),
+        error_kind=item.error_kind,
+        error_category=item.error_category,
+    )
+
+
 def classify_status(
     missing_files: list[str],
     broken_links: list[str],
@@ -1939,9 +2009,22 @@ def render_markdown(
     records: list[AgentWatch],
     bridge_home: Path,
     orphan_directories: list[str] | None = None,
+    iso_skipped_agents: set[str] | None = None,
 ) -> str:
     now_iso = datetime.now().astimezone().isoformat()
-    problems = [item for item in records if item.status != "ok"]
+    # #1820 rc4: pure expected-iso-boundary scan_error rows (permission_denied on
+    # an effectively-iso agent, controller can't read but the iso UID owns its
+    # own files) are NOT problems — they are an expected, harmless controller-
+    # side observability artifact. Exclude them from the problem count and
+    # surface them in a dedicated auditable ``iso_skipped`` bucket instead.
+    # not_found / os_error rows (even on an iso agent) are NOT in this set and
+    # stay problems.
+    iso_skipped_agents = iso_skipped_agents or set()
+    problems = [
+        item for item in records
+        if item.status != "ok" and item.agent not in iso_skipped_agents
+    ]
+    iso_skipped = [item for item in records if item.agent in iso_skipped_agents]
     orphan_directories = orphan_directories or []
     lines = [
         "# Watchdog Report",
@@ -1950,9 +2033,19 @@ def render_markdown(
         f"- bridge_home: {bridge_home}",
         f"- agents: {len(records)}",
         f"- problems: {len(problems)}",
+        f"- iso_skipped: {len(iso_skipped)}",
         f"- orphan_directories: {len(orphan_directories)}",
         "",
     ]
+    if iso_skipped:
+        # Auditable bucket: the operator can see these rows were downgraded as
+        # expected iso boundaries (not silently dropped). Each names the agent +
+        # the path the controller could not read across the 2770 boundary.
+        lines.append("## iso_skipped")
+        for item in iso_skipped:
+            detail = item.error_path or item.error_kind or "permission_denied"
+            lines.append(f"- {item.agent}: expected iso controller boundary ({detail})")
+        lines.append("")
     if orphan_directories:
         # Refs queue #4796: orphan dirs (smoke leaks, manual mkdir) used to
         # surface as profile_drift warns when the watchdog enumerated
@@ -2328,16 +2421,33 @@ def main() -> int:
     # daemon "every problem row in this report is a fresh-install
     # candidate — file at priority=low instead of high". When mixed
     # (some fresh, some not), the high-priority path is preserved.
+    # #1820 rc4: identify the pure expected-iso-boundary rows (permission_denied
+    # on an effectively-iso agent) and downgrade them out of the problem count
+    # into the auditable ``iso_skipped`` bucket. Registry-classified — no
+    # filesystem read of the (2770, Errno13-throwing) agent home. not_found /
+    # os_error rows stay problems even on an iso agent.
+    host_platform = _host_platform()
+    iso_skipped_agents = {
+        item.agent
+        for item in records
+        if is_expected_iso_boundary_row(item, registry_meta, host_platform)
+    }
     effective_problems = [
         item for item in records
-        if item.status != "ok" and not item.restart_in_progress
+        if item.status != "ok"
+        and not item.restart_in_progress
+        and item.agent not in iso_skipped_agents
     ]
+    iso_skipped_count = sum(1 for item in records if item.agent in iso_skipped_agents)
     payload = {
         "generated_at": datetime.now().astimezone().isoformat(),
         "bridge_home": str(bridge_home),
         "agent_home_root": str(agent_root),
         "agent_count": len(records),
         "problem_count": len(effective_problems),
+        # Auditable: how many rows were downgraded as expected iso boundaries.
+        "iso_skipped_count": iso_skipped_count,
+        "iso_skipped_agents": sorted(iso_skipped_agents),
         "fresh_install_only": bool(effective_problems) and all(
             item.fresh_install for item in effective_problems
         ),
@@ -2348,7 +2458,9 @@ def main() -> int:
         "orphan_directories": orphan_directories,
         "agents": [asdict(item) for item in records],
     }
-    rendered_markdown = render_markdown(records, bridge_home, orphan_directories)
+    rendered_markdown = render_markdown(
+        records, bridge_home, orphan_directories, iso_skipped_agents
+    )
     if args.json:
         print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:

--- a/bridge-watchdog.py
+++ b/bridge-watchdog.py
@@ -41,9 +41,13 @@ except ImportError:
 try:
     from bridge_iso_boundary import (
         is_expected_iso_permission_boundary as _iso_is_expected_boundary,
+        iso_boundary_applies as _iso_boundary_applies,
+        is_permission_error as _iso_is_permission_error,
     )
 except ImportError:
     _iso_is_expected_boundary = None
+    _iso_boundary_applies = None
+    _iso_is_permission_error = None
 
 MANAGED_START = "<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->"
 MANAGED_END = "<!-- END AGENT BRIDGE DOC MIGRATION -->"
@@ -657,6 +661,192 @@ def resolve_scan_path(
                     return candidate
             raise
     return default_path
+
+
+# #1820 rc4 supplement: the relative-path basenames the broken-link scan
+# emits for the Claude settings symlink in the data-tree MIRROR workdir.
+# ``bridge_isolation_v2`` materializes ``.claude/settings.json`` as a
+# symlink to ``settings.effective.json`` (see lib/bridge-hooks.sh). When the
+# data-tree mirror render is incomplete (an original anomaly agent whose
+# data-tree home never had ``settings.effective.json`` rendered — a 3B stub),
+# that mirror symlink dangles while the agent's REAL runtime HOME effective
+# settings are fully rendered and loaded. The broken-link scan classifies the
+# dangling mirror symlink as drift even though the bot is healthy and running
+# with all hooks/plugins from its runtime home. We filter that specific entry
+# out IFF the runtime HOME effective settings actually carry hooks/plugins.
+_SETTINGS_MIRROR_SYMLINK_BASENAMES = (
+    ".claude/settings.json",
+    "settings.json",
+)
+
+
+def _runtime_home_effective_settings_path(
+    meta: dict[str, str] | None,
+) -> Path | None:
+    """Resolve the agent's RUNTIME HOME effective Claude settings file
+    (#1820 rc4 supplement) — the ``settings.effective.json`` the agent
+    actually loads at runtime — NOT the data-tree mirror under
+    ``data/agents/<a>/workdir``.
+
+    Resolution (iso-aware, mirrors ``bridge_agent_claude_config_dir`` in
+    lib/bridge-agents.sh):
+      * iso agent (registry ``os_user`` non-empty): the agent's real OS
+        home ``<pw_dir>/.claude/`` where ``pw_dir`` comes from
+        ``pwd.getpwnam(os_user)`` (conventionally ``/home/agent-bridge-<a>``).
+      * shared / non-iso agent: the registry ``home`` identity-source root's
+        ``.claude/``.
+
+    Prefers ``settings.effective.json``; falls back to ``settings.json`` when
+    the effective file is absent. Returns ``None`` when no runtime home can be
+    resolved (no os_user AND no registry home) — the caller then leaves the
+    broken-link row untouched (legacy behavior).
+    """
+    meta = meta or {}
+    os_user = (meta.get("os_user") or "").strip()
+    home_root: Path | None = None
+    if os_user:
+        try:
+            import pwd as _pwd
+
+            pw_dir = _pwd.getpwnam(os_user).pw_dir
+        except (KeyError, OSError):
+            pw_dir = ""
+        if pw_dir:
+            home_root = Path(pw_dir)
+    if home_root is None:
+        home_str = (meta.get("home") or "").strip()
+        if home_str:
+            home_root = Path(home_str).expanduser()
+    if home_root is None:
+        return None
+    claude_dir = home_root / ".claude"
+    effective = claude_dir / "settings.effective.json"
+    if effective.exists():  # noqa: raw-pathlib-controller-only — runtime-home settings probe, wrapped by caller's iso-boundary catch
+        return effective
+    return claude_dir / "settings.json"
+
+
+def _settings_have_hooks_or_plugins(settings_path: Path) -> bool:
+    """True iff the JSON at ``settings_path`` carries a non-empty ``hooks``
+    block OR a non-empty ``enabledPlugins`` list (#1820 rc4 supplement).
+
+    A missing file / empty stub / unparseable JSON → False (the agent has no
+    discoverable hooks/plugins from this source). Read failures other than a
+    permission boundary are treated as "no hooks/plugins" (conservative — the
+    dangling mirror symlink stays flagged); a ``PermissionError`` is allowed to
+    propagate so the caller can classify it as the iso boundary.
+    """
+    try:
+        raw = settings_path.read_text(encoding="utf-8")  # noqa: raw-pathlib-controller-only — runtime-home settings probe, PermissionError handled by caller
+    except PermissionError:
+        raise
+    except (OSError, FileNotFoundError):
+        return False
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    hooks = data.get("hooks")
+    if isinstance(hooks, dict) and any(hooks.values()):
+        return True
+    if isinstance(hooks, list) and hooks:
+        return True
+    plugins = data.get("enabledPlugins")
+    if isinstance(plugins, (list, dict)) and plugins:
+        return True
+    return False
+
+
+def _runtime_home_hooks_plugins_state(
+    meta: dict[str, str] | None,
+    platform: str,
+) -> str:
+    """Classify whether the agent's RUNTIME HOME effective settings carry
+    hooks/plugins (#1820 rc4 supplement). Returns one of:
+
+      * ``"has"``            — runtime HOME effective settings DO carry
+        hooks/plugins. The dangling data-tree mirror symlink is a pure
+        false-positive and is filtered out of the broken-link list.
+      * ``"none"``           — runtime HOME effective settings genuinely lack
+        hooks/plugins (or no runtime home could be resolved). The dangling
+        symlink stays a problem — don't blanket-suppress the check.
+      * ``"iso-unreadable"`` — reading the runtime HOME hit a permission
+        boundary on an effectively-iso agent (the controller can't read the
+        2770/0700 iso home, but the iso UID owns + loads it). Routed through
+        the common ``bridge_iso_boundary`` classifier → graceful iso-skip:
+        the dangling mirror symlink is NOT flagged (it would be a false
+        "no hooks/plugins" problem). Perms are NEVER relaxed.
+    """
+    meta = meta or {}
+    settings_path = _runtime_home_effective_settings_path(meta)
+    if settings_path is None:
+        return "none"
+    try:
+        return "has" if _settings_have_hooks_or_plugins(settings_path) else "none"
+    except PermissionError as exc:
+        # Controller can't read the runtime HOME. If this is an effectively-iso
+        # agent, that is the EXPECTED iso controller boundary (mechanism a of
+        # the common classifier — registry metadata only, no further fs read):
+        # downgrade to a graceful iso-skip rather than fabricating a
+        # "no hooks/plugins" problem. On a shared / non-iso / off-Linux host a
+        # PermissionError here is genuine and the symlink stays flagged.
+        is_iso = (
+            _iso_boundary_applies is not None
+            and _iso_is_permission_error is not None
+            and _iso_is_permission_error(exc)
+            and _iso_boundary_applies(
+                platform=platform,
+                isolation_mode=meta.get("isolation_mode", ""),
+                os_user=meta.get("os_user", ""),
+            )
+        )
+        return "iso-unreadable" if is_iso else "none"
+
+
+def filter_settings_mirror_false_positive(
+    broken_links: list[str],
+    meta: dict[str, str] | None,
+    platform: str,
+) -> list[str]:
+    """Drop the data-tree MIRROR ``settings.json`` dangling-symlink entry from
+    ``broken_links`` when it is a pure false-positive (#1820 rc4 supplement).
+
+    The entry is removed IFF the agent's RUNTIME HOME effective settings
+    actually carry hooks/plugins (``"has"``) OR the runtime HOME can't be read
+    across the iso boundary (``"iso-unreadable"`` → graceful skip). When the
+    runtime HOME genuinely lacks hooks/plugins (``"none"``) the entry is KEPT
+    so a truly-broken settings render is still surfaced. Every other broken
+    link (a genuinely dangling symlink elsewhere in the workdir) is untouched.
+    """
+    settings_rows = [
+        link
+        for link in broken_links
+        if _broken_link_is_settings_mirror(link)
+    ]
+    if not settings_rows:
+        return broken_links
+    state = _runtime_home_hooks_plugins_state(meta, platform)
+    if state == "none":
+        return broken_links
+    # "has" or "iso-unreadable": the dangling mirror symlink is not real drift.
+    return [link for link in broken_links if link not in settings_rows]
+
+
+def _broken_link_is_settings_mirror(link: str) -> bool:
+    """True iff a broken-link entry (``"<relpath> -> <target>"``) is the
+    Claude settings mirror symlink whose target is ``settings.effective.json``.
+    Matching on BOTH the source relpath basename AND the
+    ``settings.effective.json`` target keeps an unrelated dangling
+    ``settings.json`` (not the effective-settings mirror) a real problem."""
+    src = link.split(" -> ", 1)[0].strip()
+    target = link.split(" -> ", 1)[1].strip() if " -> " in link else ""
+    src_match = src in _SETTINGS_MIRROR_SYMLINK_BASENAMES or src.endswith(
+        "/.claude/settings.json"
+    ) or src.endswith("/settings.json")
+    target_match = "settings.effective.json" in target
+    return src_match and target_match
 
 
 @dataclass
@@ -1792,6 +1982,8 @@ def scan_agent(
     fresh_install_home_dir: Path | None = None,
     agent_home_dir: Path | None = None,
     broken_links_cache: dict[str, tuple[str, BrokenLinksResult]] | None = None,
+    registry_meta_entry: dict[str, str] | None = None,
+    host_platform: str = "",
 ) -> AgentWatch:
     # #1801 r2 (#12626): ``broken_links_cache`` is an optional per-pass dict
     # the agent-loop in ``main()`` threads through so a workdir shared by
@@ -1919,6 +2111,21 @@ def scan_agent(
         # redundant walk. ``None`` cache → unconditional scan (legacy callers).
         broken = _collect_broken_links_deduped(
             agent_dir, resolved_name, broken_links_cache
+        )
+        # #1820 rc4 supplement: the broken-link scan walks the DATA-TREE MIRROR
+        # workdir, not the agent's runtime HOME. For an original anomaly agent
+        # whose data-tree mirror render is incomplete, the
+        # ``.claude/settings.json -> settings.effective.json`` mirror symlink
+        # dangles even though the agent's REAL runtime HOME effective settings
+        # are fully rendered + loaded (all hooks/plugins active, bot healthy).
+        # Decide "does this agent have hooks/plugins" from the RUNTIME HOME
+        # effective settings, not from whether the mirror symlink resolves —
+        # and drop the false-positive entry when the runtime home HAS
+        # hooks/plugins (or its iso home can't be read by the controller, which
+        # routes through the common iso-boundary classifier → graceful skip).
+        # A runtime home that genuinely lacks hooks/plugins keeps the row.
+        broken.links = filter_settings_mirror_false_positive(
+            broken.links, registry_meta_entry, host_platform
         )
         # #1801: classify_status keys off the broken-link LIST only. A
         # truncated scan that found genuine broken links still drives a
@@ -2282,6 +2489,12 @@ def main() -> int:
     # pass (a fresh dict each ``main()`` invocation) so a workdir whose
     # contents change between ticks is always re-walked next tick.
     broken_links_cache: dict[str, tuple[str, BrokenLinksResult]] = {}
+    # #1820 rc4 supplement: host platform is needed inside the scan loop too
+    # (the settings-mirror false-positive filter routes a runtime-HOME read
+    # PermissionError through the common iso-boundary classifier, which is a
+    # no-op off Linux). Computed once and reused by the post-loop iso_skipped
+    # classification below.
+    host_platform = _host_platform()
     for path in scan_paths:
         agent_name = path.name
         agent_meta = registry_meta.get(agent_name, {})
@@ -2320,6 +2533,14 @@ def main() -> int:
                     # #1801 r2: per-pass dedupe cache (see above) so a shared
                     # workdir's broken-link walk is paid once per pass.
                     broken_links_cache=broken_links_cache,
+                    # #1820 rc4 supplement: registry metadata + host platform
+                    # so scan_agent can decide the settings-mirror dangling
+                    # symlink from the RUNTIME HOME effective settings (iso-aware
+                    # os_user/home resolution) instead of the data-tree mirror,
+                    # routing an iso-unreadable home through the common
+                    # iso-boundary classifier as a graceful skip.
+                    registry_meta_entry=agent_meta,
+                    host_platform=host_platform,
                 )
             )
         except (PermissionError, FileNotFoundError, OSError) as exc:
@@ -2426,7 +2647,7 @@ def main() -> int:
     # into the auditable ``iso_skipped`` bucket. Registry-classified — no
     # filesystem read of the (2770, Errno13-throwing) agent home. not_found /
     # os_error rows stay problems even on an iso agent.
-    host_platform = _host_platform()
+    # (``host_platform`` computed once before the scan loop above.)
     iso_skipped_agents = {
         item.agent
         for item in records

--- a/lib/agent-cli-helpers/registry-format-json.py
+++ b/lib/agent-cli-helpers/registry-format-json.py
@@ -5,8 +5,11 @@
 
 Invocation contract:
     sys.argv[1] = path to TSV file with the run_registry row format
-                  (10 tab-separated columns, see run_registry comment for
-                  the schema).
+                  (12 tab-separated columns as of #1820 rc4 — the first 10
+                  are the original schema, columns 11/12 are isolation_mode /
+                  os_user; a legacy 10-column TSV still parses, both new
+                  fields default to ""). See run_registry comment for the
+                  full schema.
 
 Output: a single JSON document on stdout — sorted by `id` for stable
 diffs.
@@ -40,6 +43,12 @@ def main() -> int:
             continue
         (id_, cls, agent_source, privilege_class, home, workdir,
          engine, session, is_alive, source) = parts[:10]
+        # #1820 rc4: isolation_mode + os_user are appended columns 11/12 so a
+        # controller scanner (watchdog) can registry-classify the iso boundary
+        # without a filesystem read. Backward-compatible: an older TSV with only
+        # 10 columns defaults both to "" (shared-mode), unchanged behavior.
+        isolation_mode = parts[10] if len(parts) > 10 else ""
+        os_user = parts[11] if len(parts) > 11 else ""
         records.append({
             "id": id_,
             "class": cls,
@@ -51,6 +60,8 @@ def main() -> int:
             "session": session,
             "is_alive": is_alive == "1",
             "source": source,
+            "isolation_mode": isolation_mode,
+            "os_user": os_user,
         })
 
     records.sort(key=lambda r: r["id"])

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1126,6 +1126,29 @@ bridge_agent_linux_user_isolation_effective() {
   return 0
 }
 
+# bridge_iso_boundary_applies <agent>
+#   Common iso-v2 controller-boundary classifier (#1820 rc4), the shell
+#   sibling of lib/bridge_iso_boundary.py::iso_boundary_applies. Returns 0
+#   (true) iff the controller-vs-iso-UID file boundary applies to this agent —
+#   i.e. its home/files are owned by the iso UID at 2770/0660 and a controller
+#   scanner must NOT direct-read across the boundary.
+#
+#   This is PURELY registry-based: it delegates to
+#   bridge_agent_linux_user_isolation_effective (isolation_mode==linux-user +
+#   Linux host + resolved os_user). It performs NO filesystem read of the agent
+#   home, so it can never itself trip the Errno13 it exists to let callers
+#   avoid. Every controller-run scanner (reconcile iso-map builder, watchdog,
+#   wiki-rebuild) classifies "is this an iso boundary" through this one
+#   predicate so they all agree. A non-iso / shared-mode / macOS agent returns
+#   non-zero and the caller takes its normal path (byte-identical legacy
+#   behavior).
+bridge_iso_boundary_applies() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 || return 1
+  bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null
+}
+
 # bridge_agent_start_supp_group_preflight — first-start determinism for
 # linux-user-isolated agents (Issue #1836).
 #

--- a/lib/bridge-layout-v2-reconcile.sh
+++ b/lib/bridge-layout-v2-reconcile.sh
@@ -171,6 +171,7 @@ bridge_layout_v2_reconcile_iso_agents_json() {
     return 0
   fi
   local out="{" i=0
+  local p
   for p in "${pairs[@]}"; do
     if [[ $i -gt 0 ]]; then out+=","; fi
     out+="$p"
@@ -178,6 +179,63 @@ bridge_layout_v2_reconcile_iso_agents_json() {
   done
   out+="}"
   printf '%s' "$out"
+}
+
+# bridge_layout_v2_reconcile_host_iso_active <agents-csv>
+#   Print "1" iff this host is iso-v2-active, else "0" (#1820 rc4). This is the
+#   HOST-LEVEL signal the engine's defensive belt uses: when active, a
+#   controller PermissionError reaching an agent home is recorded as a
+#   structured graceful-skip instead of an Errno13 warning — EVEN for an agent
+#   the iso-map builder failed to classify (the cm-prod 6/8 case, where the
+#   reconcile driver context had incomplete os_user / isolation_mode registry
+#   metadata for some production bots).
+#
+#   A host is iso-v2-active iff:
+#     * host platform is Linux (the OS-user boundary only exists there), AND
+#     * at least one rostered agent either resolved into the iso map OR merely
+#       REQUESTED linux-user isolation (isolation_mode==linux-user). We accept
+#       "requested" — not only "effective" — precisely because the bug is that
+#       os_user resolution can be incomplete; gating the belt on full
+#       resolution would re-open the exact gap. On a pure shared-mode Linux
+#       host (no agent requests linux-user) this is "0" and PermissionErrors
+#       stay warnings, byte-identical to pre-rc4. On macOS it is always "0".
+#   Best-effort + side-effect-free: a missing predicate yields "0" (shared-mode
+#   behavior preserved).
+bridge_layout_v2_reconcile_host_iso_active() {
+  local agents_csv="$1"
+  # macOS / non-Linux: the boundary does not exist. Resolve platform via the
+  # canonical predicate when available, else uname.
+  local platform=""
+  if command -v bridge_host_platform >/dev/null 2>&1; then
+    platform="$(bridge_host_platform 2>/dev/null || true)"
+  else
+    platform="$(uname -s 2>/dev/null || true)"
+  fi
+  [[ "$platform" == "Linux" ]] || { printf '0'; return 0; }
+  # If the iso-map builder classified anything, the host is iso-active.
+  local iso_json
+  iso_json="$(bridge_layout_v2_reconcile_iso_agents_json "$agents_csv")"
+  if [[ -n "$iso_json" && "$iso_json" != "{}" ]]; then
+    printf '1'
+    return 0
+  fi
+  # Otherwise check whether ANY rostered agent merely REQUESTED linux-user
+  # isolation — robust to incomplete os_user resolution (the cm-prod gap).
+  if command -v bridge_agent_linux_user_isolation_requested >/dev/null 2>&1; then
+    local agent
+    local IFS=,
+    local -a ids=()
+    read -r -a ids <<<"$agents_csv"
+    unset IFS
+    for agent in "${ids[@]}"; do
+      [[ -n "$agent" ]] || continue
+      if bridge_agent_linux_user_isolation_requested "$agent" 2>/dev/null; then
+        printf '1'
+        return 0
+      fi
+    done
+  fi
+  printf '0'
 }
 
 # bridge_layout_v2_reconcile_noop_json
@@ -330,6 +388,16 @@ bridge_layout_v2_reconcile_run() {
     printf '%s' "$iso_agents_json" >"$iso_agents_file" 2>/dev/null || iso_agents_file=""
   fi
 
+  # Host-level iso-v2-active signal for the engine's defensive belt (#1820 rc4).
+  # When active, a controller PermissionError reaching an agent home becomes a
+  # structured graceful-skip even for an agent the iso-map builder missed (the
+  # cm-prod 6/8 case). On shared-mode / macOS this is "0" → PermissionErrors
+  # stay warnings (byte-identical to pre-rc4).
+  local host_iso_active
+  host_iso_active="$(bridge_layout_v2_reconcile_host_iso_active "$agents_csv")"
+  local -a host_iso_flag=()
+  [[ "$host_iso_active" == "1" ]] && host_iso_flag=(--host-iso-active)
+
   local out rc
   out="$("$python_bin" "$helper" \
     --bridge-home "${BRIDGE_HOME:-$HOME/.agent-bridge}" \
@@ -338,6 +406,7 @@ bridge_layout_v2_reconcile_run() {
     --mode "$mode" \
     --backup-root "$backup_root" \
     --iso-agents-json "$iso_agents_file" \
+    "${host_iso_flag[@]}" \
     --queue-task-dir "$queue_dir" 2>/dev/null)"
   rc=$?
 

--- a/lib/bridge_iso_boundary.py
+++ b/lib/bridge_iso_boundary.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""bridge_iso_boundary.py — the ONE common iso-v2 controller-boundary
+classifier shared across every controller-run scanner (#1820 rc4).
+
+Background (cm-prod, the first real Linux iso-v2 production host)
+----------------------------------------------------------------
+A controller (the operator's normal UID running ``layout-v2-reconcile.py``,
+``bridge-watchdog.py``, the wiki rebuild, …) cannot read an iso-v2 agent's
+files. On a *properly* isolated agent the agent **home** is
+``2770 owner=agent-bridge-<a>:ab-agent-<a>`` and the controller is NOT a
+member of ``ab-agent-<a>`` — so ``os.scandir(home)`` / ``os.walk`` /
+``is_dir()`` raise ``[Errno 13] Permission denied`` **before** any per-file
+logic runs. That is BY DESIGN and harmless: the iso UID reads its own files
+fine (zero data loss). It is pure controller-side observability noise.
+
+The cm-prod rc3 soak proved the #1876 reconcile iso-skip only covered 2 of 8
+iso bots: the other 6 were ABSENT from the iso registry map handed to the
+engine, so they fell through to the home traversal and threw Errno13. The
+SAME boundary fires in the watchdog scan (rows classified ``iso-uid-side``)
+and latently in any other controller scanner. cm-prod's recommendation: a
+single shared primitive every scanner uses, with two complementary
+mechanisms.
+
+The two mechanisms this module provides
+---------------------------------------
+(a) **Registry classification** — decide "the iso boundary applies to this
+    agent" *purely from loaded roster metadata*: ``isolation_mode ==
+    linux-user`` + a resolved ``os_user`` + host == Linux. NO filesystem read
+    of the agent home is performed to make this decision (that read is exactly
+    what throws Errno13). This mirrors the shell predicate
+    ``bridge_agent_linux_user_isolation_effective`` in ``lib/bridge-agents.sh``
+    so the shell and python sides agree on "this is an iso agent".
+
+(b) **Defensive boundary catch** — when a controller scanner DOES attempt a
+    read and gets ``PermissionError`` / Errno13 on an iso-UID-owned path on an
+    iso-v2-active host, classify it as the EXPECTED iso boundary so the caller
+    records a structured graceful-skip instead of an ``unexpected error`` /
+    ``scan_error`` / problem. On a shared-mode / macOS / non-iso install this
+    returns False, so a PermissionError there stays a genuine warning/problem
+    (byte-identical legacy behavior — the helper is a no-op off-host).
+
+This module performs NO filesystem mutation and NO direct read of an
+iso-owned path. It is pure classification over already-known inputs. That is
+deliberate: it can never itself trip the Errno13 it exists to absorb, and it
+is out of scope for the raw-pathlib-on-isolated lint (no probe/mutator calls).
+"""
+
+from __future__ import annotations
+
+import errno
+
+# Canonical token for the isolation mode that triggers the v2 OS-user boundary.
+LINUX_USER_ISOLATION_MODE = "linux-user"
+
+
+def host_is_linux(platform: str | None) -> bool:
+    """True iff ``platform`` (e.g. ``uname -s`` / ``platform.system()``) is
+    Linux. The iso-v2 OS-user boundary only exists on Linux; macOS / other
+    hosts never have it, so every classifier here is a no-op off Linux."""
+    return (platform or "").strip() == "Linux"
+
+
+def iso_boundary_applies(
+    *,
+    platform: str | None,
+    isolation_mode: str | None,
+    os_user: str | None,
+) -> bool:
+    """Registry classification (mechanism a).
+
+    Return True iff this agent is an EFFECTIVELY iso-v2 isolated agent — the
+    controller boundary applies to its home/files — decided purely from loaded
+    registry metadata, with NO filesystem read:
+
+      * host is Linux, AND
+      * ``isolation_mode == "linux-user"`` (the agent requested OS-user
+        isolation), AND
+      * a non-empty ``os_user`` is resolved (the iso account actually exists /
+        was provisioned).
+
+    This is the exact triple the shell predicate
+    ``bridge_agent_linux_user_isolation_effective`` checks
+    (``bridge_agent_linux_user_isolation_requested`` + Linux host +
+    non-empty ``bridge_agent_os_user``). Off Linux, or for a shared-mode
+    agent, or when the os_user is unknown, it returns False and the caller
+    takes its normal (legacy) path.
+    """
+    if not host_is_linux(platform):
+        return False
+    if (isolation_mode or "").strip() != LINUX_USER_ISOLATION_MODE:
+        return False
+    if not (os_user or "").strip():
+        return False
+    return True
+
+
+def is_permission_error(exc: BaseException) -> bool:
+    """True iff ``exc`` is a controller-side permission denial — a
+    ``PermissionError`` or any ``OSError`` whose ``errno`` is ``EACCES`` /
+    ``EPERM`` (the Errno13 / Errno1 the controller hits crossing the iso
+    boundary). Non-OSError exceptions are never a permission boundary."""
+    if isinstance(exc, PermissionError):
+        return True
+    if isinstance(exc, OSError) and exc.errno in (errno.EACCES, errno.EPERM):
+        return True
+    return False
+
+
+def is_expected_iso_permission_boundary(
+    *,
+    platform: str | None,
+    isolation_mode: str | None,
+    os_user: str | None,
+    error_kind: str | None,
+    error_category: str | None = None,
+) -> bool:
+    """Defensive boundary catch (mechanism b), watchdog flavor.
+
+    Decide whether a scanner row / caught error is the PURE expected iso
+    controller-boundary — the controller could not read an iso-UID-owned path,
+    but the iso UID owns and can read it (the agent is healthy). Only such
+    rows are downgraded out of the problem count.
+
+    Precise predicate (must satisfy ALL):
+      * the agent is an effectively-iso agent (``iso_boundary_applies``), AND
+      * ``error_kind == "permission_denied"`` — the boundary is a denial, not a
+        ``not_found`` / ``os_error`` (those are GENUINE drift and must stay
+        problems even on an iso agent), AND
+      * ``error_category`` is either empty/None (caller did no category split)
+        or one of the iso-boundary categories the watchdog already emits for a
+        controller-can't-read-but-iso-UID-owns case
+        (``iso-uid-side`` / ``controller-cache-stale``). A ``publish-gap`` is
+        an operator-actionable create-time gap and is NOT downgraded.
+
+    The cm-prod rows were ``permission_denied`` + ``iso-uid-side`` on a
+    perfectly healthy iso bot, because the controller could not even ``stat``
+    the 2770 home to run the iso-UID readability probe — so the category fell
+    through to ``iso-uid-side``. Registry classification is what lets us
+    downgrade those WITHOUT trusting the (already-failed) runtime probe, while
+    still keeping ``not_found`` / ``os_error`` rows as real problems.
+    """
+    if not iso_boundary_applies(
+        platform=platform, isolation_mode=isolation_mode, os_user=os_user
+    ):
+        return False
+    if (error_kind or "").strip() != "permission_denied":
+        return False
+    cat = (error_category or "").strip()
+    if cat and cat not in ("iso-uid-side", "controller-cache-stale"):
+        # e.g. "publish-gap" — a real create-time gap, stays a problem.
+        return False
+    return True
+
+
+def iso_skip_reason(error_kind: str | None) -> str:
+    """The structured ``reason`` token for a graceful-skip record produced by
+    the reconcile belt when a controller PermissionError is absorbed at an iso
+    agent home. Distinct from the clean up-front ``iso-agent-private`` reason so
+    last-apply.json can tell "skipped because classified iso up-front" from
+    "skipped because the controller hit Errno13 reaching the iso home"."""
+    return "home-unreadable-controller"

--- a/lib/upgrade-helpers/layout-v2-reconcile.py
+++ b/lib/upgrade-helpers/layout-v2-reconcile.py
@@ -80,6 +80,25 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Common iso-v2 controller-boundary classifier (#1820 rc4). This standalone
+# helper lives in lib/upgrade-helpers/, so the shared module sits one level up
+# in lib/. Import it via a sys.path-relative insert that works under the
+# file-as-argv invocation (footgun #11 — no package install, no PYTHONPATH
+# assumption). If the import is ever unavailable (a stripped-down install), the
+# belt below degrades to the prior behavior (PermissionError stays a warning),
+# never crashing.
+_RECONCILE_LIB_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _RECONCILE_LIB_DIR not in sys.path:
+    sys.path.insert(0, _RECONCILE_LIB_DIR)
+try:
+    from bridge_iso_boundary import (
+        is_permission_error as _iso_is_permission_error,
+        iso_skip_reason as _iso_skip_reason,
+    )
+except ImportError:  # pragma: no cover — stripped-down install fallback
+    _iso_is_permission_error = None
+    _iso_skip_reason = None
+
 SCHEMA = "layout-v2-reconcile/1"
 
 # Append-like memory files reconciled with the prefix/superset rule. Anything
@@ -154,6 +173,21 @@ class Reconciler:
         # an iso home 0700). The conflict/fencing DATA logic below is unchanged —
         # it simply is not entered for these agents.
         self.iso_agents: dict[str, str] = self._load_iso_agents(args.iso_agents_json)
+        # iso-v2-active host signal for the DEFENSIVE belt (#1820 rc4). The
+        # up-front iso-map skip (braces) only covers agents the wrapper managed
+        # to classify; cm-prod proved 6/8 iso bots can be ABSENT from that map
+        # (registry metadata not fully loaded in the reconcile driver context),
+        # fall through to the home traversal, and throw Errno13 on
+        # os.scandir(2770-home). The belt catches that PermissionError and — ONLY
+        # when this host is iso-v2-active — records a structured graceful-skip
+        # (reason=home-unreadable-controller) instead of an unstructured
+        # warning. On a shared-mode / macOS / non-iso install this flag is False
+        # and a PermissionError STILL surfaces as a warning (byte-identical
+        # legacy behavior — we never blanket-swallow perm errors off an iso
+        # host). The flag is host-level (passed by the wrapper from the layout
+        # marker + Linux platform), independent of whether any single agent made
+        # it into the iso map — that independence is the whole point of the belt.
+        self.host_iso_active: bool = bool(args.host_iso_active)
         self.stamp = _now_stamp()
 
         self.copied: list[dict] = []
@@ -167,6 +201,11 @@ class Reconciler:
         # iso permission handling is auditable in last-apply.json rather than
         # falling to unstructured warnings (#1820 rc3 observability).
         self.isolation_v2_migration: list[dict] = []
+        # Agents for which the defensive belt (#1820 rc4) has already recorded a
+        # structured iso skip — so a per-FILE PermissionError storm on one iso
+        # agent's home produces exactly ONE isolation_v2_migration entry, not
+        # one per file.
+        self._iso_belt_recorded: set[str] = set()
         self._cur_v1_home: Path | None = None
         self._cur_v2_home: Path | None = None
 
@@ -221,6 +260,56 @@ class Reconciler:
             {"agent": agent, "kind": kind, "rel": rel, "reason": reason}
         )
 
+    # --- iso-boundary defensive belt (#1820 rc4) ----------------------------
+    def _is_iso_boundary_permission_error(self, exc: BaseException) -> bool:
+        """True iff ``exc`` is a controller-side permission denial (Errno13 /
+        Errno1) raised crossing the iso boundary AND this host is iso-v2-active.
+
+        Off an iso host (shared-mode / macOS) this is always False, so a
+        PermissionError there is NOT absorbed — it falls through to the caller's
+        legacy warning path, byte-identical to pre-rc4 behavior. The classifier
+        delegates to the common helper; if that helper failed to import we
+        conservatively treat NOTHING as an iso boundary (warning preserved)."""
+        if not self.host_iso_active:
+            return False
+        if _iso_is_permission_error is None:
+            return False
+        return _iso_is_permission_error(exc)
+
+    def _record_iso_belt_skip(self, agent: str, exc: BaseException) -> None:
+        """Record a STRUCTURED graceful-skip for an iso agent whose home the
+        controller could not read (Errno13 reaching the 2770 home), instead of
+        an unstructured warning. Reason ``home-unreadable-controller`` is
+        distinct from the clean up-front ``iso-agent-private`` so last-apply.json
+        can tell "skipped by registry classification" from "skipped because the
+        controller hit the boundary at the home". os_user is taken from the iso
+        map when present (the agent WAS classified but the belt still fired,
+        e.g. a partial read), else empty (the agent was absent from the map —
+        the cm-prod 6/8 case the belt exists to cover).
+
+        Idempotent per agent: a per-file PermissionError storm on one iso home
+        records exactly ONE entry (first hit wins) so last-apply.json carries one
+        skip per iso agent, matching the up-front-skip shape."""
+        if agent in self._iso_belt_recorded:
+            return
+        self._iso_belt_recorded.add(agent)
+        reason = _iso_skip_reason(None) if _iso_skip_reason else "home-unreadable-controller"
+        self.isolation_v2_migration.append(
+            {
+                "agent": agent,
+                "os_user": self.iso_agents.get(agent, ""),
+                "action": "skipped-iso-private",
+                "reason": reason,
+                "detail": (
+                    "controller could not read this iso agent's home "
+                    f"({exc.__class__.__name__}: {exc}); the iso UID owns and "
+                    "manages its agent-private memory — controller backup/"
+                    "reconcile of it is the wrong contract (graceful-skip)"
+                ),
+            }
+        )
+        self._skip(agent, "agent", ".", "iso_home_unreadable_controller")
+
     # --- mutation primitives (no-op in dry-run) ------------------------------
     def _backup(self, agent: str, side: str, src: Path, rel: str) -> None:
         if self.mode != "apply" or self.backup_root is None:
@@ -230,7 +319,15 @@ class Reconciler:
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dst)
         except OSError as exc:
-            self._warn(agent, f"backup failed for {side}:{rel}: {exc}")
+            # iso-boundary belt (#1820 rc4): a controller-side permission denial
+            # backing up an iso agent's 0600 agent-private file is the expected
+            # boundary on an iso-v2-active host — record a structured skip, not a
+            # "backup failed" warning. Off an iso host (or any non-permission
+            # OSError) it stays a warning, byte-identical to before.
+            if self._is_iso_boundary_permission_error(exc):
+                self._record_iso_belt_skip(agent, exc)
+            else:
+                self._warn(agent, f"backup failed for {side}:{rel}: {exc}")
 
     def _pre_mutation_backup(self, agent: str, v1_home: Path, v2_home: Path) -> None:
         """Snapshot BOTH sides' reconcile surfaces before any write.
@@ -821,7 +918,18 @@ class Reconciler:
             try:
                 self._reconcile_agent(agent)
             except Exception as exc:  # pragma: no cover — defensive
-                self._warn(agent, f"unexpected error: {exc}")
+                # iso-boundary belt (#1820 rc4): a PermissionError raised while
+                # reaching this agent's home (os.scandir / iterdir / is_dir on
+                # the 2770 iso home) on an iso-v2-active host is the EXPECTED
+                # controller boundary — record it as a structured graceful-skip
+                # (no Errno13 warning), even if the agent was absent from the
+                # iso map (the cm-prod 6/8 case). Off an iso host, or for any
+                # non-permission error, it stays an unstructured warning exactly
+                # as before — we never blanket-swallow.
+                if self._is_iso_boundary_permission_error(exc):
+                    self._record_iso_belt_skip(agent, exc)
+                else:
+                    self._warn(agent, f"unexpected error: {exc}")
         return {
             "mode": self.mode,
             "schema": SCHEMA,
@@ -867,6 +975,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     # skipped from the controller-side reconcile/backup (see Reconciler). Empty
     # / absent => no iso agents => prior shared-mode behavior, byte-identical.
     parser.add_argument("--iso-agents-json", default="")
+    # Host-level iso-v2-active signal for the defensive belt (#1820 rc4). When
+    # set, a controller PermissionError reaching an agent home is recorded as a
+    # structured graceful-skip instead of an Errno13 warning — EVEN for an agent
+    # absent from --iso-agents-json (the cm-prod 6/8 case). Absent/unset =>
+    # shared-mode / macOS / non-iso install: a PermissionError stays a warning,
+    # byte-identical to pre-rc4. The wrapper sets this from the layout marker +
+    # Linux platform; it is host-level, not per-agent, by design.
+    parser.add_argument(
+        "--host-iso-active",
+        action="store_true",
+        default=False,
+    )
     return parser.parse_args(argv)
 
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -146,6 +146,18 @@ add_required 1820-iso-reconcile-permission
 # topology is fixed to make the iso HOME unreadable (reproducing cm-prod). In
 # the full static suite so any reconcile/watchdog/iso edit re-runs the guard.
 add_required 1820-rc4-iso-home-unreadable-belt
+# Issue #1820 rc4 supplement (cm-prod #7277): the watchdog's broken-symlink scan
+# walks the DATA-TREE MIRROR workdir; for an original anomaly agent whose mirror
+# render is incomplete the `.claude/settings.json -> settings.effective.json`
+# mirror symlink dangles even though the agent's REAL runtime HOME effective
+# settings are fully rendered + loaded (all hooks/plugins active, bot healthy) —
+# a pure false-positive. The fix decides "has hooks/plugins" from the agent's
+# runtime HOME effective settings (iso-aware home resolution), filters the
+# dangling mirror symlink out IFF the runtime home HAS hooks/plugins (or its iso
+# home is unreadable → graceful skip via bridge_iso_boundary), and keeps the row
+# when the runtime home genuinely lacks them. In the full static suite so any
+# bridge-watchdog.py / bridge_iso_boundary.py edit re-runs the guard.
+add_required 1820-rc4-watchdog-settings-source
 # Issue #1835: bridge-queue-gateway.py's SOCKET-transport client preflight
 # (_read_inline_text) now applies the #1280 sudo-as-owner body-file fallback on
 # PermissionError, with an actionable iso-ownership error when it cannot apply.

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -132,6 +132,20 @@ add_required rc2-reconcile-observability
 # structured isolation_v2_migration(skipped-iso-private) section. In the full
 # static suite so any reconcile/iso edit re-runs the iso-permission guard.
 add_required 1820-iso-reconcile-permission
+# Issue #1820 rc4 (cm-prod real-Linux iso-v2 production soak of v0.16.10-rc3):
+# the rc3 iso skip covered only 2/8 iso bots — the other 6 were absent from the
+# engine iso map AND their HOME itself is 2770 (controller non-member), so
+# os.scandir(home) threw [Errno 13] BEFORE any per-file skip → an unstructured
+# perm-warning with no isolation_v2_migration entry. The systemic fix: a common
+# registry-based iso-boundary classifier (lib/bridge_iso_boundary.py) shared
+# across controller scanners, a defensive belt in the reconcile (host-iso-active
+# → PermissionError reaching an iso home becomes a structured graceful-skip,
+# reason home-unreadable-controller, even for an agent absent from the map), and
+# a watchdog downgrade of pure permission_denied iso-boundary rows into an
+# auditable iso_skipped bucket (not_found/os_error stay problems). The rig
+# topology is fixed to make the iso HOME unreadable (reproducing cm-prod). In
+# the full static suite so any reconcile/watchdog/iso edit re-runs the guard.
+add_required 1820-rc4-iso-home-unreadable-belt
 # Issue #1835: bridge-queue-gateway.py's SOCKET-transport client preflight
 # (_read_inline_text) now applies the #1280 sudo-as-owner body-file fallback on
 # PermissionError, with an actionable iso-ownership error when it cannot apply.
@@ -4454,7 +4468,7 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # re-introduce the unbounded rglob (which blew the 30s scan ceiling on
       # a HOME-scale workdir for 9+ days) or silently drop / over-escalate
       # on a bound.
-      add_required watchdog-profile-contract watchdog-registry-anchored watchdog-silence-stderr-capture 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill ε-watchdog-rescan-codex G-beta4-watchdog-noise 1520c-create-isolate-profile-publish 1801-watchdog-bounded-broken-links codex-doctor queue
+      add_required watchdog-profile-contract watchdog-registry-anchored watchdog-silence-stderr-capture 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill ε-watchdog-rescan-codex G-beta4-watchdog-noise 1520c-create-isolate-profile-publish 1801-watchdog-bounded-broken-links 1820-rc4-iso-home-unreadable-belt codex-doctor queue
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1820-rc4-iso-home-unreadable-belt.sh
+++ b/scripts/smoke/1820-rc4-iso-home-unreadable-belt.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1820-rc4-iso-home-unreadable-belt.sh
+#
+# Issue #1820 rc4 — the systemic iso-boundary graceful-skip across controller
+# scanners, AND the test-rig TOPOLOGY fix.
+#
+# cm-prod (first real Linux iso-v2 production host) soaked rc3 + the #1876 iso
+# reconcile skip and it covered only 2 of 8 iso bots. Root cause: on a properly
+# isolated v2 agent the agent HOME itself is `2770 owner=agent-bridge-<a>:
+# ab-agent-<a>` with the controller NOT a group member — so `os.scandir(home)`
+# throws `[Errno 13] Permission denied` BEFORE any per-file skip. 6 of 8 bots
+# were ALSO absent from the engine's iso map (incomplete registry metadata in
+# the reconcile driver context), so the up-front `iso_agents.get(agent)` skip
+# never fired and the home traversal threw Errno13 → an unstructured perm
+# WARNING, with NO isolation_v2_migration entry.
+#
+# The previous rc3 rig (1820-iso-reconcile-permission.sh) chmod-000'd the
+# agent-private FILE, leaving the HOME controller-traversable — which is exactly
+# why gate-2 gave a false "zero Errno13": os.scandir(home) succeeded. THIS smoke
+# fixes the topology: it makes the iso bot HOME ITSELF unreadable (chmod 000 dir
+# = the controller-non-member stand-in for 2770), so `os.scandir(home)` throws
+# Errno13 for this (non-root) user — reproducing cm-prod.
+#
+# Asserts:
+#   PRE  — engine over the HOME-unreadable iso bot WITHOUT --host-iso-active
+#          (shared-mode contract) reproduces the cm-prod symptom: >=1 Errno13
+#          perm-warning, 0 isolation_v2_migration entries.
+#   POST — the SAME fixture WITH --host-iso-active (iso-v2-active host, the
+#          defensive belt) records 0 warnings + exactly 1 structured
+#          isolation_v2_migration entry (action skipped-iso-private, reason
+#          home-unreadable-controller), and the v2 memory is UNTOUCHED.
+#          Crucially the bot is NOT in the iso map — proving the belt covers the
+#          cm-prod 6/8 "absent from map" case, not just the cleanly-classified
+#          agents.
+#   WD   — the watchdog downgrades a permission_denied scan_error on a
+#          registry-classified iso agent out of the problem count into the
+#          auditable iso_skipped bucket on a Linux host, while a shared-mode
+#          agent's identical denial stays a problem; on a Darwin host NOTHING is
+#          downgraded (byte-identical legacy behavior).
+#   TRIP — static tripwires bind the belt + downgrade + common helper to source.
+#
+# Portability (macOS / CI have no real cross-UID boundary): chmod-000 on a dir
+# gives a non-root user the same Errno13 as the real 2770 boundary; the host
+# platform is stubbed via BRIDGE_HOST_PLATFORM_OVERRIDE. Root can read 000, so
+# the rig teeth that need a real denial are skipped when run as uid 0; the real
+# dual-UID Linux re-gate runs at patch-dev gate-2.
+#
+# Footgun #11: NO heredoc-stdin to any subprocess; fixtures via printf, JSON
+# probed file-as-argv. Run under Bash 5.x (macOS system bash is 3.2).
+
+set -uo pipefail
+SMOKE_NAME="1820-rc4-iso-home-unreadable-belt"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+REPO_ROOT="$SMOKE_REPO_ROOT"
+ENGINE="$REPO_ROOT/lib/upgrade-helpers/layout-v2-reconcile.py"
+WATCHDOG="$REPO_ROOT/bridge-watchdog.py"
+COMMON="$REPO_ROOT/lib/bridge_iso_boundary.py"
+PROBE="$REPO_ROOT/scripts/smoke/1820-iso-reconcile-permission-probe.py"
+
+UNREADABLE_DIR=""
+UNREADABLE_DIR2=""
+cleanup() {
+  [[ -n "$UNREADABLE_DIR"  && -e "$UNREADABLE_DIR"  ]] && chmod 0755 "$UNREADABLE_DIR"  2>/dev/null || true
+  [[ -n "$UNREADABLE_DIR2" && -e "$UNREADABLE_DIR2" ]] && chmod 0755 "$UNREADABLE_DIR2" 2>/dev/null || true
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+smoke_make_temp_root "$SMOKE_NAME"
+smoke_assert_file_exists "$ENGINE"   "reconcile engine"
+smoke_assert_file_exists "$WATCHDOG" "watchdog"
+smoke_assert_file_exists "$COMMON"   "common iso-boundary helper"
+smoke_assert_file_exists "$PROBE"    "iso-reconcile probe helper"
+
+IS_ROOT=0
+[[ "$(id -u 2>/dev/null || echo 1)" == "0" ]] && IS_ROOT=1
+
+probe_result() {
+  python3 "$PROBE" "$1" "$2" "$3"
+}
+
+run_engine() {
+  # run_engine <bridge_home> <data_root> <agents_csv> <backup_root> [host_iso_active=0|1]
+  local bh="$1" dr="$2" agents="$3" bkp="$4" host_iso="${5:-0}"
+  local -a argv=(
+    "$ENGINE"
+    --bridge-home "$bh"
+    --data-root "$dr"
+    --agents-csv "$agents"
+    --mode apply
+    --backup-root "$bkp"
+  )
+  [[ "$host_iso" == "1" ]] && argv+=(--host-iso-active)
+  python3 "${argv[@]}" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: iso bot `isobot` whose v1 agent HOME ITSELF is unreadable (chmod 000
+# dir) — the 2770 controller-non-member stand-in. The bot is intentionally NOT
+# passed in any --iso-agents-json (reproducing cm-prod's 6/8 "absent from the
+# map" case). v2 home present with its own memory.
+# ---------------------------------------------------------------------------
+BH="$SMOKE_TMP_ROOT/bh"
+DR="$SMOKE_TMP_ROOT/dr"
+mkdir -p "$BH/agents/isobot" "$DR/agents/isobot/home"
+printf 'shared-line\nv1-only-line\n' >"$BH/agents/isobot/MEMORY.md"
+printf 'shared-line\n' >"$DR/agents/isobot/home/MEMORY.md"
+V2_MEM="$DR/agents/isobot/home/MEMORY.md"
+V2_BASELINE="$SMOKE_TMP_ROOT/v2-baseline.md"
+cp "$V2_MEM" "$V2_BASELINE"
+
+# Make the HOME directory itself unreadable/un-scandir-able for this user.
+chmod 000 "$BH/agents/isobot"
+UNREADABLE_DIR="$BH/agents/isobot"
+
+if [[ "$IS_ROOT" == "1" ]]; then
+  smoke_log "PRE/POST SKIP: running as root (chmod 000 does not block root scandir; needs a non-root run or the real dual-UID Linux rig — see gate-2 re-gate)"
+else
+  # PRE — shared-mode contract (no --host-iso-active): cm-prod symptom reproduced.
+  PRE_OUT="$(run_engine "$BH" "$DR" isobot "$SMOKE_TMP_ROOT/bkp-pre" 0)"
+  printf '%s' "$PRE_OUT" >"$SMOKE_TMP_ROOT/pre.json"
+  read -r PRE_ERRNO PRE_ISOCOUNT _PRE_ACT _PRE_DRIFT < <(probe_result "$SMOKE_TMP_ROOT/pre.json" "$V2_MEM" "$V2_BASELINE")
+  [[ "$PRE_ERRNO" == "1" ]] || smoke_fail "PRE FAIL: HOME-unreadable iso bot must raise >=1 Errno13 warning WITHOUT --host-iso-active (the cm-prod symptom the rig must reproduce); got none\n$PRE_OUT"
+  [[ "$PRE_ISOCOUNT" == "0" ]] || smoke_fail "PRE FAIL: WITHOUT --host-iso-active there must be no isolation_v2_migration entry, got $PRE_ISOCOUNT"
+  smoke_log "PRE PASS: rig reproduces cm-prod — os.scandir(home) Errno13 surfaces as a warning, 0 structured iso entries (shared-mode contract)"
+
+  # POST — iso-v2-active host (--host-iso-active): belt downgrades to a skip.
+  POST_OUT="$(run_engine "$BH" "$DR" isobot "$SMOKE_TMP_ROOT/bkp-post" 1)"
+  printf '%s' "$POST_OUT" >"$SMOKE_TMP_ROOT/post.json"
+  read -r POST_ERRNO POST_ISOCOUNT POST_ACTION POST_DRIFT < <(probe_result "$SMOKE_TMP_ROOT/post.json" "$V2_MEM" "$V2_BASELINE")
+  [[ "$POST_ERRNO" == "0" ]] || smoke_fail "POST FAIL: an Errno13 warning was emitted WITH --host-iso-active (expected 0 — the belt must absorb it)\n$POST_OUT"
+  [[ "$POST_ISOCOUNT" == "1" ]] || smoke_fail "POST FAIL: expected exactly 1 isolation_v2_migration entry (one structured skip per iso agent), got $POST_ISOCOUNT\n$POST_OUT"
+  [[ "$POST_ACTION" == "skipped-iso-private" ]] || smoke_fail "POST FAIL: expected action skipped-iso-private, got '$POST_ACTION'\n$POST_OUT"
+  [[ "$POST_DRIFT" == "0" ]] || smoke_fail "POST FAIL: iso agent's v2 memory DRIFTED (must be untouched / drift 0)"
+  # Assert the belt-specific reason (distinct from the clean up-front skip).
+  python3 "$PROBE" "$SMOKE_TMP_ROOT/post.json" "$V2_MEM" "$V2_BASELINE" >/dev/null
+  REASON="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d["isolation_v2_migration"][0].get("reason","-"))' "$SMOKE_TMP_ROOT/post.json")"
+  [[ "$REASON" == "home-unreadable-controller" ]] || smoke_fail "POST FAIL: expected belt reason home-unreadable-controller, got '$REASON'"
+  smoke_log "POST PASS: belt absorbs the home-unreadable Errno13 — 0 warnings, 1 structured skip (skipped-iso-private / home-unreadable-controller), v2 drift 0, bot NOT in any iso map (covers cm-prod 6/8)"
+fi
+
+# ---------------------------------------------------------------------------
+# WD — watchdog downgrades the pure expected-iso-boundary row out of the
+# problem count; not_found/os_error and shared-mode denials stay problems.
+# ---------------------------------------------------------------------------
+WD_BH="$SMOKE_TMP_ROOT/wd/bh"
+mkdir -p "$WD_BH/agents/isobot/workdir" "$WD_BH/agents/plainbot/workdir" "$WD_BH/state"
+# Both workdirs unreadable (chmod 000) → permission_denied scan_error rows.
+chmod 000 "$WD_BH/agents/isobot/workdir"
+chmod 000 "$WD_BH/agents/plainbot/workdir"
+UNREADABLE_DIR2="$WD_BH/agents/isobot/workdir"
+REG="$SMOKE_TMP_ROOT/wd/reg.json"
+mkdir -p "$SMOKE_TMP_ROOT/wd"
+printf '%s\n' \
+  '[' \
+  "  {\"id\":\"isobot\",\"engine\":\"claude\",\"agent_source\":\"static\",\"workdir\":\"$WD_BH/agents/isobot/workdir\",\"home\":\"$WD_BH/agents/isobot\",\"isolation_mode\":\"linux-user\",\"os_user\":\"agent-bridge-isobot\"}," \
+  "  {\"id\":\"plainbot\",\"engine\":\"claude\",\"agent_source\":\"static\",\"workdir\":\"$WD_BH/agents/plainbot/workdir\",\"home\":\"$WD_BH/agents/plainbot\",\"isolation_mode\":\"\",\"os_user\":\"\"}" \
+  ']' >"$REG"
+
+if [[ "$IS_ROOT" == "1" ]]; then
+  smoke_log "WD SKIP: running as root (chmod 000 workdir is root-readable; real denial needs a non-root run / the gate-2 rig)"
+else
+  WD_LINUX="$(BRIDGE_HOST_PLATFORM_OVERRIDE=Linux python3 "$WATCHDOG" scan --bridge-home "$WD_BH" --agent-registry-json "$REG" --json 2>/dev/null)"
+  read -r WD_PROB WD_SKIP < <(printf '%s' "$WD_LINUX" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["problem_count"], d["iso_skipped_count"])')
+  [[ "$WD_SKIP" == "1" ]] || smoke_fail "WD FAIL (Linux): expected 1 iso_skipped (isobot permission_denied downgraded), got $WD_SKIP\n$WD_LINUX"
+  [[ "$WD_PROB" == "1" ]] || smoke_fail "WD FAIL (Linux): expected plainbot's denial to STAY a problem (problem_count=1), got $WD_PROB\n$WD_LINUX"
+  WD_AGENTS="$(printf '%s' "$WD_LINUX" | python3 -c 'import json,sys; print(",".join(json.load(sys.stdin)["iso_skipped_agents"]))')"
+  [[ "$WD_AGENTS" == "isobot" ]] || smoke_fail "WD FAIL (Linux): only isobot should be downgraded, got '$WD_AGENTS'"
+  smoke_log "WD PASS (Linux): isobot permission_denied downgraded to iso_skipped; plainbot (shared-mode) denial stays a problem"
+
+  WD_MAC="$(BRIDGE_HOST_PLATFORM_OVERRIDE=Darwin python3 "$WATCHDOG" scan --bridge-home "$WD_BH" --agent-registry-json "$REG" --json 2>/dev/null)"
+  read -r WD_MPROB WD_MSKIP < <(printf '%s' "$WD_MAC" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["problem_count"], d["iso_skipped_count"])')
+  [[ "$WD_MSKIP" == "0" ]] || smoke_fail "WD FAIL (Darwin): nothing must be downgraded off Linux, got iso_skipped=$WD_MSKIP\n$WD_MAC"
+  [[ "$WD_MPROB" == "2" ]] || smoke_fail "WD FAIL (Darwin): both denials must stay problems off Linux (problem_count=2), got $WD_MPROB\n$WD_MAC"
+  smoke_log "WD PASS (Darwin): no iso downgrade off Linux — both denials stay problems (byte-identical legacy behavior)"
+fi
+
+# ---------------------------------------------------------------------------
+# TRIP — static tripwires bind the rc4 behavior to source.
+# ---------------------------------------------------------------------------
+grep -q 'host_iso_active' "$ENGINE" \
+  || smoke_fail "TRIP FAIL: engine lost the --host-iso-active belt gate"
+grep -q 'home-unreadable-controller' "$COMMON" \
+  || smoke_fail "TRIP FAIL: common helper lost the home-unreadable-controller skip reason"
+grep -q 'iso_boundary_applies' "$COMMON" \
+  || smoke_fail "TRIP FAIL: common helper lost the registry classifier iso_boundary_applies"
+grep -q 'is_expected_iso_permission_boundary' "$COMMON" \
+  || smoke_fail "TRIP FAIL: common helper lost the watchdog downgrade predicate"
+grep -q 'iso_skipped_count' "$WATCHDOG" \
+  || smoke_fail "TRIP FAIL: watchdog lost the iso_skipped downgrade bucket"
+grep -q 'is_expected_iso_boundary_row' "$WATCHDOG" \
+  || smoke_fail "TRIP FAIL: watchdog lost the per-row iso-boundary classifier"
+grep -q 'host-iso-active' "$REPO_ROOT/lib/bridge-layout-v2-reconcile.sh" \
+  || smoke_fail "TRIP FAIL: reconcile wrapper no longer passes the host-iso-active signal to the engine"
+grep -q 'bridge_layout_v2_reconcile_host_iso_active' "$REPO_ROOT/lib/bridge-layout-v2-reconcile.sh" \
+  || smoke_fail "TRIP FAIL: reconcile wrapper lost the host-iso-active classifier"
+smoke_log "TRIP PASS: rc4 belt + watchdog downgrade + common helper + wrapper wiring all bound to source"
+
+smoke_log "all 1820-rc4-iso-home-unreadable-belt tests PASS"

--- a/scripts/smoke/1820-rc4-watchdog-settings-source.sh
+++ b/scripts/smoke/1820-rc4-watchdog-settings-source.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# scripts/smoke/1820-rc4-watchdog-settings-source.sh — #1820 rc4 supplement.
+#
+# The controller-run watchdog walks the agent's DATA-TREE MIRROR workdir
+# (`$BRIDGE_DATA_ROOT/agents/<a>/workdir`) for broken symlinks. On an original
+# anomaly agent whose data-tree mirror render is incomplete, the
+# `.claude/settings.json -> settings.effective.json` mirror symlink DANGLES even
+# though the agent's REAL runtime HOME effective settings are fully rendered and
+# loaded (all hook events + enabledPlugins active, bot healthy). Pre-fix the
+# watchdog inferred "operating without hooks/plugins" from the unresolved
+# data-tree-mirror symlink and raised a pure false-positive (cm-prod #7277,
+# test_clean).
+#
+# The fix: decide "does this agent have hooks/plugins configured" from the
+# agent's RUNTIME HOME effective settings (`<home>/.claude/settings.effective.
+# json`, falling back to settings.json) — iso-aware (an iso agent's real OS
+# home), NOT from whether the data-tree-mirror symlink resolves. The dangling
+# mirror symlink is filtered out of the broken-link list IFF the runtime HOME
+# effective settings actually carry hooks/plugins; an agent that genuinely lacks
+# them is still flagged; an iso home the controller can't read routes through
+# the common iso-boundary classifier as a graceful skip.
+#
+# Cases (shared-mode / macOS-runnable axis):
+#   C1. Dangling data-tree-mirror `.claude/settings.json` +
+#       runtime HOME effective settings HAVE hooks/plugins
+#       → NOT flagged: broken_links does NOT contain the settings mirror,
+#         status=ok, problem_count derived without it.
+#   C2. Dangling data-tree-mirror `.claude/settings.json` +
+#       runtime HOME effective settings genuinely LACK hooks/plugins
+#       → still flagged: broken_links contains the settings mirror, status=warn
+#         (the check is NOT blanket-suppressed).
+#   C3. A genuinely-dangling UNRELATED symlink in the mirror workdir is always
+#       flagged regardless of runtime-home hooks/plugins state (control: the
+#       filter is scoped to the settings-effective mirror symlink only).
+#
+# Iso cross-UID (an iso agent's `os_user` real OS home is 0700/2770 and
+# unreadable by the controller → graceful iso-skip via bridge_iso_boundary)
+# cannot be exercised on macOS without a real linux-user rig — deferred to
+# gate-2 real rig. The unit-level iso-unreadable branch is covered by the
+# common-classifier mechanism this PR already ships.
+#
+# Uses an isolated BRIDGE_HOME via smoke_setup_bridge_home — never touches the
+# operator's live runtime.
+
+set -uo pipefail
+
+SMOKE_NAME="1820-rc4-watchdog-settings-source"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+smoke_require_cmd "$PY_BIN"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+# Seed a well-formed Claude profile into a mirror workdir so missing_files is
+# empty (the only drift signal under test is the broken settings symlink).
+seed_profile() {
+  local dir="$1"
+  mkdir -p "$dir/.claude"
+  cat >"$dir/CLAUDE.md" <<'EOF'
+<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->
+managed
+<!-- END AGENT BRIDGE DOC MIGRATION -->
+EOF
+  : >"$dir/SOUL.md"
+  : >"$dir/MEMORY-SCHEMA.md"
+  : >"$dir/MEMORY.md"
+  cat >"$dir/SESSION-TYPE.md" <<'EOF'
+# Session Type
+
+- Session Type: static-claude
+- Onboarding State: complete
+EOF
+}
+
+# Render the runtime HOME `.claude/settings.effective.json` carrying hooks +
+# enabledPlugins (the fully-rendered runtime home the agent actually loads).
+seed_runtime_home_with_hooks() {
+  local home="$1"
+  mkdir -p "$home/.claude"
+  cat >"$home/.claude/settings.effective.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [{"hooks": [{"type": "command", "command": "echo hi"}]}],
+    "PreToolUse": [{"hooks": [{"type": "command", "command": "echo guard"}]}]
+  },
+  "enabledPlugins": ["teams@local", "cosmax-crm@local"]
+}
+EOF
+  # Mirror the real layout: settings.json is a symlink to the effective file.
+  ln -sf "settings.effective.json" "$home/.claude/settings.json"
+}
+
+# Render the runtime HOME with effective settings that genuinely lack any
+# hooks/plugins (empty objects/lists).
+seed_runtime_home_without_hooks() {
+  local home="$1"
+  mkdir -p "$home/.claude"
+  cat >"$home/.claude/settings.effective.json" <<'EOF'
+{
+  "hooks": {},
+  "enabledPlugins": []
+}
+EOF
+  ln -sf "settings.effective.json" "$home/.claude/settings.json"
+}
+
+# Make the data-tree-mirror `.claude/settings.json` a DANGLING symlink (the
+# incomplete-mirror-render shape: the mirror never had settings.effective.json
+# materialized, so its settings.json symlink target is absent).
+seed_dangling_mirror_settings() {
+  local workdir="$1"
+  ln -sf "settings.effective.json" "$workdir/.claude/settings.json"
+  # Deliberately do NOT create settings.effective.json in the mirror — the
+  # symlink dangles.
+}
+
+run_scan() {
+  local registry_json="$1"
+  "$PY_BIN" "$REPO_ROOT/bridge-watchdog.py" scan --json \
+    --agent-registry-json "$registry_json" 2>"$SMOKE_TMP_ROOT/stderr.log"
+}
+
+# ---------------------------------------------------------------------------
+# C1: dangling mirror settings.json + runtime HOME effective HAS hooks/plugins
+#     → NOT flagged.
+# ---------------------------------------------------------------------------
+smoke_log "C1: dangling mirror settings symlink + runtime home has hooks/plugins → not flagged"
+C1_AGENT="anomaly_has_hooks"
+C1_WORKDIR="$BRIDGE_DATA_ROOT/agents/$C1_AGENT/workdir"
+C1_HOME="$BRIDGE_DATA_ROOT/agents/$C1_AGENT/home"
+# The watchdog enumerates tracked-tree dirs under $BRIDGE_AGENT_HOME_ROOT and
+# intersects with the registry ids; resolve_scan_path then redirects the actual
+# scan to the registry `workdir`. So a tracked-tree dir must exist for the agent
+# to be enumerated at all (mirrors the v2 layout on the operator host).
+mkdir -p "$BRIDGE_AGENT_HOME_ROOT/$C1_AGENT/.claude"
+seed_profile "$C1_WORKDIR"
+seed_dangling_mirror_settings "$C1_WORKDIR"
+seed_runtime_home_with_hooks "$C1_HOME"
+
+C1_REGISTRY="$SMOKE_TMP_ROOT/c1-registry.json"
+cat >"$C1_REGISTRY" <<EOF
+[
+  {
+    "id": "$C1_AGENT",
+    "class": "static",
+    "agent_source": "static",
+    "engine": "claude",
+    "workdir": "$C1_WORKDIR",
+    "home": "$C1_HOME"
+  }
+]
+EOF
+
+C1_JSON="$(run_scan "$C1_REGISTRY")"
+"$PY_BIN" - "$C1_JSON" "$C1_AGENT" <<'PY' || smoke_fail "C1 assertions failed: settings-mirror false-positive NOT filtered when runtime home has hooks/plugins"
+import json, sys
+payload = json.loads(sys.argv[1])
+agent = sys.argv[2]
+row = next(r for r in payload["agents"] if r["agent"] == agent)
+mirror_rows = [b for b in row["broken_links"] if "settings.json" in b and "settings.effective.json" in b]
+assert not mirror_rows, f"settings mirror symlink must be filtered out, got broken_links={row['broken_links']}"
+assert row["status"] == "ok", f"expected status=ok with the settings mirror filtered, got {row['status']} broken_links={row['broken_links']}"
+assert payload["problem_count"] == 0, f"expected problem_count=0, got {payload['problem_count']}"
+PY
+smoke_log "C1 PASS: settings mirror symlink filtered; agent classifies ok"
+
+# ---------------------------------------------------------------------------
+# C2: dangling mirror settings.json + runtime HOME effective LACKS hooks/plugins
+#     → still flagged (don't blanket-suppress the check).
+# ---------------------------------------------------------------------------
+smoke_log "C2: dangling mirror settings symlink + runtime home lacks hooks/plugins → still flagged"
+C2_AGENT="genuine_no_hooks"
+C2_WORKDIR="$BRIDGE_DATA_ROOT/agents/$C2_AGENT/workdir"
+C2_HOME="$BRIDGE_DATA_ROOT/agents/$C2_AGENT/home"
+mkdir -p "$BRIDGE_AGENT_HOME_ROOT/$C2_AGENT/.claude"
+seed_profile "$C2_WORKDIR"
+seed_dangling_mirror_settings "$C2_WORKDIR"
+seed_runtime_home_without_hooks "$C2_HOME"
+
+C2_REGISTRY="$SMOKE_TMP_ROOT/c2-registry.json"
+cat >"$C2_REGISTRY" <<EOF
+[
+  {
+    "id": "$C2_AGENT",
+    "class": "static",
+    "agent_source": "static",
+    "engine": "claude",
+    "workdir": "$C2_WORKDIR",
+    "home": "$C2_HOME"
+  }
+]
+EOF
+
+C2_JSON="$(run_scan "$C2_REGISTRY")"
+"$PY_BIN" - "$C2_JSON" "$C2_AGENT" <<'PY' || smoke_fail "C2 assertions failed: settings-mirror dangling symlink was suppressed even though runtime home genuinely lacks hooks/plugins"
+import json, sys
+payload = json.loads(sys.argv[1])
+agent = sys.argv[2]
+row = next(r for r in payload["agents"] if r["agent"] == agent)
+mirror_rows = [b for b in row["broken_links"] if "settings.json" in b and "settings.effective.json" in b]
+assert mirror_rows, f"settings mirror symlink must STILL be flagged when runtime home lacks hooks/plugins, got broken_links={row['broken_links']}"
+assert row["status"] == "warn", f"expected status=warn (broken link surfaces drift), got {row['status']}"
+PY
+smoke_log "C2 PASS: settings mirror symlink still flagged when runtime home genuinely lacks hooks/plugins"
+
+# ---------------------------------------------------------------------------
+# C3: a genuinely-dangling UNRELATED symlink is always flagged (control — the
+#     filter is scoped to the settings-effective mirror symlink only).
+# ---------------------------------------------------------------------------
+smoke_log "C3: unrelated dangling symlink always flagged even when runtime home has hooks/plugins"
+C3_AGENT="anomaly_other_drift"
+C3_WORKDIR="$BRIDGE_DATA_ROOT/agents/$C3_AGENT/workdir"
+C3_HOME="$BRIDGE_DATA_ROOT/agents/$C3_AGENT/home"
+mkdir -p "$BRIDGE_AGENT_HOME_ROOT/$C3_AGENT/.claude"
+seed_profile "$C3_WORKDIR"
+seed_dangling_mirror_settings "$C3_WORKDIR"
+seed_runtime_home_with_hooks "$C3_HOME"
+# An unrelated genuinely-broken symlink in the workdir.
+ln -sf "/nonexistent/some-real-target" "$C3_WORKDIR/dangling-other.link"
+
+C3_REGISTRY="$SMOKE_TMP_ROOT/c3-registry.json"
+cat >"$C3_REGISTRY" <<EOF
+[
+  {
+    "id": "$C3_AGENT",
+    "class": "static",
+    "agent_source": "static",
+    "engine": "claude",
+    "workdir": "$C3_WORKDIR",
+    "home": "$C3_HOME"
+  }
+]
+EOF
+
+C3_JSON="$(run_scan "$C3_REGISTRY")"
+"$PY_BIN" - "$C3_JSON" "$C3_AGENT" <<'PY' || smoke_fail "C3 assertions failed: unrelated dangling symlink was wrongly suppressed, or settings mirror leaked through"
+import json, sys
+payload = json.loads(sys.argv[1])
+agent = sys.argv[2]
+row = next(r for r in payload["agents"] if r["agent"] == agent)
+# The settings mirror symlink IS filtered (runtime home has hooks/plugins).
+mirror_rows = [b for b in row["broken_links"] if "settings.json" in b and "settings.effective.json" in b]
+assert not mirror_rows, f"settings mirror should still be filtered in C3, got broken_links={row['broken_links']}"
+# The unrelated dangling symlink is NOT filtered.
+other_rows = [b for b in row["broken_links"] if "dangling-other.link" in b]
+assert other_rows, f"unrelated dangling symlink must stay flagged, got broken_links={row['broken_links']}"
+assert row["status"] == "warn", f"expected status=warn from the unrelated broken link, got {row['status']}"
+PY
+smoke_log "C3 PASS: unrelated dangling symlink stays flagged; settings mirror still filtered (filter is scoped)"
+
+smoke_log "all 3 cases PASS (#1820 rc4 settings-source correction); iso cross-UID home-unreadable deferred to gate-2 real rig"


### PR DESCRIPTION
## 3-scanner root cause (cm-prod, first real Linux iso-v2 production host)

A controller running a scanner cannot read iso-UID-owned files. On a *properly* isolated v2 agent the agent **home itself** is `2770 owner=agent-bridge-<a>:ab-agent-<a>` with the controller a non-member, so `os.scandir(home)` / `os.walk` / `is_dir()` throw `[Errno 13] Permission denied` **before** any per-file logic. The cm-prod v0.16.10-rc3 soak of the #1876 reconcile iso-skip covered only **2 of 8** iso bots:

- **reconcile** — 6/8 bots were ABSENT from the engine iso map (incomplete `os_user`/`isolation_mode` registry metadata in the reconcile driver context), fell through to the home traversal, and threw Errno13 → an unstructured perm-**warning**, with **no** `isolation_v2_migration` entry. The 2 that "passed" had controller-traversable homes (an incomplete-isolation artifact + a group/ACL exception) — which is also exactly why the gate-2 rig gave a false zero-Errno13.
- **watchdog** — the same 6 bots produced `scan_error` / `permission_denied` / `error_category: iso-uid-side` rows on a perfectly healthy iso bot, counted as HIGH problems.
- **wiki-rebuild** — latent (see descope below).

Harmless by design: the iso UID reads its own files fine (all 8 customer bot ports `{"ok":true}`, zero data loss). It is pure controller-side observability noise. The fix is to make the **controller** stop reading across the boundary — never to relax the 0660/0700 iso perms.

## Common-helper design

`lib/bridge_iso_boundary.py` — the ONE registry-based classifier every controller scanner uses, two complementary mechanisms:

- **(a) registry classification** — `iso_boundary_applies(platform, isolation_mode, os_user)` decides "iso boundary applies" purely from `isolation_mode==linux-user` + resolved `os_user` + Linux host, with **no** filesystem read of the home (the read that throws Errno13). Mirrors the shell predicate `bridge_agent_linux_user_isolation_effective`; `lib/bridge-agents.sh` gains the shell sibling `bridge_iso_boundary_applies`.
- **(b) defensive boundary catch** — `is_permission_error` + `is_expected_iso_permission_boundary` classify a caught `PermissionError` / a `permission_denied` row on an effectively-iso agent as the expected boundary, so callers record a structured graceful-skip instead of an error/problem. A no-op off Linux / shared-mode.

**reconcile** (`lib/upgrade-helpers/layout-v2-reconcile.py`): keeps the up-front `iso_agents.get(agent)` skip (braces) AND adds a **belt** — on an iso-v2-active host (`--host-iso-active`, computed by the wrapper from the layout marker + Linux platform, robust to incomplete per-agent registry resolution) a `PermissionError` reaching an agent home becomes a structured `isolation_v2_migration` skip (`action: skipped-iso-private`, reason `home-unreadable-controller`), **even for an agent absent from the iso map** (the 6/8 case). One entry per agent (idempotent). On shared-mode / macOS the belt is off and a `PermissionError` STILL surfaces as a warning. **Net on cm-prod: warnings 6→0, all 8 iso bots get an `isolation_v2_migration` entry.**

**watchdog** (`bridge-watchdog.py`): downgrades **only** the pure expected-iso-boundary rows (`permission_denied` on a registry-classified iso agent) out of the problem count into an auditable `iso_skipped` bucket. `not_found` / `os_error` rows stay problems even on an iso agent. Classification is registry-based (no dependency on the runtime iso-readability probe that already failed) via two new registry fields `isolation_mode` / `os_user` (`bridge-agent.sh` `run_registry` + `registry-format-json.py`, backward-compatible — a legacy 10-column TSV defaults both to `""`).

## Rig topology fix (critical)

`scripts/smoke/1820-rc4-iso-home-unreadable-belt.sh` makes the iso bot **home itself** unreadable (`chmod 000` dir = the 2770 controller-non-member stand-in) so `os.scandir(home)` throws Errno13, reproducing cm-prod (the prior rig chmod-000'd only the *file*, leaving the home traversable → the false green). Asserts **PRE-fix** ≥1 Errno13 warning, **POST-fix** 0 warnings + exactly one structured skip per iso agent (bot NOT in any iso map), plus the watchdog Linux-downgrade / Darwin-no-op split. Registered in `scripts/ci-select-smoke.sh` (always-required #1820 block + the watchdog conditional group).

## Byte-identical-fencing proof

The reconcile fencing/conflict DATA logic is **byte-identical** to `origin/main` — verified by a targeted per-function body diff of `_archive_conflict`, `_path_chain_fenced`, `_foreign_symlink`, `_chains_fenced`, `_reconcile_file`, `_home_anchored`, `_realpath_within`, `_conflict_dedup_marker`, `_conflict_marker_text`, `_queue_task_text` (all IDENTICAL), plus `_pre_mutation_backup` IDENTICAL and the up-front `iso_agents.get(agent)` skip in `_reconcile_agent` unchanged. The belt only touches `run()`'s exception arm and `_backup`'s OSError arm. **Iso file/dir ownership/perms are never relaxed — controller-side skip only.**

## wiki-rebuild descope (justified)

`scripts/wiki-v2-rebuild.sh` already runs the **entire** rebuild block AS the iso UID via `bridge_isolation_run_as_agent_user_via_bash` (the shipped #1827 / #1222 fix), so it never issues a controller-side read across the boundary and **does not exhibit this PR's Errno13 symptom**. Adding a redundant up-front registry skip to that already-gated, working path is materially riskier than the benefit. reconcile + watchdog ship in rc4 as required; wiki-rebuild is a follow-up only if a future read-side regression appears.

## Validation

- `bash -n` (all changed .sh + root scripts) — pass
- `shellcheck` (changed .sh, repo `.shellcheckrc`) — clean
- `python3 -m py_compile` (changed .py) — pass
- `git diff --check origin/main...HEAD` — clean
- raw-pathlib-on-isolated + heredoc-ban + iso-helper ratchets — pass (no new sites, **no baseline updates needed**)
- new + related smokes (`1820-rc4-...`, `1820-iso-reconcile-permission`, `1119-watchdog-perm-error`, `1108-watchdog-v2-workdir`, `watchdog-registry-anchored`, `1827-wiki-v2-rebuild-iso`, reconcile data-path smokes) — pass on macOS
- `ci-select-smoke.sh --changed-file <files>` selects the new smoke — confirmed
- **iso paths validated at patch-dev gate-2 on a topology-matched real Linux rig (rig set to home 2770 iso-UID-owned, controller non-member)** — macOS simulates the boundary via `chmod 000` + `BRIDGE_HOST_PLATFORM_OVERRIDE`; the root-blind teeth defer to the real dual-UID rig.

Note: `scripts/smoke-test.sh`'s lint stage trips a pre-existing `SC2102 (info)` in untouched `bridge-run.sh` under the local shellcheck 0.11.0; that file is not in this changeset and the finding is present on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
